### PR TITLE
Make list order changes easier to follow

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prettysize": "2.0.0",
     "raw-loader": "4.0.1",
     "react-bootstrap": "1.0.1",
+    "react-flip-toolkit": "7.0.12",
     "react-ga": "2.7.0",
     "react-markdown": "4.3.1",
     "react-test-renderer": "16.13.1",

--- a/src/Device/DeviceSelector/DeviceList/AnimatedList.jsx
+++ b/src/Device/DeviceSelector/DeviceList/AnimatedList.jsx
@@ -35,46 +35,61 @@
  */
 
 import React from 'react';
-import { func } from 'prop-types';
-import { useSelector } from 'react-redux';
+import { arrayOf, node, string } from 'prop-types';
+import { Flipper, Flipped, spring } from 'react-flip-toolkit';
+import deviceShape from '../deviceShape';
 
-import { sortedDevices } from '../../deviceReducer';
-import Device from './Device';
-import { AnimatedList, AnimatedItem } from './AnimatedList';
+const changesOnReorder = devices => devices
+    .map(device => device.serialNumber)
+    .join('\n');
 
-import './device-list.scss';
-
-const NoDevicesConnected = () => (
-    <p className="no-devices-connected">
-        Connect a{' '}
-        <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://www.nordicsemi.com/Software-and-tools/Development-Kits"
-        >
-            Nordic development kit
-        </a>
-        {' '}to your computer.
-    </p>
+export const AnimatedList = ({ children, className, devices }) => (
+    <Flipper
+        element="ul"
+        className={className}
+        flipKey={changesOnReorder(devices)}
+    >
+        {children}
+    </Flipper>
 );
+AnimatedList.propTypes = {
+    children: node.isRequired,
+    className: string.isRequired,
+    devices: arrayOf(deviceShape.isRequired).isRequired,
+};
 
-const DeviceList = ({ doSelectDevice }) => {
-    const devices = useSelector(sortedDevices);
-
-    if (devices.length === 0) return <NoDevicesConnected />;
-
-    return (
-        <AnimatedList devices={devices} className="device-list">
-            {devices.map(device => (
-                <AnimatedItem key={device.serialNumber} itemKey={device.serialNumber}>
-                    <Device device={device} doSelectDevice={doSelectDevice} />
-                </AnimatedItem>
-            ))}
-        </AnimatedList>
+const fadeInOrOut = fadeOut => (element, _, removeElement) => {
+    const range = fadeOut ? [1, 0] : [0, 1];
+    return (spring({
+        values: {
+            opacity: range,
+            scale: range,
+        },
+        onUpdate: ({ opacity, scale }) => {
+            element.style.opacity = opacity; // eslint-disable-line no-param-reassign
+            element.style.transform = `scaleY(${scale})`; // eslint-disable-line no-param-reassign
+        },
+        onComplete: () => {
+            if (fadeOut) {
+                removeElement();
+            }
+        },
+    })
     );
 };
-DeviceList.propTypes = {
-    doSelectDevice: func.isRequired,
-};
 
-export default DeviceList;
+export const AnimatedItem = ({ children, itemKey }) => (
+    <Flipped
+        flipId={itemKey}
+        onAppear={fadeInOrOut(false)}
+        onExit={fadeInOrOut(true)}
+    >
+        <li>
+            {children}
+        </li>
+    </Flipped>
+);
+AnimatedItem.propTypes = {
+    itemKey: string.isRequired,
+    children: node.isRequired,
+};


### PR DESCRIPTION
When a device changes it position in the list (because it is favorited
or the name is changed) it may jump to a different position which is
confusing. So this adds an animation, so that the transition is visually
shown on the screen.

As a bonus it is also now animated when devices are added or removed,
making it easier to see which devices come, go, or stay.

![Animated device list](https://user-images.githubusercontent.com/260705/87530571-ccb18e00-c690-11ea-8853-d08acc721909.gif)
