### PR TITLE
Small visual redesign changes

### DIFF
--- a/src/About/about.scss
+++ b/src/About/about.scss
@@ -26,7 +26,7 @@ $section-gap: 2ex;
         background-color: $white;
         border: 1px solid $gray-200;
 
-        font-weight: 200;
+        font-weight: $font-weight-light;
 
         .about-card-title {
             text-align: right;

--- a/src/App/VisibilityBar.jsx
+++ b/src/App/VisibilityBar.jsx
@@ -37,11 +37,14 @@
 import React from 'react';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
+import {
+    isSidePanelVisibleSelector,
+    isLogVisibleSelector,
+    toggleSidePanelVisible,
+    toggleLogVisible,
+} from './appLayout';
 
 import './visibility-bar.scss';
-import {
-    isSidePanelVisibleSelector, isLogVisibleSelector, toggleSidePanelVisible, toggleLogVisible,
-} from './appLayout';
 
 export default () => {
     const dispatch = useDispatch();
@@ -49,7 +52,7 @@ export default () => {
     const isLogVisible = useSelector(isLogVisibleSelector);
     return (
         <div className="core19-visibility-bar">
-            <div className="core19-visibility-bar-show-side-panel">
+            <div className={`core19-visibility-bar-show-side-panel ${isSidePanelVisible ? '' : 'panel-hidden'}`}>
                 <Form.Switch
                     id="visibility-bar-show-side-panel"
                     label="Show side panel"

--- a/src/App/visibility-bar.scss
+++ b/src/App/visibility-bar.scss
@@ -12,6 +12,10 @@
         color: $gray-700;
         background-color: $gray-100;
         padding: 5px 10px;
+
+        &.panel-hidden {
+            background-color: $gray-50;
+        }
     }
 
     .core19-visibility-bar-show-log {

--- a/src/Device/DeviceSelector/DeviceList/device-list.scss
+++ b/src/Device/DeviceSelector/DeviceList/device-list.scss
@@ -15,7 +15,7 @@
         list-style: none;
         padding: 0;
 
-        font-weight: 200;
+        font-weight: $font-weight-light;
 
         > :first-child {
             border-top: 1px solid $primary-darkened;

--- a/src/Device/DeviceSelector/DeviceList/edit-device-buttons.scss
+++ b/src/Device/DeviceSelector/DeviceList/edit-device-buttons.scss
@@ -6,7 +6,7 @@
         height: 35px;
 
         font-size: 11px;
-        font-weight: 400;
+        font-weight: $font-weight-normal;
 
         text-transform: uppercase;
         text-align: center;

--- a/src/Device/DeviceSelector/basic-device-info.scss
+++ b/src/Device/DeviceSelector/basic-device-info.scss
@@ -19,7 +19,7 @@
 
             .name {
                 font-size: 15px;
-                font-weight: 400;
+                font-weight: $font-weight-normal;
             }
         }
 

--- a/src/Device/DeviceSelector/selector-button.scss
+++ b/src/Device/DeviceSelector/selector-button.scss
@@ -16,6 +16,7 @@
             background: $white;
 
             .serial-number {
+                color: inherit;
                 font-weight: $font-weight-light;
                 font-size: 11px;
             }

--- a/src/Device/DeviceSelector/selector-button.scss
+++ b/src/Device/DeviceSelector/selector-button.scss
@@ -16,7 +16,7 @@
             background: $white;
 
             .serial-number {
-                font-weight: 200;
+                font-weight: $font-weight-light;
                 font-size: 11px;
             }
 
@@ -29,7 +29,7 @@
         &.no-device-selected {
             .show-list-indicator {
                 margin-right: 20px;
-            }                
+            }
         }
 
         .select-device {
@@ -45,7 +45,7 @@
             display: none;
 
             background: $gray-800;
-            font-weight: 200;
+            font-weight: $font-weight-light;
             font-size: 11px;
             text-transform: uppercase;
 

--- a/src/Log/log-header.scss
+++ b/src/Log/log-header.scss
@@ -11,7 +11,7 @@
 .core19-log-header-text {
     height: 30px;
     line-height: 30px;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     padding-left: 20px;
     font-size: 14px;
     margin: 0;

--- a/src/NavBar/nav-menu-item.scss
+++ b/src/NavBar/nav-menu-item.scss
@@ -21,5 +21,6 @@
 
     &:focus, &:hover {
         text-decoration: none;
+        color: $gray-500;
     }
 }

--- a/src/NavBar/nav-menu-item.scss
+++ b/src/NavBar/nav-menu-item.scss
@@ -11,12 +11,12 @@
     padding: 0;
 
     font-size: 14px;
-    font-weight: 200;
+    font-weight: $font-weight-light;
     color: $gray-500;
     text-transform: uppercase;
 
     &.selected {
-        font-weight: bold;
+        font-weight: $font-weight-bold;
     }
 
     &:focus, &:hover {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -79,6 +79,10 @@ $side-panel-width: 260px;
 $nav-bar-height: 40px;
 $visibility-bar-height: 32px;
 
+$font-weight-light: 200;
+$font-weight-normal: 400;
+$font-weight-bold: 700;
+
 //
 // Bootstrap variables below
 // --------------------------------------------------

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -79,7 +79,7 @@ $side-panel-width: 260px;
 $nav-bar-height: 40px;
 $visibility-bar-height: 32px;
 
-$font-weight-light: 200;
+$font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 


### PR DESCRIPTION
Part of [NCP-3117](https://projecttools.nordicsemi.no/jira/browse/NCP-3117).

Several small changes from that issue:
* The pane titles in the navigation bar turn blue on hover. Let them stay grey.
* Roboto thin looks too fragile on some displays, use Roboto light instead.
* Selected device: the serial number should be blue, not grey.
* In the visibility bar, the background of the “show side panel” area has the same colour as the padding in the main view. This looks strange if both side panel and log are hidden. Resolution: Change the background of the “show side panel” area to the background colour of the side panel if the side panel is hidden.
