### PR TITLE
Rename project to pc-nrfconnect-shared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 package-lock.json
 jest.json
-pc-nrfconnect-devdep-*.tgz
+pc-nrfconnect-shared-*.tgz

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Version 4.0
+### Breaking change
+- This package was renamed to “pc-nrfconnect-shared”. If you refer to it anywhere under
+  the old name (e.g. in a package.json or import a component from it) then you must
+  update these references when upgrading to version 4.
+
 ## Version 3.6
 ### Changed
 - Moved the shared components from core to this project (They can now be used by importing

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
-# pc-nrfconnect-devdep
+# pc-nrfconnect-shared
 
-This project provides common package dependencies for pc-nrfconnect-* packages.
+This project provides Shared commodities for developing nRF Connect for Desktop apps and their launcher:
+
+* React components
+* Build scripts
+* Configurations
+* Test facilities

--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -1,20 +1,20 @@
 {
   "rootDir": "../../../",
   "moduleNameMapper": {
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/fileMock.js",
-    "\\.(css|less|scss)$": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/emptyMock.js",
-    "nrfconnect/core": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/coreMock.js",
-    "pc-ble-driver-js": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/bleDriverMock.js",
-    "pc-nrfjprog-js|serialport|usb": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/emptyMock.js",
-    "electron": "<rootDir>/node_modules/pc-nrfconnect-devdep/mocks/electronMock.js"
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/fileMock.js",
+    "\\.(css|less|scss)$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
+    "nrfconnect/core": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/coreMock.js",
+    "pc-ble-driver-js": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/bleDriverMock.js",
+    "pc-nrfjprog-js|serialport|usb": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
+    "electron": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/electronMock.js"
   },
   "transform": {
     "^.+\\.jsx?$": [
       "babel-jest",
-      { "configFile": "./node_modules/pc-nrfconnect-devdep/config/babel.config.js" }
+      { "configFile": "./node_modules/pc-nrfconnect-shared/config/babel.config.js" }
     ]
   },
-  "transformIgnorePatterns": [ "node_modules/(?!(pc-nrfconnect-devdep)/)" ],
+  "transformIgnorePatterns": [ "node_modules/(?!(pc-nrfconnect-shared)/)" ],
   "testURL": "file:/",
-  "setupFilesAfterEnv": [ "<rootDir>/node_modules/pc-nrfconnect-devdep/test/setupTests.js" ]
+  "setupFilesAfterEnv": [ "<rootDir>/node_modules/pc-nrfconnect-shared/test/setupTests.js" ]
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -22,7 +22,7 @@ function createExternals() {
         'usb',
         'nrf-device-setup',
         'nrfconnect/core',
-        'pc-nrfconnect-devdep',
+        'pc-nrfconnect-shared',
     ];
 
     // Libs provided by the app at runtime
@@ -67,7 +67,7 @@ module.exports = {
                 loader: require.resolve('babel-loader'),
                 options: {
                     cacheDirectory: true,
-                    configFile: './node_modules/pc-nrfconnect-devdep/config/babel.config.js',
+                    configFile: './node_modules/pc-nrfconnect-shared/config/babel.config.js',
                 }
             }, {
                 loader: require.resolve('eslint-loader'),
@@ -75,7 +75,7 @@ module.exports = {
                     configFile: eslintConfig,
                 }
             }],
-            exclude: /node_modules\/(?!pc-nrfconnect-devdep\/)/,
+            exclude: /node_modules\/(?!pc-nrfconnect-shared\/)/,
         }, {
             test: /\.scss|\.css$/,
             use: [

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "pc-nrfconnect-devdep",
+  "name": "pc-nrfconnect-shared",
   "version": "3.6.0",
-  "description": "Common development dependencies for pc-nrfconnect-* packages.",
+  "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",
-    "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git"
+    "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git"
   },
   "author": "Nordic Semiconductor ASA",
   "license": "ISC",

--- a/scripts/lint-init.js
+++ b/scripts/lint-init.js
@@ -41,7 +41,7 @@ const path = require('path');
 
 const configFileSource = path.join(
     'node_modules',
-    'pc-nrfconnect-devdep',
+    'pc-nrfconnect-shared',
     'config',
     'eslintrc.json'
 );
@@ -52,5 +52,5 @@ fs.copyFile(configFileSource, configFileDestination, err => {
         console.error(err);
         process.exit(1);
     }
-    console.log('.eslintrc is updated according to pc-nrfconnect-devdep');
+    console.log('.eslintrc is updated according to pc-nrfconnect-shared');
 });


### PR DESCRIPTION
This is part of [NCP-2704](https://projecttools.nordicsemi.no/jira/browse/NCP-2704).

Because this may require that other packages using this package have to
be slightly adapted, this is a breaking change.

But please note, that they only can and have to be adapted if they
actually depend on version 4 (or later) of this package. And it is not
necessary, that all packages have to be adapted right away:

E.g. the core/launcher could already use version 4.0 of this package
under the name pc-nrfconnect-shared, while an app may still refer to
version 3.5 of it as pc-nrfconnect-devdep.