### PR TITLE
Correct reference to project core/launcher

### DIFF
--- a/src/Device/deviceActions.js
+++ b/src/Device/deviceActions.js
@@ -169,7 +169,7 @@ const logDeviceListerError = error => dispatch => {
             message += 'Please check your udev rules concerning permissions for USB devices, see '
                     + 'https://github.com/NordicSemiconductor/nrf-udev';
         } else if (process.platform === 'win32') {
-            message += 'Please check that a libusb-compatible kernel driver is bound to this device, see https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/master/doc/win32-usb-troubleshoot.md';
+            message += 'Please check that a libusb-compatible kernel driver is bound to this device, see https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/master/doc/win32-usb-troubleshoot.md';
         }
 
         dispatch(showAppReloadDialog(


### PR DESCRIPTION
This is part of [NCP-2704](https://projecttools.nordicsemi.no/jira/browse/NCP-2704).

The project `pc-nrfconnect-core` was renamed to `pc-nrfconnect-launcher`. This corrects references to the old name (links are redirected but it might still be confusing to keep on using the old name).