### PR TITLE
Fix missing mocks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
-## Unreleased
+## Version 4.8.1
+### Fixed
+- Added missing mocks for nrf-device-lister and nrf-device-setup to jest config.
+
 ### Changed
 - Updated dependencies
+- Removed mocking *.less files from the jest configuration, as we do not use them.
 
 ## Version 4.8
 ### Changed

--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -2,10 +2,10 @@
   "rootDir": "../../../",
   "moduleNameMapper": {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/fileMock.js",
-    "\\.(css|less|scss)$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
+    "\\.(css|scss)$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
     "nrfconnect/core": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/coreMock.js",
     "pc-ble-driver-js": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/bleDriverMock.js",
-    "pc-nrfjprog-js|serialport|usb": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
+    "pc-nrfjprog-js|nrf-device-lister|nrf-device-setup|serialport|usb": "./node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
     "electron": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/electronMock.js"
   },
   "transform": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-shared",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As discovered in switching the boilerplate app to the new architecture, mocking nrf-device-lister and nrf-device-setup was still missing in the jest configuration: https://github.com/NordicSemiconductor/pc-nrfconnect-boilerplate/tree/new-arch

The missing configuration is the reason why this build failed: https://dev.azure.com/NordicSemiconductor/Wayland/_build/results?buildId=4430&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=9c939e41-62c2-5605-5e05-fc3554afc9f5&l=101