### PR TITLE
Switch to new serialport property path

### DIFF
--- a/src/Device/DeviceSelectorView.jsx
+++ b/src/Device/DeviceSelectorView.jsx
@@ -59,8 +59,7 @@ export default class DeviceSelector extends React.Component {
     static mapSerialPortsToListItems(device) {
         return Object.keys(device)
             .filter(key => key.startsWith('serialport'))
-            // eslint-disable-next-line react/no-array-index-key
-            .map((key, index) => <li key={index}>Serial port: {device[key].path}</li>);
+            .map(key => <li key={key}>Serial port: {device[key].path}</li>);
     }
 
     componentDidMount() {

--- a/src/Device/DeviceSelectorView.jsx
+++ b/src/Device/DeviceSelectorView.jsx
@@ -59,7 +59,8 @@ export default class DeviceSelector extends React.Component {
     static mapSerialPortsToListItems(device) {
         return Object.keys(device)
             .filter(key => key.startsWith('serialport'))
-            .map(key => <li key={device[key].comName}>Serial port: {device[key].comName}</li>);
+            // eslint-disable-next-line react/no-array-index-key
+            .map((key, index) => <li key={index}>Serial port: {device[key].path}</li>);
     }
 
     componentDidMount() {


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

Because this component is not used in old apps, we do not have to remain backward compatible.

Also switch to using the index as key, because the path/comName is not always unique.