### PR TITLE
Remove all uses of defaultProps

### DIFF
--- a/src/Device/DeviceSetup/DeviceSetupView.jsx
+++ b/src/Device/DeviceSetup/DeviceSetupView.jsx
@@ -124,7 +124,3 @@ DeviceSetupDialog.propTypes = {
     onOk: func.isRequired,
     onCancel: func.isRequired,
 };
-
-DeviceSetupDialog.defaultProps = {
-    text: '',
-};

--- a/src/Dialog/ConfirmationDialog.jsx
+++ b/src/Dialog/ConfirmationDialog.jsx
@@ -48,8 +48,8 @@ import Spinner from './Spinner';
  * and button actions can be customized.
  *
  * @param {boolean} isVisible Show the dialog or not.
- * @param {boolean} [isInProgress] Shows a spinner if true.
- * @param {string} [title] The dialog title.
+ * @param {boolean} [isInProgress] Shows a spinner if true. Default: false.
+ * @param {string} [title] The dialog title. Default: "Confirm".
  * @param {Array|*} [children] Array or React element to render in the dialog.
  * @param {string} [text] Text to render in the dialog. Alternative to `children`.
  * @param {function} onOk Invoked when the user clicks OK.
@@ -58,20 +58,19 @@ import Spinner from './Spinner';
  * @param {string} [okButtonText] Label text for the OK button. Default: "OK".
  * @param {string} [cancelButtonText] Label text for the cancel button. Default: "Cancel".
  * @param {boolean} [isOkButtonEnabled] Enable the OK button or not. Default: true.
- * @param {string} [buttonCssClass] CSS class name for the buttons. Default: "core-btn".
  * @returns {*} React element to be rendered.
  */
 const ConfirmationDialog = ({
     isVisible,
-    isInProgress,
-    title,
+    isInProgress = false,
+    title = 'Confirm',
     children,
     text,
     onOk,
     onCancel,
-    okButtonText,
-    cancelButtonText,
-    isOkButtonEnabled,
+    okButtonText = 'OK',
+    cancelButtonText = 'Cancel',
+    isOkButtonEnabled = true,
 }) => (
     <Modal show={isVisible} onHide={onCancel} backdrop={isInProgress ? 'static' : false}>
         <Modal.Header closeButton={!isInProgress}>
@@ -115,16 +114,6 @@ ConfirmationDialog.propTypes = {
     cancelButtonText: string,
     isInProgress: bool,
     isOkButtonEnabled: bool,
-};
-
-ConfirmationDialog.defaultProps = {
-    title: 'Confirm',
-    text: null,
-    children: null,
-    isInProgress: false,
-    isOkButtonEnabled: true,
-    okButtonText: 'OK',
-    cancelButtonText: 'Cancel',
 };
 
 export default ConfirmationDialog;

--- a/src/Log/LogHeaderButton.jsx
+++ b/src/Log/LogHeaderButton.jsx
@@ -38,7 +38,7 @@ import React from 'react';
 import { bool, func, string } from 'prop-types';
 
 const LogHeaderButton = ({
-    title, iconCssClass, isSelected, onClick,
+    title, iconCssClass, isSelected = false, onClick,
 }) => (
     <button
         title={title}
@@ -55,10 +55,6 @@ LogHeaderButton.propTypes = {
     onClick: func.isRequired,
     iconCssClass: string.isRequired,
     isSelected: bool,
-};
-
-LogHeaderButton.defaultProps = {
-    isSelected: false,
 };
 
 export default LogHeaderButton;

--- a/src/Logo/Logo.jsx
+++ b/src/Logo/Logo.jsx
@@ -56,7 +56,7 @@ const chooseLogo = (changeWithDeviceState, deviceIsSelected) => {
     return deviceIsSelected ? logoConnected : logoDisconnected;
 };
 
-const Logo = ({ changeWithDeviceState }) => {
+const Logo = ({ changeWithDeviceState = false }) => {
     const deviceIsSelected = useSelector(deviceIsSelectedSelector);
     const logo = chooseLogo(changeWithDeviceState, deviceIsSelected);
     return (
@@ -75,6 +75,5 @@ const Logo = ({ changeWithDeviceState }) => {
 };
 
 Logo.propTypes = { changeWithDeviceState: bool };
-Logo.defaultProps = { changeWithDeviceState: false };
 
 export default Logo;

--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -57,8 +57,4 @@ NavBar.propTypes = {
     panes: arrayOf(array.isRequired).isRequired,
 };
 
-NavBar.defaultProps = ({
-    deviceSelect: null,
-});
-
 export default NavBar;

--- a/src/Slider/Handle.jsx
+++ b/src/Slider/Handle.jsx
@@ -45,8 +45,9 @@ const useAutoupdatingRef = value => {
     return ref;
 };
 
+const noop = () => {};
 const Handle = ({
-    value, range, onChange, onChangeComplete, sliderWidth,
+    value, range, onChange, onChangeComplete = noop, sliderWidth,
 }) => {
     const [currentlyDragged, setCurrentlyDragged] = useState(false);
     const percentage = toPercentage(value, range);
@@ -107,10 +108,6 @@ Handle.propTypes = {
     onChange: func.isRequired,
     onChangeComplete: func,
     sliderWidth: number,
-};
-Handle.defaultProps = {
-    onChangeComplete: () => {},
-    sliderWidth: null,
 };
 
 export default Handle;

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -79,9 +79,5 @@ Slider.propTypes = {
     onChange: arrayOf(func.isRequired).isRequired,
     onChangeComplete: func,
 };
-Slider.defaultProps = {
-    id: null,
-    onChangeComplete: () => {},
-};
 
 export default Slider;


### PR DESCRIPTION
Forgot to do this in the PR #60: Some uses of `defaultProps` were just unnecessary and could be removed. Others could be converted to default function arguments.