### PR TITLE
Update Jest

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## Version 4.4
+- Update Jest
+
 ## Version 4.3
 ### Added
 - Ease configuration of git hooks #40. If you want to automatically run the `lint` and `test` scripts before pushing changes, add a file `.huskyrc.json` to your project with this content:

--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -15,6 +15,5 @@
     ]
   },
   "transformIgnorePatterns": [ "node_modules/(?!(pc-nrfconnect-shared)/)" ],
-  "testURL": "file:/",
   "setupFilesAfterEnv": [ "<rootDir>/node_modules/pc-nrfconnect-shared/test/setupTests.js" ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-shared",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "@babel/plugin-transform-parameters": "7.4.4",
     "@babel/plugin-transform-spread": "7.2.2",
     "@babel/preset-react": "7.0.0",
-    "@testing-library/jest-dom": "4.2.4",
+    "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "9.3.2",
     "babel-eslint": "10.0.2",
     "babel-loader": "8.0.6",
@@ -47,7 +47,7 @@
     "ftp": "0.3.10",
     "husky": "3.1.0",
     "immutable": "4.0.0-rc.12",
-    "jest": "24.9.0",
+    "jest": "25.1.0",
     "jest-bamboo-formatter": "1.0.1",
     "moment": "2.24.0",
     "mousetrap": "1.6.3",


### PR DESCRIPTION
This also removes the configuration for testURL, because the new Jest
version incorporates a new jsdom version that chokes if testURL is set
to `file:/`. But the default `http://localhost` for testURL works fine for
the tests, so we just remove our setting.