### PR TITLE
Weaken proptypes

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -101,14 +101,15 @@ ConnectedApp.propTypes = {
     sidePanel: node.isRequired,
 };
 
-const App = ({ appReducer, ...props }) => (
+const noopReducer = state => state;
+const App = ({ appReducer = noopReducer, ...props }) => (
     <ConnectedToStore appReducer={appReducer}>
         <ConnectedApp {...props} />
     </ConnectedToStore>
 );
 
 App.propTypes = {
-    appReducer: func.isRequired,
+    appReducer: func, // eslint-disable-line react/require-default-props
 };
 
 export default App;

--- a/src/Device/DeviceSelector/DeviceSelector.jsx
+++ b/src/Device/DeviceSelector/DeviceSelector.jsx
@@ -126,12 +126,12 @@ DeviceSelector.propTypes = {
         serialport: bool,
         jlink: bool,
     }).isRequired,
+    /* eslint-disable react/require-default-props */
     deviceSetup: exact({
         jprog: object,
         dfu: object,
         needSerialport: bool,
-    }).isRequired,
-    /* eslint-disable react/require-default-props */
+    }),
     releaseCurrentDevice: func, // () => {}
     onDeviceSelected: func, // (device) => {}
     onDeviceDeselected: func, // () => {}


### PR DESCRIPTION
As described in the [docs](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/api_reference), the properties `appReducer` and `deviceSetup` are optional.