### PR TITLE
Remove dependency to react-infinite

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Version 4.2
 ### Changed
 - Enhanced handling custom devices
+- Remove dependency of react-infinite. #38
 
 ## Version 4.1
 ### Changed

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "react": "16.12.0",
     "react-bootstrap": "1.0.0-beta.16",
     "react-dom": "16.12.0",
-    "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
     "react-redux": "7.1.3",
     "react-test-renderer": "16.12.0",
     "redux": "4.0.4",

--- a/resources/css/log-entry.scss
+++ b/resources/css/log-entry.scss
@@ -18,6 +18,7 @@
     }
     .core19-log-time {
         width: 132px;
+        min-width: 132px;
     }
 }
 

--- a/resources/css/log-viewer.scss
+++ b/resources/css/log-viewer.scss
@@ -11,9 +11,9 @@
         position: relative;
         overflow-x: scroll !important;
         background-color: white;
+        height: 155px;
 
         > div {
-            position: absolute;
             display: table;
             min-width: 100%;
         }

--- a/src/Log/LogViewer.jsx
+++ b/src/Log/LogViewer.jsx
@@ -46,61 +46,21 @@ import '../../resources/css/log-viewer.scss';
 
 const elementHeight = 20;
 
-class LogViewer extends React.Component {
-    logContainer = createRef();
+const LogViewer = ({ logEntries, autoScroll, dispatch }) => {
+    const logContainer = useRef(null);
 
-    state = {
-        containerHeight: 200,
-    }
+    autoScroll && useEffect(() => { logContainer.current.lastChild.scrollIntoView(); });
+    useEffect(() => { startListening(dispatch); }, []);
 
-    componentDidMount() {
-        const { dispatch } = this.props;
-        startListening(dispatch);
-
-        const { containerHeight } = this.state;
-        if (containerHeight !== this.logContainer.current.offsetHeight) {
-            this.setState({ containerHeight: this.logContainer.current.offsetHeight });
-        }
-    }
-
-    componentDidUpdate() {
-        const { containerHeight } = this.state;
-        if (containerHeight !== this.logContainer.current.offsetHeight) {
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({ containerHeight: this.logContainer.current.offsetHeight });
-        }
-    }
-
-    componentWillUnmount() {
-        stopListening();
-    }
-
-    render() {
-        const { autoScroll, logEntries } = this.props;
-        const { containerHeight } = this.state;
-
-        const infiniteLoadBeginEdgeOffset = Math.max(
-            containerHeight - elementHeight, elementHeight,
-        );
-
-        return (
-            <div className="core19-log-viewer">
-                <LogHeader />
-                <div ref={this.logContainer}>
-                    <Infinite
-                        elementHeight={elementHeight}
-                        containerHeight={containerHeight}
-                        infiniteLoadBeginEdgeOffset={infiniteLoadBeginEdgeOffset}
-                        className="core19-infinite-log"
-                        autoScroll={autoScroll}
-                    >
-                        {logEntries.map(entry => <LogEntry {...{ entry }} key={entry.id} />)}
-                    </Infinite>
-                </div>
+    return (
+        <div className="core19-log-viewer">
+            <LogHeader />
+            <div ref={logContainer} className="core19-infinite-log">
+                { logEntries.map(entry => <LogEntry {...{ entry }} key={entry.id} />) }
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 LogViewer.propTypes = {
     dispatch: func.isRequired,

--- a/src/Log/LogViewer.jsx
+++ b/src/Log/LogViewer.jsx
@@ -34,22 +34,23 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { createRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, bool, func } from 'prop-types';
-import Infinite from 'react-infinite';
 import LogHeader from './LogHeader';
 import LogEntry, { entryShape } from './LogEntry';
-import { stopListening, startListening } from './logListener';
+import { startListening } from './logListener';
 
 import '../../resources/css/log-viewer.scss';
-
-const elementHeight = 20;
 
 const LogViewer = ({ logEntries, autoScroll, dispatch }) => {
     const logContainer = useRef(null);
 
-    autoScroll && useEffect(() => { logContainer.current.lastChild.scrollIntoView(); });
+    useEffect(() => {
+        if (autoScroll && logContainer.current.lastChild) {
+            logContainer.current.lastChild.scrollIntoView();
+        }
+    });
     useEffect(() => { startListening(dispatch); }, []);
 
     return (

--- a/src/Log/logReducer.js
+++ b/src/Log/logReducer.js
@@ -36,7 +36,7 @@
 
 import { ADD_ENTRIES, CLEAR_ENTRIES, TOGGLE_AUTOSCROLL } from './logActions';
 
-const MAX_ENTRIES = 10000;
+const MAX_ENTRIES = 1000;
 
 const initialState = {
     autoScroll: true,


### PR DESCRIPTION
This PR removes dependency to old and unmaintained react-infinite module in the by a simple reimplementation of the LogViewer component that has reduced limitation of 1000 log entries.

Related PR: https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/pull/401