### PR TITLE
Make device selector, sidepanel, and log optional

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -36,9 +36,9 @@
 
 import React, { useEffect } from 'react';
 import {
-    array, arrayOf, func, node,
+    array, arrayOf, func, node, bool,
 } from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import Mousetrap from 'mousetrap';
 import { ipcRenderer } from 'electron';
@@ -50,7 +50,12 @@ import AppReloadDialog from '../AppReload/AppReloadDialog';
 import NavBar from '../NavBar/NavBar';
 import VisibilityBar from './VisibilityBar';
 import ConnectedToStore from './ConnectedToStore';
-import { isSidePanelVisibleSelector, isLogVisibleSelector, currentPaneSelector } from './appLayout';
+import {
+    isSidePanelVisibleSelector,
+    isLogVisibleSelector,
+    currentPaneSelector,
+    toggleLogVisible,
+} from './appLayout';
 
 import './shared.scss';
 import './app.scss';
@@ -58,16 +63,21 @@ import './app.scss';
 const hiddenUnless = isVisible => (isVisible ? '' : 'd-none');
 
 const ConnectedApp = ({
-    deviceSelect, panes, sidePanel,
+    deviceSelect, panes, sidePanel, showLogByDefault = true,
 }) => {
     const allPanes = [...panes, ['About', About]];
     const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
     const isLogVisible = useSelector(isLogVisibleSelector);
     const currentPane = useSelector(currentPaneSelector);
+    const dispatch = useDispatch();
 
     useEffect(() => {
         Mousetrap.bind('alt+l', () => ipcRenderer.send('open-app-launcher'));
-    }, []);
+
+        if (!showLogByDefault) {
+            dispatch(toggleLogVisible());
+        }
+    }, [dispatch, showLogByDefault]);
 
     return (
         <div className="core19-app">
@@ -76,7 +86,7 @@ const ConnectedApp = ({
                 panes={allPanes}
             />
             <div className="core19-app-content">
-                <div className={`core19-side-panel ${hiddenUnless(isSidePanelVisible)}`}>
+                <div className={`core19-side-panel ${hiddenUnless(sidePanel && isSidePanelVisible)}`}>
                     {sidePanel}
                 </div>
                 <div className="core19-main-and-log">
@@ -90,7 +100,7 @@ const ConnectedApp = ({
                     </div>
                 </div>
             </div>
-            <VisibilityBar />
+            <VisibilityBar isSidePanelEnabled={sidePanel !== null} />
 
             <AppReloadDialog />
             <ErrorDialog />
@@ -99,9 +109,10 @@ const ConnectedApp = ({
 };
 
 ConnectedApp.propTypes = {
-    deviceSelect: node.isRequired,
+    deviceSelect: node,
     panes: arrayOf(array.isRequired).isRequired,
-    sidePanel: node.isRequired,
+    sidePanel: node,
+    showLogByDefault: bool,
 };
 
 const noopReducer = state => state;

--- a/src/App/VisibilityBar.jsx
+++ b/src/App/VisibilityBar.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+import { bool } from 'prop-types';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
 import { autoScroll as autoScrollSelector } from '../Log/logReducer';
@@ -49,7 +50,7 @@ import {
 
 import './visibility-bar.scss';
 
-export default () => {
+const VisibilityBar = ({ isSidePanelEnabled }) => {
     const dispatch = useDispatch();
     const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
     const isLogVisible = useSelector(isLogVisibleSelector);
@@ -57,14 +58,16 @@ export default () => {
 
     return (
         <div className="core19-visibility-bar">
-            <div className={`core19-visibility-bar-show-side-panel ${isSidePanelVisible ? '' : 'panel-hidden'}`}>
-                <Form.Switch
-                    id="visibility-bar-show-side-panel"
-                    label="Show side panel"
-                    checked={isSidePanelVisible}
-                    onChange={() => dispatch(toggleSidePanelVisible())}
-                />
-            </div>
+            {isSidePanelEnabled && (
+                <div className={`core19-visibility-bar-show-side-panel ${isSidePanelVisible ? '' : 'panel-hidden'}`}>
+                    <Form.Switch
+                        id="visibility-bar-show-side-panel"
+                        label="Show side panel"
+                        checked={isSidePanelVisible}
+                        onChange={() => dispatch(toggleSidePanelVisible())}
+                    />
+                </div>
+            )}
             <div className="core19-visibility-bar-show-log">
                 <button
                     type="button"
@@ -99,3 +102,9 @@ export default () => {
         </div>
     );
 };
+
+VisibilityBar.propTypes = {
+    isSidePanelEnabled: bool.isRequired,
+};
+
+export default VisibilityBar;

--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -44,9 +44,11 @@ import './nav-bar.scss';
 
 const NavBar = ({ deviceSelect, panes }) => (
     <div className="core19-nav-bar">
-        <div className="core19-nav-bar-device-selector">
-            {deviceSelect != null && deviceSelect}
-        </div>
+        {deviceSelect && (
+            <div className="core19-nav-bar-device-selector">
+                {deviceSelect}
+            </div>
+        )}
         <NavMenu panes={panes} />
         <Logo changeWithDeviceState />
     </div>


### PR DESCRIPTION
Currently, the device selector, sidepanel, and log UI elements are mandatory in the new API, even if they aren't needed. This is the case in the Toolchain Manager, which doesn't use any of them.

This PR:

* Makes the `deviceSelect` and `sidePanel` props optional, only rendering them if they're not `null`
* Introduces a new `showLogByDefault` prop, which determines whether the log will open on application startup or otherwise. It defaults to `true`.

An app with everything turned off will thus look like this:

![Merknad 2020-08-14 084554](https://user-images.githubusercontent.com/4018892/90221558-afe0b580-de0a-11ea-9771-67e67c1d302d.png)
