### PR TITLE
Fix line ending issue with Prettier on Windows

### DIFF
--- a/config/prettier.config.js
+++ b/config/prettier.config.js
@@ -2,4 +2,5 @@ module.exports = {
     singleQuote: true,
     tabWidth: 4,
     arrowParens: 'avoid',
+    endOfLine: 'auto'
 };


### PR DESCRIPTION
There was a problem regarding line endings when running Prettier on Windows (LF vs CRLF).

Adding `endOfLine: auto` to the config file fixes this, in line with https://stackoverflow.com/a/53769213/2480017.