### PR TITLE
Render all panes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Render all panes of the App, but only the current is visible
+
 ## Version 4.8.4
 ### Added
 - Favorite and nickname in device selector for new design

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -50,7 +50,7 @@ import AppReloadDialog from '../AppReload/AppReloadDialog';
 import NavBar from '../NavBar/NavBar';
 import VisibilityBar from './VisibilityBar';
 import ConnectedToStore from './ConnectedToStore';
-import { isSidePanelVisibleSelector, isLogVisibleSelector, mainComponentSelector } from './appLayout';
+import { isSidePanelVisibleSelector, isLogVisibleSelector, currentPaneSelector } from './appLayout';
 
 import './shared.scss';
 import './app.scss';
@@ -63,7 +63,7 @@ const ConnectedApp = ({
     const allPanes = [...panes, ['About', About]];
     const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
     const isLogVisible = useSelector(isLogVisibleSelector);
-    const MainComponent = useSelector(mainComponentSelector(allPanes));
+    const currentPane = useSelector(currentPaneSelector);
 
     useEffect(() => {
         Mousetrap.bind('alt+l', () => ipcRenderer.send('open-app-launcher'));
@@ -80,9 +80,11 @@ const ConnectedApp = ({
                     {sidePanel}
                 </div>
                 <div className="core19-main-and-log">
-                    <div className="core19-main-container">
-                        <MainComponent />
-                    </div>
+                    {allPanes.map(([name, MainComponent], index) => (
+                        <div key={name} className={`core19-main-container ${index === currentPane ? '' : 'd-none'}`}>
+                            <MainComponent />
+                        </div>
+                    ))}
                     <div className={`core19-log-viewer ${hiddenUnless(isLogVisible)}`}>
                         <LogViewer />
                     </div>

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -44,7 +44,7 @@ import Mousetrap from 'mousetrap';
 import { ipcRenderer } from 'electron';
 
 import LogViewer from '../Log/LogViewer';
-
+import About from '../About/About';
 import ErrorDialog from '../ErrorDialog/ErrorDialog';
 import AppReloadDialog from '../AppReload/AppReloadDialog';
 import NavBar from '../NavBar/NavBar';
@@ -60,9 +60,10 @@ const hiddenUnless = isVisible => (isVisible ? '' : 'd-none');
 const ConnectedApp = ({
     deviceSelect, panes, sidePanel,
 }) => {
+    const allPanes = [...panes, ['About', About]];
     const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
     const isLogVisible = useSelector(isLogVisibleSelector);
-    const MainComponent = useSelector(mainComponentSelector(panes));
+    const MainComponent = useSelector(mainComponentSelector(allPanes));
 
     useEffect(() => {
         Mousetrap.bind('alt+l', () => ipcRenderer.send('open-app-launcher'));
@@ -72,7 +73,7 @@ const ConnectedApp = ({
         <div className="core19-app">
             <NavBar
                 deviceSelect={deviceSelect}
-                panes={panes}
+                panes={allPanes}
             />
             <div className="core19-app-content">
                 <div className={`core19-side-panel ${hiddenUnless(isSidePanelVisible)}`}>

--- a/src/App/App.test.jsx
+++ b/src/App/App.test.jsx
@@ -36,28 +36,27 @@
 
 import React from 'react';
 import render from '../../test/testrenderer';
-import NavMenu from './NavMenu';
+import App from './App';
+
+const renderApp = panes => {
+    const dummyReducer = (s = null) => s;
+    const dummyNode = <div />;
+
+    return render(<App
+        appReducer={dummyReducer}
+        deviceSelect={dummyNode}
+        sidePanel={dummyNode}
+        panes={panes}
+    />);
+};
 
 const aPane = ['an menu item', () => <div>A pane</div>];
 const anotherPane = ['another menu item', () => <div>Another pane</div>];
 
-expect.extend({
-    toBeHighlighted(element) {
-        const pass = element.classList.contains('selected');
-        const not = pass ? 'not ' : '';
-        const message = () => (
-            `Expected the element to ${not}contain a class 'selected' to signify that `
-            + `it is ${not}highlighted. It actually contained: ${element.className}`
-        );
-        return { pass, message };
-    },
-});
+describe('App', () => {
+    it('automatically gets an About pane attached', () => {
+        const { getByText } = renderApp([aPane, anotherPane]);
 
-describe('NavMenu', () => {
-    it('displays multiple items', () => {
-        const { getByText } = render(<NavMenu panes={[aPane, anotherPane]} />);
-
-        expect(getByText('an menu item')).toBeInTheDocument();
-        expect(getByText('another menu item')).toBeInTheDocument();
+        expect(getByText('About')).toBeInTheDocument();
     });
 });

--- a/src/App/appLayout.js
+++ b/src/App/appLayout.js
@@ -36,25 +36,26 @@
 
 const TOGGLE_LOG_VISIBLE = 'TOGGLE_LOG_VISIBLE';
 const TOGGLE_SIDE_PANEL_VISIBLE = 'TOGGLE_SIDE_PANEL_VISIBLE';
-const SET_MAIN_COMPONENT = 'SET_MAIN_COMPONENT';
+const SET_CURRENT_PANE = 'SET_CURRENT_PANE';
 
 export const toggleLogVisible = () => ({ type: TOGGLE_LOG_VISIBLE });
 export const toggleSidePanelVisible = () => ({ type: TOGGLE_SIDE_PANEL_VISIBLE });
-export const setMainComponent = mainComponent => ({ type: SET_MAIN_COMPONENT, mainComponent });
+export const setCurrentPane = currentPane => ({ type: SET_CURRENT_PANE, currentPane });
 
 const initialState = {
     isSidePanelVisible: true,
     isLogVisible: true,
+    currentPane: 0,
 };
 
-export const reducer = (state = initialState, action) => {
-    switch (action.type) {
+export const reducer = (state = initialState, { type, currentPane }) => {
+    switch (type) {
         case TOGGLE_SIDE_PANEL_VISIBLE:
             return { ...state, isSidePanelVisible: !state.isSidePanelVisible };
         case TOGGLE_LOG_VISIBLE:
             return { ...state, isLogVisible: !state.isLogVisible };
-        case SET_MAIN_COMPONENT:
-            return { ...state, mainComponent: action.mainComponent };
+        case SET_CURRENT_PANE:
+            return { ...state, currentPane };
         default:
             return state;
     }
@@ -62,8 +63,4 @@ export const reducer = (state = initialState, action) => {
 
 export const isSidePanelVisibleSelector = state => state.appLayout.isSidePanelVisible;
 export const isLogVisibleSelector = state => state.appLayout.isLogVisible;
-
-export const mainComponentSelector = panes => state => {
-    const defaultMainComponent = panes[0][1];
-    return state.appLayout.mainComponent || defaultMainComponent;
-};
+export const currentPaneSelector = state => state.appLayout.currentPane;

--- a/src/NavBar/NavMenu.jsx
+++ b/src/NavBar/NavMenu.jsx
@@ -38,20 +38,20 @@ import React from 'react';
 import { array, arrayOf } from 'prop-types';
 import { useSelector } from 'react-redux';
 
-import { mainComponentSelector } from '../App/appLayout';
+import { currentPaneSelector } from '../App/appLayout';
 import NavMenuItem from './NavMenuItem';
 
 const NavMenu = ({ panes }) => {
-    const currentMainComponent = useSelector(mainComponentSelector(panes));
+    const currentPane = useSelector(currentPaneSelector);
 
     return (
         <div data-testid="nav-menu">
-            {panes.map(([name, component], index) => (
+            {panes.map(([name], index) => (
                 <NavMenuItem
                     key={name}
-                    component={component}
+                    index={index}
                     isFirst={index === 0}
-                    isSelected={currentMainComponent === component}
+                    isSelected={currentPane === index}
                     label={name}
                 />
             ))}

--- a/src/NavBar/NavMenu.jsx
+++ b/src/NavBar/NavMenu.jsx
@@ -39,16 +39,14 @@ import { array, arrayOf } from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { mainComponentSelector } from '../App/appLayout';
-import About from '../About/About';
 import NavMenuItem from './NavMenuItem';
 
 const NavMenu = ({ panes }) => {
     const currentMainComponent = useSelector(mainComponentSelector(panes));
-    const allPanes = [...panes, ['About', About]];
 
     return (
         <div data-testid="nav-menu">
-            {allPanes.map(([name, component], index) => (
+            {panes.map(([name, component], index) => (
                 <NavMenuItem
                     key={name}
                     component={component}

--- a/src/NavBar/NavMenuItem.jsx
+++ b/src/NavBar/NavMenuItem.jsx
@@ -35,16 +35,16 @@
  */
 
 import React from 'react';
-import { bool, elementType, string } from 'prop-types';
+import { bool, number, string } from 'prop-types';
 import { useDispatch } from 'react-redux';
 import Button from 'react-bootstrap/Button';
 
-import { setMainComponent } from '../App/appLayout';
+import { setCurrentPane } from '../App/appLayout';
 
 import './nav-menu-item.scss';
 
 const NavMenuItem = ({
-    component, isFirst, isSelected, label,
+    index, isFirst, isSelected, label,
 }) => {
     const dispatch = useDispatch();
 
@@ -53,7 +53,7 @@ const NavMenuItem = ({
             variant="link"
             active={false}
             className={`core19-nav-menu-item ${isSelected ? 'selected' : ''} ${isFirst ? 'first' : ''}`}
-            onClick={() => dispatch(setMainComponent(component))}
+            onClick={() => dispatch(setCurrentPane(index))}
             type="button"
         >
             {label}
@@ -62,7 +62,7 @@ const NavMenuItem = ({
 };
 
 NavMenuItem.propTypes = {
-    component: elementType.isRequired,
+    index: number.isRequired,
     isFirst: bool.isRequired,
     isSelected: bool.isRequired,
     label: string.isRequired,


### PR DESCRIPTION
This PR is important for any app that maintains objects/state/logic which is created by the components when they get rendered in the main view. Since the About pane is automatically added, even single pane apps are effected by this flaw.

Potential improvement would be to animate the change between panes, maybe to use some-kind of a Carousel component.