### PR TITLE
Add old ALT+L (Option+L) keyboard shortcut to open Launcher window

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -40,6 +40,9 @@ import {
 } from 'prop-types';
 import { useSelector } from 'react-redux';
 
+import Mousetrap from 'mousetrap';
+import { ipcRenderer } from 'electron';
+
 import LogViewer from '../Log/LogViewer';
 
 import ErrorDialog from '../ErrorDialog/ErrorDialog';
@@ -58,6 +61,10 @@ const ConnectedApp = ({
     const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
     const isLogVisible = useSelector(isLogVisibleSelector);
     const MainComponent = useSelector(mainComponentSelector(panes));
+
+    useEffect(() => {
+        Mousetrap.bind('alt+l', () => ipcRenderer.send('open-app-launcher'));
+    }, []);
 
     return (
         <div className="core19-app">

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     array, arrayOf, func, node,
 } from 'prop-types';


### PR DESCRIPTION
This PR binds ALT+L keyboard shortcut in the app to opening the Launcher window just as it used to be in legacy apps.