### PR TITLE
Enhance removed sources handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## Version 4.1
+### Changed
+- Enhanced error dialogs:
+    - Made URLs in error messages clickable (and more generally interpret them as markdown)
+    - Made error messages selectable again (regression) to enable copy&pasting them.
+    - Enabled custom error resolutions
+
 ## Version 4.0
 ### Breaking change
 - This package was renamed to “pc-nrfconnect-shared”. If you refer to it anywhere under

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-bootstrap": "1.0.0-beta.16",
     "react-dom": "16.12.0",
     "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
+    "react-markdown": "4.2.2",
     "react-redux": "7.1.3",
     "react-test-renderer": "16.12.0",
     "redux": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-shared",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",

--- a/resources/css/error.scss
+++ b/resources/css/error.scss
@@ -1,0 +1,3 @@
+.core19-error-body {
+    user-select: text;
+}

--- a/src/ErrorDialog/ErrorDialog.jsx
+++ b/src/ErrorDialog/ErrorDialog.jsx
@@ -38,6 +38,7 @@ import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
+import ReactMarkdown from 'react-markdown';
 
 import { hideDialog } from './errorDialogActions';
 
@@ -54,7 +55,13 @@ const ErrorDialog = () => {
                 <Modal.Title>Error</Modal.Title>
             </Modal.Header>
             <Modal.Body className="core19-error-body">
-                { messages.map(message => <p key={message}>{message}</p>)}
+                { messages.map(message => (
+                    <ReactMarkdown
+                        key={message}
+                        source={message}
+                        linkTarget="_blank"
+                    />
+                ))}
             </Modal.Body>
             <Modal.Footer>
                 <Button onClick={doHideDialog}>Close</Button>

--- a/src/ErrorDialog/ErrorDialog.jsx
+++ b/src/ErrorDialog/ErrorDialog.jsx
@@ -41,6 +41,8 @@ import Button from 'react-bootstrap/Button';
 
 import { hideDialog } from './errorDialogActions';
 
+import '../../resources/css/error.scss';
+
 const ErrorDialog = () => {
     const { isVisible, messages } = useSelector(state => state.errorDialog);
     const dispatch = useDispatch();
@@ -51,7 +53,7 @@ const ErrorDialog = () => {
             <Modal.Header closeButton>
                 <Modal.Title>Error</Modal.Title>
             </Modal.Header>
-            <Modal.Body>
+            <Modal.Body className="core19-error-body">
                 { messages.map(message => <p key={message}>{message}</p>)}
             </Modal.Body>
             <Modal.Footer>

--- a/src/ErrorDialog/ErrorDialog.jsx
+++ b/src/ErrorDialog/ErrorDialog.jsx
@@ -45,9 +45,14 @@ import { hideDialog } from './errorDialogActions';
 import '../../resources/css/error.scss';
 
 const ErrorDialog = () => {
-    const { isVisible, messages } = useSelector(state => state.errorDialog);
     const dispatch = useDispatch();
     const doHideDialog = useCallback(() => dispatch(hideDialog()), [dispatch]);
+
+    const { isVisible, messages } = useSelector(state => state.errorDialog);
+
+    const defaultErrorResolutions = { Close: doHideDialog };
+    const errorResolutions = useSelector(state => state.errorDialog.errorResolutions)
+        || defaultErrorResolutions;
 
     return (
         <Modal show={isVisible} onHide={doHideDialog}>
@@ -64,7 +69,11 @@ const ErrorDialog = () => {
                 ))}
             </Modal.Body>
             <Modal.Footer>
-                <Button onClick={doHideDialog}>Close</Button>
+                {Object.entries(errorResolutions).map(([label, handler], index) => (
+                    <Button key={label} onClick={handler} variant={index === 0 ? 'primary' : 'outline-secondary'}>
+                        {label}
+                    </Button>
+                ))}
             </Modal.Footer>
         </Modal>
     );

--- a/src/ErrorDialog/ErrorDialog.test.jsx
+++ b/src/ErrorDialog/ErrorDialog.test.jsx
@@ -104,4 +104,17 @@ describe('ErrorDialog', () => {
             await waitForElementToBeRemoved(getDialog);
         });
     });
+
+    it('can have a custom error resolutions', () => {
+        const specialHandling = jest.fn();
+
+        const { getByText } = render(
+            <ErrorDialog />,
+            [showDialog('An error occured', { 'Special Handling': specialHandling })],
+        );
+
+        fireEvent.click(getByText('Special Handling'));
+
+        expect(specialHandling).toHaveBeenCalled();
+    });
 });

--- a/src/ErrorDialog/errorDialogActions.js
+++ b/src/ErrorDialog/errorDialogActions.js
@@ -35,7 +35,9 @@
  */
 
 export const ERROR_DIALOG_SHOW = 'ERROR_DIALOG_SHOW';
-export const showDialog = message => ({ type: ERROR_DIALOG_SHOW, message });
+export const showDialog = (message, errorResolutions) => (
+    { type: ERROR_DIALOG_SHOW, message, errorResolutions }
+);
 
 export const ERROR_DIALOG_HIDE = 'ERROR_DIALOG_HIDE';
 export const hideDialog = () => ({ type: ERROR_DIALOG_HIDE });

--- a/src/ErrorDialog/errorDialogReducer.js
+++ b/src/ErrorDialog/errorDialogReducer.js
@@ -39,6 +39,7 @@ import { ERROR_DIALOG_SHOW, ERROR_DIALOG_HIDE } from './errorDialogActions';
 const initialState = {
     messages: [],
     isVisible: false,
+    errorResolutions: undefined,
 };
 
 const appendIfNew = (messages, message) => (messages.includes(message)
@@ -51,12 +52,9 @@ const reducer = (state = initialState, action) => {
             ...state,
             isVisible: true,
             messages: appendIfNew(state.messages, action.message),
+            errorResolutions: action.errorResolutions,
         };
-        case ERROR_DIALOG_HIDE: return {
-            ...state,
-            isVisible: false,
-            messages: [],
-        };
+        case ERROR_DIALOG_HIDE: return initialState;
         default: return state;
     }
 };


### PR DESCRIPTION
This supports [NCP-2674](https://projecttools.nordicsemi.no/jira/browse/NCP-2674) to enhance the error message when a sources file was removed. The main change for that issue is done in the launcher.

This change here enhanced error dialogs:
- Made URLs in error messages clickable (and more generally interpret them as markdown)
- Made error messages selectable again (regression) to enable copy&pasting them.
- Enabled custom error resolutions