### PR TITLE
Use focus-visible polyfill to separate keyboard focus from pointer focus

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Added focus-visible dependency and disabled focus styles when clicked
+
 ## Version 4.9.1
 ### Fixed
 - Relax ESLint rule regardint @ts-ignore comments

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "eslint-plugin-react-hooks": "4.0.4",
         "eslint-webpack-plugin": "^2.1.0",
         "file-loader": "6.0.0",
+        "focus-visible": "5.1.0",
         "ftp": "0.3.10",
         "husky": "4.2.5",
         "immutable": "4.0.0-rc.12",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -42,6 +42,8 @@ import Mousetrap from 'mousetrap';
 import { ipcRenderer } from 'electron';
 import Carousel from 'react-bootstrap/Carousel';
 
+import 'focus-visible';
+
 import LogViewer from '../Log/LogViewer';
 import About from '../About/About';
 import ErrorDialog from '../ErrorDialog/ErrorDialog';

--- a/src/App/shared.scss
+++ b/src/App/shared.scss
@@ -39,6 +39,8 @@ body {
     outline-color: $accent !important;
     outline-width: 3px;
 }
-:focus:active {
-    outline-style: none;
+// focus-visible js polyfill, see: https://github.com/WICG/focus-visible
+.js-focus-visible :focus:not(.focus-visible) {
+    outline: none !important;
+    box-shadow: none !important;
 }


### PR DESCRIPTION
This PR removes outline and box-shadow of focused elements if it was focused by pointer, but not when focus was received by keyboard.