### PR TITLE
Lint and test before push

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-push": "bash scripts/pre-push.sh"
+  }
+}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+## Version 4.3
+### Added
+- Ease configuration of git hooks #40. If you want to automatically run the `lint` and `test` scripts before pushing changes, add a file `.huskyrc.json` to your project with this content:
+```json
+{
+    "hooks": {
+        "pre-push": "bash node_modules/pc-nrfconnect-shared/scripts/pre-push.sh"
+    }
+}
+```
+
 ## Version 4.2
 ### Changed
 - Enhanced handling custom devices

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react-hooks": "1.6.1",
     "file-loader": "4.0.0",
     "ftp": "0.3.10",
+    "husky": "3.1.0",
     "immutable": "4.0.0-rc.12",
     "jest": "24.9.0",
     "jest-bamboo-formatter": "1.0.1",
@@ -72,14 +73,6 @@
     "url-loader": "2.0.1",
     "webpack": "4.35.2",
     "winston": "3.2.1"
-  },
-  "devDependencies": {
-    "husky": "3.1.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-push": "bash scripts/pre-push.sh"
-    }
   },
   "jest": {
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,14 @@
     "webpack": "4.35.2",
     "winston": "3.2.1"
   },
+  "devDependencies": {
+    "husky": "3.1.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "scripts/pre-push.sh"
+    }
+  },
   "jest": {
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/mocks/fileMock.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "src",
   "scripts": {
-    "lint": "./bin/nrfconnect-scripts.js lint src",
+    "lint": "node ./bin/nrfconnect-scripts.js lint src",
     "test": "jest --testResultsProcessor jest-bamboo-formatter src",
     "test-watch": "jest --watch src"
   },
@@ -78,7 +78,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "scripts/pre-push.sh"
+      "pre-push": "bash scripts/pre-push.sh"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-shared",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+[ "$GIT_SKIP_LINT_ON_PUSH" ] || npm run lint
+[ "$GIT_SKIP_TEST_ON_PUSH" ] || npm run test


### PR DESCRIPTION
This creates a git hook using [husky](https://github.com/typicode/husky) when running `npm install` that lints and tests the code before pushing it (and aborts the push if there are any error detected).

You can opt out of linting by setting the environment variable `GIT_SKIP_LINT_ON_PUSH` and similar `GIT_SKIP_TEST_ON_PUSH` to skip running the tests. If you want to skip all hooks, you can instead also set the environment variable `HUSKY_SKIP_HOOKS` to `1`, [as described in the husky docs](https://github.com/typicode/husky#skip-all-hooks-rebase).

As you probably are aware, you can also skip running the hooks during a push with the parameter `--no-verify` as in `git push --no-verify`.