### PR TITLE
Fix remote property on electron mock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
-## Unreleased
+## Version 4.8.5
+### Fixed
+- The remote property on the electron mock was noch mocked correctly
 ### Changed
 - Render all panes of the App, but only the current is visible
 

--- a/mocks/electronMock.js
+++ b/mocks/electronMock.js
@@ -4,8 +4,10 @@ module.exports = {
     require: jest.fn(),
     match: jest.fn(),
     app: jest.fn(),
-    remote: jest.fn(),
     dialog: jest.fn(),
+    remote: {
+        require: jest.fn(),
+    },
     ipcRenderer: {
         once: jest.fn(),
         send: jest.fn(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-shared",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The remote property is not a function but an object which has several other properties. The most relevant to mock is the require property since this may cause tests to fail if unexpected modules are required in other modules. https://www.electronjs.org/docs/api/remote

The necessity for this fix is currently demonstrated by [a manual override in `AppManagementFilter.test.jsx`](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/bc2c62be0133bb4e97ab510067c2ed960ef7e3b1/src/launcher/components/AppManagementFilter.test.jsx#L39-L42) without which the test fails.