### PR TITLE
Enhance device selector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Version 4.8.17
+### Updated
+- New design, device selector: Add PCA number, better alignment for port names,
+  removed wrong line below port names
+
 ## Version 4.8.16
 ## Added
 - Added support for files written in TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.8.16",
+    "version": "4.8.17",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.jsx
+++ b/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.jsx
@@ -42,6 +42,17 @@ import deviceShape from '../deviceShape';
 
 import './more-device-info.scss';
 
+const PcaNumber = ({ device }) => {
+    if (device.boardVersion == null) {
+        return null;
+    }
+
+    return <div>{device.boardVersion}</div>;
+};
+PcaNumber.propTypes = {
+    device: deviceShape.isRequired,
+};
+
 const MaybeDeviceName = ({ device }) => {
     const hasNickname = device.nickname !== '';
     if (!hasNickname) {
@@ -75,6 +86,7 @@ Serialports.propTypes = {
 
 const MoreDeviceInfo = ({ device }) => (
     <div className="more-infos">
+        <PcaNumber device={device} />
         <MaybeDeviceName device={device} />
         <Serialports ports={serialports(device)} />
     </div>

--- a/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.jsx
+++ b/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.jsx
@@ -35,12 +35,22 @@
  */
 
 import React from 'react';
-import { arrayOf, shape, string } from 'prop-types';
+import { arrayOf, node, shape, string } from 'prop-types';
 
 import { serialports, displayedDeviceName } from '../../deviceInfo/deviceInfo';
 import deviceShape from '../deviceShape';
 
 import './more-device-info.scss';
+
+const Row = ({ children }) => (
+    <div className="info-row">
+        <div className="flex-space" />
+        {children}
+    </div>
+);
+Row.propTypes = {
+    children: node.isRequired,
+};
 
 const PcaNumber = ({ device }) => {
     if (device.boardVersion == null) {
@@ -86,9 +96,15 @@ Serialports.propTypes = {
 
 const MoreDeviceInfo = ({ device }) => (
     <div className="more-infos">
-        <PcaNumber device={device} />
-        <MaybeDeviceName device={device} />
-        <Serialports ports={serialports(device)} />
+        <Row>
+            <PcaNumber device={device} />
+        </Row>
+        <Row>
+            <MaybeDeviceName device={device} />
+        </Row>
+        <Row>
+            <Serialports ports={serialports(device)} />
+        </Row>
     </div>
 );
 

--- a/src/Device/DeviceSelector/DeviceList/device-list.scss
+++ b/src/Device/DeviceSelector/DeviceList/device-list.scss
@@ -25,7 +25,7 @@
             padding: 20px;
         }
 
-        ul {
+        > ul {
             padding: 0;
             margin-bottom: 0;
 

--- a/src/Device/DeviceSelector/DeviceList/more-device-info.scss
+++ b/src/Device/DeviceSelector/DeviceList/more-device-info.scss
@@ -2,7 +2,15 @@
 
 .core19-device-selector {
     .more-infos {
-        padding-left: 68px;
+        .info-row {
+            display: flex;
+            flex-direction: row;
+            padding-right: 20px;
+        }
+
+        .flex-space {
+            width: 68px;
+        }
 
         .name {
             margin-top: 1em;
@@ -13,7 +21,6 @@
             padding: 0;
             text-decoration: underline;
             margin-top: 1em;
-            margin-left: -68px;
             text-align: center;
         }
     }


### PR DESCRIPTION
Three small changes to the device selector, more specifically to the device details:
- Add PCA number
- Remove the wrong line below the port names
- Better alignment for the port names: Port names were centered, which looked okay for long names but out of place for shorter names. If they are short enough, they are now left aligned with the other text
above (device name, serial number, PCA number). If the port names are so
long that they would run to the right out of the device area, then they
port names are moved to the left just enough to fit.

How a device looked before:
![Before](https://user-images.githubusercontent.com/260705/92468707-de686b00-f1d3-11ea-8d68-a9587dc37edc.png)

How it looks now:
![After](https://user-images.githubusercontent.com/260705/92468813-0d7edc80-f1d4-11ea-9f21-1c455951a1df.png)

How it looks now with short port names (before they were centred):
![After with short port names](https://user-images.githubusercontent.com/260705/92468856-1d96bc00-f1d4-11ea-80c2-dffd9474486d.png)

