### PR TITLE
Disable ESLint rule react/require-default-props

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 ## Unreleased
 ### Added
 - Favorite and nickname in device selector for new design
+### Changed
+- Disabled the ESLint rule react/require-default-props, you should remove your
+  local disables when upgrading to this version.
 
 ## Version 4.8.3
 ### Changed

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -22,6 +22,7 @@
         ],
         "react/jsx-one-expression-per-line": "off",
         "react/jsx-props-no-spreading": "off",
+        "react/require-default-props": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "error",
         "jsx-a11y/control-has-associated-label": "off",

--- a/src/About/AboutButton.jsx
+++ b/src/About/AboutButton.jsx
@@ -52,7 +52,7 @@ const AboutButton = ({ url, label }) => (
     </Button>
 );
 AboutButton.propTypes = {
-    url: string, // eslint-disable-line react/require-default-props
+    url: string,
     label: string.isRequired,
 };
 

--- a/src/About/Section.jsx
+++ b/src/About/Section.jsx
@@ -46,8 +46,8 @@ const Section = ({ children, title }) => (
     </div>
 );
 Section.propTypes = {
-    title: string, // eslint-disable-line react/require-default-props
-    children: node, // eslint-disable-line react/require-default-props
+    title: string,
+    children: node,
 };
 
 export default Section;

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -109,7 +109,7 @@ const App = ({ appReducer = noopReducer, ...props }) => (
 );
 
 App.propTypes = {
-    appReducer: func, // eslint-disable-line react/require-default-props
+    appReducer: func,
 };
 
 export default App;

--- a/src/Device/DeviceSelector/BasicDeviceInfo.jsx
+++ b/src/Device/DeviceSelector/BasicDeviceInfo.jsx
@@ -73,7 +73,6 @@ const DeviceName = ({ device, inputRef }) => {
 };
 DeviceName.propTypes = {
     device: deviceShape.isRequired,
-    // eslint-disable-next-line react/require-default-props
     inputRef: shape({ current: shape({ focus: func.isRequired }) }),
 };
 
@@ -101,7 +100,6 @@ const BasicDeviceInfo = ({
 );
 BasicDeviceInfo.propTypes = {
     device: deviceShape.isRequired,
-    // eslint-disable-next-line react/require-default-props
     deviceNameInputRef: shape({ current: shape({ focus: func.isRequired }) }),
     whiteBackground: bool.isRequired,
     additionalToggle: node.isRequired,

--- a/src/Device/DeviceSelector/DeviceIcon.jsx
+++ b/src/Device/DeviceSelector/DeviceIcon.jsx
@@ -55,7 +55,7 @@ const DeviceIcon = ({ device, whiteBackground }) => {
     );
 };
 DeviceIcon.propTypes = {
-    device: deviceShape, // eslint-disable-line react/require-default-props
+    device: deviceShape,
     whiteBackground: bool.isRequired,
 };
 

--- a/src/Device/DeviceSelector/DeviceSelector.jsx
+++ b/src/Device/DeviceSelector/DeviceSelector.jsx
@@ -123,7 +123,6 @@ DeviceSelector.propTypes = {
         serialport: bool,
         jlink: bool,
     }).isRequired,
-    /* eslint-disable react/require-default-props */
     deviceSetup: exact({
         jprog: object,
         dfu: object,

--- a/src/InlineInput/InlineInput.jsx
+++ b/src/InlineInput/InlineInput.jsx
@@ -113,10 +113,10 @@ const InlineInput = React.forwardRef(({
 
 InlineInput.propTypes = {
     value: string.isRequired,
-    isValid: func, // eslint-disable-line react/require-default-props
+    isValid: func,
     onChange: func.isRequired,
-    className: string, // eslint-disable-line react/require-default-props
-    style: object, // eslint-disable-line react/require-default-props, react/forbid-prop-types
+    className: string,
+    style: object, // eslint-disable-line react/forbid-prop-types
 };
 
 export default InlineInput;

--- a/src/Main/Main.jsx
+++ b/src/Main/Main.jsx
@@ -41,6 +41,6 @@ import './main.scss';
 
 const Main = ({ children }) => <div className="core19-main-view">{children}</div>;
 
-Main.propTypes = { children: node }; // eslint-disable-line react/require-default-props
+Main.propTypes = { children: node };
 
 export default Main;

--- a/src/PseudoButton/PseudoButton.jsx
+++ b/src/PseudoButton/PseudoButton.jsx
@@ -70,7 +70,6 @@ const PseudoButton = ({
     </div>
 );
 PseudoButton.propTypes = {
-    /* eslint-disable react/require-default-props */
     onClick: func,
     className: string,
     children: node,


### PR DESCRIPTION
It is too often quite reasonable to not follow the rule, as the examples
show where we had previously disabled it locally. These overrides are
also removed in this commit.