### PR TITLE
Bump version number

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 4.8.19
+### Fixed
+- Version number for 4.8.18 release was wrong in `package.json`.
+
 ## Version 4.8.18
 ### Updated
 - Added `prettier.config.js` to existing script `npm run lint-init`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.8.17",
+    "version": "4.8.19",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Version 4.8.18 was tagged on GitHub but the version number in `package.json` was not increased. So we need to jump to the next number and release that as 4.8.19.