### PR TITLE
Allow @ts-ignore comments when a description is provided

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -21,6 +21,9 @@
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/ban-ts-comment": ["error", {
+            "ts-ignore": "allow-with-description"
+        }],
         "camelcase": "off",
         "quotes": ["error", "single"],
         "linebreak-style": "off",


### PR DESCRIPTION
Sometimes we need to ignore a typing error; this way we at least have to provide an explanation of why.