### PR TITLE
Fix the Toggle components state in case it's controlled from outside

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 4.8.12
+### Fixed
+- Fixed the Toggle components state in case it's controlled from outside
+
 ## Version 4.8.11
 ### Fixed
 - Fixed the fix of installation failure in local apps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-shared",
-  "version": "4.8.11",
+  "version": "4.8.12",
   "description": "Shared commodities for developing pc-nrfconnect-* packages",
   "repository": {
     "type": "git",

--- a/src/Toggle/Toggle.jsx
+++ b/src/Toggle/Toggle.jsx
@@ -56,15 +56,19 @@ const Toggle = ({
     disabled = false,
     children,
 }) => {
-    const [toggled, setToggled] = useState(isToggled || false);
+    const isControlled = isToggled !== undefined;
+    const [internalToggled, setInternalToggled] = useState(!!isToggled);
+    const toggled = isControlled ? isToggled : internalToggled;
     const isPrimary = variant === 'primary';
     const isSecondary = variant === 'secondary';
 
     const handleToggle = () => {
         if (onToggle) {
-            onToggle();
+            onToggle(!toggled);
         }
-        setToggled(!toggled);
+        if (!isControlled) {
+            setInternalToggled(!internalToggled);
+        }
     };
 
     const toggleClassName = [


### PR DESCRIPTION
Should the state of the Toggle component depend on a value that has changed outside of the Toggle itself would end up in a mismatch between the internal state and the external value.
This PR is meant to fix this case.
Additionally the onToggle callback now provides the newly set value.