### PR TITLE
Enable showing info for USB connected devices

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,19 @@
+## 4.10.0
+### Added
+- Enable showing an own icon and links on the About pane for USB connected
+  devices.
+### Steps to upgrade when using this package
+- This version does introduce a first file in `shared` that is converted from
+  JavaScript to TypeScript: `deviceInfo`. While most is already prepared for
+  that, the `webpack.config.js` in the launcher still needs two adjustments to
+  work with this: The lines
+  [39](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/497c1fde51246e1a4fcbc9efbb595d6764a7e056/webpack.config.js#L39)
+  and
+  [69](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/497c1fde51246e1a4fcbc9efbb595d6764a7e056/webpack.config.js#L69)
+  needs to be changed, so that webpack does not only pick up files with the
+  ending `.jsx?` but also `.tsx?`. Apps, on the other hand, do not need to be
+  changed for this.
+
 ## 4.9.7
 ### Updated
 - Updated how client is generated for usage statistics

--- a/config/jest.config.json
+++ b/config/jest.config.json
@@ -10,7 +10,7 @@
     "^electron-store$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/electronStoreMock.js"
   },
   "transform": {
-    "^.+\\.jsx?$": [
+    "^.+\\.[jt]sx?$": [
       "babel-jest",
       { "configFile": "./node_modules/pc-nrfconnect-shared/config/babel.config.js" }
     ]

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -70,7 +70,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.(js|jsx|tsx?)$/,
+                test: /\.(jsx?|tsx?)$/,
                 use: [
                     {
                         loader: require.resolve('babel-loader'),

--- a/index.d.ts
+++ b/index.d.ts
@@ -159,23 +159,29 @@ declare module 'pc-nrfconnect-shared' {
         needSerialPort?: boolean;
     }
 
+    interface Serialport {
+        path: string;
+        manufacturer: string;
+        productId: string;
+        serialNumber: string;
+        vendorId: string;
+        pnpId?: string;
+        /**
+         * @deprecated Using the property `comName` has been
+         * deprecated. You should now use `path`. The property
+         * will be removed in the next major release.
+         */
+        comName: string;
+    }
+
     interface Device {
         boardVersion: string;
         serialNumber: string;
         traits: readonly string[];
-        serialport: {
-            path: string;
-            manufacturer: string;
-            productId: string;
-            serialNumber: string;
-            vendorId: string;
-            pnpId?: string;
-            /**
-             * @deprecated Using the property `comName` has been
-             * deprecated. You should now use `path`. The property
-             * will be removed in the next major release.
-             */
-            comName: string;
+        nickname?: string;
+        serialport?: Serialport;
+        usb?: {
+            product?: string;
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
             "pc-nrfjprog-js|nrf-device-lister|nrf-device-setup": "<rootDir>/mocks/emptyMock.js"
         },
         "transform": {
-            "^.+\\.jsx?$": [
+            "^.+\\.[jt]sx?$": [
                 "babel-jest",
                 {
                     "configFile": "./config/babel.config.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.9.7",
+    "version": "4.10.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/About/DeviceCard.jsx
+++ b/src/About/DeviceCard.jsx
@@ -45,8 +45,7 @@ import {
     deviceInfo as deviceInfoSelector,
 } from '../Device/deviceReducer';
 import {
-    cores,
-    deviceName,
+    deviceInfo,
     productPageUrl,
     buyOnlineUrl,
 } from '../Device/deviceInfo/deviceInfo';
@@ -61,7 +60,7 @@ const memorySize = memoryInBytes => {
 
 export default () => {
     const device = useSelector(selectedDevice);
-    const deviceInfo = useSelector(deviceInfoSelector) || {};
+    const extendedDeviceInfo = useSelector(deviceInfoSelector) || {};
 
     if (device == null) {
         return (
@@ -72,21 +71,29 @@ export default () => {
     }
 
     const pca = device.boardVersion;
+    const { name, cores } = deviceInfo(device);
 
     return (
         <Card title="Device">
-            <Section title="Name">{deviceName(device) || 'Unknown'}</Section>
+            <Section title="Name">{name || 'Unknown'}</Section>
             <Section title="ID">{device.serialNumber}</Section>
             <Section title="PCA">{pca || 'Unknown'}</Section>
-            <Section title="Cores">{cores(pca) || 'Unknown'}</Section>
-            <Section title="RAM">{memorySize(deviceInfo.ramSize)}</Section>
-            <Section title="Flash">{memorySize(deviceInfo.codeSize)}</Section>
-            <Section>
-                <AboutButton url={buyOnlineUrl(pca)} label="Find distributor" />
+            <Section title="Cores">{cores || 'Unknown'}</Section>
+            <Section title="RAM">
+                {memorySize(extendedDeviceInfo.ramSize)}
+            </Section>
+            <Section title="Flash">
+                {memorySize(extendedDeviceInfo.codeSize)}
             </Section>
             <Section>
                 <AboutButton
-                    url={productPageUrl(pca)}
+                    url={buyOnlineUrl(device)}
+                    label="Find distributor"
+                />
+            </Section>
+            <Section>
+                <AboutButton
+                    url={productPageUrl(device)}
                     label="Go to product page"
                 />
             </Section>

--- a/src/Device/DeviceSelector/DeviceIcon.jsx
+++ b/src/Device/DeviceSelector/DeviceIcon.jsx
@@ -35,13 +35,13 @@
  */
 
 import React from 'react';
-import { deviceIcon } from '../deviceInfo/deviceInfo';
+import { deviceInfo } from '../deviceInfo/deviceInfo';
 import deviceShape from './deviceShape';
 
 import './device-icon.scss';
 
 const DeviceIcon = ({ device }) => {
-    const Icon = deviceIcon(device);
+    const Icon = deviceInfo(device).icon;
     return (
         <div className="icon">
             <Icon />

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -169,31 +169,22 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         },
     },
 };
-const deviceInfo = (pcaNumber: string): DeviceInfo =>
-    devicesByPca[String(pcaNumber).toUpperCase()] || { website: {} };
+
+const deviceByPca = (device: Device) =>
+    devicesByPca[String(device.boardVersion).toUpperCase()];
 
 const NORDIC_VENDOR_ID = '1915';
 const isNordicDevice = (device: Device) =>
-    device.serialport && device.serialport.vendorId === NORDIC_VENDOR_ID;
+    device.serialport?.vendorId === NORDIC_VENDOR_ID;
 
-const iconForUnknown = (device: Device) =>
-    isNordicDevice(device) ? unknownNordicLogo : unknownLogo;
+const unknownDevice = (device: Device): DeviceInfo => ({
+    name: device.usb?.product,
+    icon: isNordicDevice(device) ? unknownNordicLogo : unknownLogo,
+    website: {},
+});
 
-export const deviceIcon = (device: Device) =>
-    deviceInfo(device.boardVersion).icon || iconForUnknown(device);
-
-export const deviceName = (device: Device) => {
-    const pca = device.boardVersion;
-    if (deviceInfo(pca).name) {
-        return deviceInfo(pca).name;
-    }
-
-    if (device.usb && device.usb.product) {
-        return device.usb.product;
-    }
-
-    return null;
-};
+export const deviceInfo = (device: Device): DeviceInfo =>
+    deviceByPca(device) || unknownDevice(device);
 
 export const displayedDeviceName = (
     device: Device,
@@ -203,7 +194,7 @@ export const displayedDeviceName = (
         return device.nickname;
     }
 
-    return deviceName(device) || device.boardVersion || 'Unknown';
+    return deviceInfo(device).name || device.boardVersion || 'Unknown';
 };
 
 export const serialports = (device: Device) =>
@@ -211,16 +202,14 @@ export const serialports = (device: Device) =>
         .filter(([key]) => key.startsWith('serialport'))
         .map(([, value]: [string, Serialport]) => value);
 
-export const cores = (pca: string) => deviceInfo(pca).cores;
-
-export const productPageUrl = (pca: string) =>
-    deviceInfo(pca).website.productPagePath &&
+export const productPageUrl = (device: Device) =>
+    deviceInfo(device).website.productPagePath &&
     `https://www.nordicsemi.com/Software-and-tools/${
-        deviceInfo(pca).website.productPagePath
+        deviceInfo(device).website.productPagePath
     }`;
 
-export const buyOnlineUrl = (pca: string) =>
-    deviceInfo(pca).website.buyOnlineParams &&
+export const buyOnlineUrl = (device: Device) =>
+    deviceInfo(device).website.buyOnlineParams &&
     `https://www.nordicsemi.com/About-us/BuyOnline?${
-        deviceInfo(pca).website.buyOnlineParams
+        deviceInfo(device).website.buyOnlineParams
     }`;

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -76,7 +76,19 @@ interface DeviceInfo {
     };
 }
 
-const devicesByPca: { [index: string]: DeviceInfo } = {
+type DevicePCA =
+    | 'PCA10028'
+    | 'PCA10031'
+    | 'PCA10040'
+    | 'PCA10056'
+    | 'PCA10059'
+    | 'PCA10090'
+    | 'PCA10100'
+    | 'PCA10095'
+    | 'PCA20020'
+    | 'PCA20035';
+
+const devicesByPca: { [P in DevicePCA]: DeviceInfo } = {
     PCA10028: {
         name: 'nRF51 DK',
         cores: 1,
@@ -174,7 +186,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
 };
 
 const deviceByPca = (device: Device) =>
-    devicesByPca[String(device.boardVersion).toUpperCase()];
+    devicesByPca[String(device.boardVersion).toUpperCase() as DevicePCA];
 
 const NORDIC_VENDOR_ID = '1915';
 const isNordicDevice = (device: Device) =>

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -57,6 +57,8 @@
    through CSS, e.g. to change the colours.
 */
 
+import { Device, Serialport } from 'pc-nrfconnect-shared';
+
 import nrf51logo from '!!@svgr/webpack!./nRF51-Series-logo.svg';
 import nrf52logo from '!!@svgr/webpack!./nRF52-Series-logo.svg';
 import nrf53logo from '!!@svgr/webpack!./nRF53-Series-logo.svg';
@@ -64,116 +66,123 @@ import nrf91logo from '!!@svgr/webpack!./nRF91-Series-logo.svg';
 import unknownLogo from '!!@svgr/webpack!./unknown-logo.svg';
 import unknownNordicLogo from '!!@svgr/webpack!./unknown-nordic-logo.svg';
 
-const deviceInfo = pcaNumber =>
-    ({
-        PCA10028: {
-            name: 'nRF51 DK',
-            cores: 1,
-            icon: nrf51logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF51-DK',
-                buyOnlineParams: 'search_token=nrf51-DK&series_token=nRF51822',
-            },
+interface DeviceInfo {
+    name?: string;
+    cores?: number;
+    icon: React.Component;
+    website: {
+        productPagePath?: string;
+        buyOnlineParams?: string;
+    };
+}
+
+const devicesByPca: { [index: string]: DeviceInfo } = {
+    PCA10028: {
+        name: 'nRF51 DK',
+        cores: 1,
+        icon: nrf51logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF51-DK',
+            buyOnlineParams: 'search_token=nrf51-DK&series_token=nRF51822',
         },
-        PCA10031: {
-            name: 'nRF51 Dongle',
-            cores: 1,
-            icon: nrf51logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF51-Dongle',
-                buyOnlineParams:
-                    'search_token=nRF51-Dongle&series_token=nRF51822',
-            },
+    },
+    PCA10031: {
+        name: 'nRF51 Dongle',
+        cores: 1,
+        icon: nrf51logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF51-Dongle',
+            buyOnlineParams: 'search_token=nRF51-Dongle&series_token=nRF51822',
         },
-        PCA10040: {
-            name: 'nRF52 DK',
-            cores: 1,
-            icon: nrf52logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF52-DK',
-                buyOnlineParams: 'search_token=nRF52-DK&series_token=nRF52832',
-            },
+    },
+    PCA10040: {
+        name: 'nRF52 DK',
+        cores: 1,
+        icon: nrf52logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF52-DK',
+            buyOnlineParams: 'search_token=nRF52-DK&series_token=nRF52832',
         },
-        PCA10056: {
-            name: 'nRF52840 DK',
-            cores: 1,
-            icon: nrf52logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF52840-DK',
-                buyOnlineParams:
-                    'search_token=nrf52840-DK&series_token=nRF52840',
-            },
+    },
+    PCA10056: {
+        name: 'nRF52840 DK',
+        cores: 1,
+        icon: nrf52logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF52840-DK',
+            buyOnlineParams: 'search_token=nrf52840-DK&series_token=nRF52840',
         },
-        PCA10059: {
-            name: 'nRF52840 Dongle',
-            cores: 1,
-            icon: nrf52logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF52840-Dongle',
-                buyOnlineParams:
-                    'search_token=nRF52840DONGLE&series_token=nRF52840',
-            },
+    },
+    PCA10059: {
+        name: 'nRF52840 Dongle',
+        cores: 1,
+        icon: nrf52logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF52840-Dongle',
+            buyOnlineParams:
+                'search_token=nRF52840DONGLE&series_token=nRF52840',
         },
-        PCA10090: {
-            name: 'nRF9160 DK',
-            cores: 1,
-            icon: nrf91logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF9160-DK',
-                buyOnlineParams: 'search_token=nrf9160-DK&series_token=nRF9160',
-            },
+    },
+    PCA10090: {
+        name: 'nRF9160 DK',
+        cores: 1,
+        icon: nrf91logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF9160-DK',
+            buyOnlineParams: 'search_token=nrf9160-DK&series_token=nRF9160',
         },
-        PCA10100: {
-            name: 'nRF52833 DK',
-            cores: 1,
-            icon: nrf52logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF52833-DK',
-                buyOnlineParams:
-                    'search_token=nRF52833-DK&series_token=nRF52833',
-            },
+    },
+    PCA10100: {
+        name: 'nRF52833 DK',
+        cores: 1,
+        icon: nrf52logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF52833-DK',
+            buyOnlineParams: 'search_token=nRF52833-DK&series_token=nRF52833',
         },
-        PCA10095: {
-            name: 'nRF5340 DK',
-            cores: 2,
-            icon: nrf53logo,
-            website: {
-                productPagePath: 'Development-Kits/nRF5340-PDK',
-                buyOnlineParams:
-                    'search_token=nRF5340-PDK&series_token=nRF5340',
-            },
+    },
+    PCA10095: {
+        name: 'nRF5340 DK',
+        cores: 2,
+        icon: nrf53logo,
+        website: {
+            productPagePath: 'Development-Kits/nRF5340-PDK',
+            buyOnlineParams: 'search_token=nRF5340-PDK&series_token=nRF5340',
         },
-        PCA20020: {
-            name: 'Nordic Thingy:52',
-            cores: 1,
-            icon: nrf52logo,
-            website: {
-                productPagePath: 'Prototyping-platforms/Nordic-Thingy-52',
-                buyOnlineParams: 'search_token=nRF6936&series_token=nRF52832',
-            },
+    },
+    PCA20020: {
+        name: 'Nordic Thingy:52',
+        cores: 1,
+        icon: nrf52logo,
+        website: {
+            productPagePath: 'Prototyping-platforms/Nordic-Thingy-52',
+            buyOnlineParams: 'search_token=nRF6936&series_token=nRF52832',
         },
-        PCA20035: {
-            name: 'Nordic Thingy:91',
-            cores: 1,
-            icon: nrf91logo,
-            website: {
-                productPagePath: 'Prototyping-platforms/Nordic-Thingy-91',
-                buyOnlineParams: 'search_token=nRF6943&series_token=nRF9160',
-            },
+    },
+    PCA20035: {
+        name: 'Nordic Thingy:91',
+        cores: 1,
+        icon: nrf91logo,
+        website: {
+            productPagePath: 'Prototyping-platforms/Nordic-Thingy-91',
+            buyOnlineParams: 'search_token=nRF6943&series_token=nRF9160',
         },
-    }[String(pcaNumber).toUpperCase()] || { website: {} });
+    },
+};
+const deviceInfo = (pcaNumber: string): DeviceInfo =>
+    devicesByPca[String(pcaNumber).toUpperCase()] || { website: {} };
 
 const NORDIC_VENDOR_ID = '1915';
-const isNordicDevice = device =>
+const isNordicDevice = (device: Device) =>
     device.serialport && device.serialport.vendorId === NORDIC_VENDOR_ID;
 
-const iconForUnknown = device =>
+const iconForUnknown = (device: Device) =>
     isNordicDevice(device) ? unknownNordicLogo : unknownLogo;
 
-export const deviceIcon = device =>
+export const deviceIcon = (device: Device) =>
     deviceInfo(device.boardVersion).icon || iconForUnknown(device);
 
-export const deviceName = device => {
+export const deviceName = (device: Device) => {
     const pca = device.boardVersion;
     if (deviceInfo(pca).name) {
         return deviceInfo(pca).name;
@@ -187,7 +196,7 @@ export const deviceName = device => {
 };
 
 export const displayedDeviceName = (
-    device,
+    device: Device,
     { respectNickname = true } = {}
 ) => {
     if (respectNickname && device.nickname) {
@@ -197,20 +206,20 @@ export const displayedDeviceName = (
     return deviceName(device) || device.boardVersion || 'Unknown';
 };
 
-export const serialports = device =>
+export const serialports = (device: Device) =>
     Object.entries(device)
         .filter(([key]) => key.startsWith('serialport'))
-        .map(([, value]) => value);
+        .map(([, value]: [string, Serialport]) => value);
 
-export const cores = pca => deviceInfo(pca).cores;
+export const cores = (pca: string) => deviceInfo(pca).cores;
 
-export const productPageUrl = pca =>
+export const productPageUrl = (pca: string) =>
     deviceInfo(pca).website.productPagePath &&
     `https://www.nordicsemi.com/Software-and-tools/${
         deviceInfo(pca).website.productPagePath
     }`;
 
-export const buyOnlineUrl = pca =>
+export const buyOnlineUrl = (pca: string) =>
     deviceInfo(pca).website.buyOnlineParams &&
     `https://www.nordicsemi.com/About-us/BuyOnline?${
         deviceInfo(pca).website.buyOnlineParams

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -82,7 +82,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf51logo,
         website: {
-            productPagePath: 'Development-Kits/nRF51-DK',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF51-DK',
             buyOnlineParams: 'search_token=nrf51-DK&series_token=nRF51822',
         },
     },
@@ -91,7 +91,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf51logo,
         website: {
-            productPagePath: 'Development-Kits/nRF51-Dongle',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF51-Dongle',
             buyOnlineParams: 'search_token=nRF51-Dongle&series_token=nRF51822',
         },
     },
@@ -100,7 +100,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf52logo,
         website: {
-            productPagePath: 'Development-Kits/nRF52-DK',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF52-DK',
             buyOnlineParams: 'search_token=nRF52-DK&series_token=nRF52832',
         },
     },
@@ -109,7 +109,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf52logo,
         website: {
-            productPagePath: 'Development-Kits/nRF52840-DK',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF52840-DK',
             buyOnlineParams: 'search_token=nrf52840-DK&series_token=nRF52840',
         },
     },
@@ -118,7 +118,8 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf52logo,
         website: {
-            productPagePath: 'Development-Kits/nRF52840-Dongle',
+            productPagePath:
+                'Software-and-tools/Development-Kits/nRF52840-Dongle',
             buyOnlineParams:
                 'search_token=nRF52840DONGLE&series_token=nRF52840',
         },
@@ -128,7 +129,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf91logo,
         website: {
-            productPagePath: 'Development-Kits/nRF9160-DK',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF9160-DK',
             buyOnlineParams: 'search_token=nrf9160-DK&series_token=nRF9160',
         },
     },
@@ -137,7 +138,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf52logo,
         website: {
-            productPagePath: 'Development-Kits/nRF52833-DK',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF52833-DK',
             buyOnlineParams: 'search_token=nRF52833-DK&series_token=nRF52833',
         },
     },
@@ -146,7 +147,7 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 2,
         icon: nrf53logo,
         website: {
-            productPagePath: 'Development-Kits/nRF5340-PDK',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF5340-PDK',
             buyOnlineParams: 'search_token=nRF5340-PDK&series_token=nRF5340',
         },
     },
@@ -155,7 +156,8 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf52logo,
         website: {
-            productPagePath: 'Prototyping-platforms/Nordic-Thingy-52',
+            productPagePath:
+                'Software-and-tools/Prototyping-platforms/Nordic-Thingy-52',
             buyOnlineParams: 'search_token=nRF6936&series_token=nRF52832',
         },
     },
@@ -164,7 +166,8 @@ const devicesByPca: { [index: string]: DeviceInfo } = {
         cores: 1,
         icon: nrf91logo,
         website: {
-            productPagePath: 'Prototyping-platforms/Nordic-Thingy-91',
+            productPagePath:
+                'Software-and-tools/Prototyping-platforms/Nordic-Thingy-91',
             buyOnlineParams: 'search_token=nRF6943&series_token=nRF9160',
         },
     },
@@ -177,6 +180,20 @@ const NORDIC_VENDOR_ID = '1915';
 const isNordicDevice = (device: Device) =>
     device.serialport?.vendorId === NORDIC_VENDOR_ID;
 
+const usbDeviceInfo = (device: Device): DeviceInfo => ({
+    name: device.usb?.product,
+    icon: unknownNordicLogo, // FIXME Replace this with a correct icon when we have one
+    website: {
+        productPagePath: undefined, // FIXME Replace this when we have corrent link
+        buyOnlineParams: undefined, // FIXME Replace this when we have corrent link
+    },
+});
+
+const deviceByUsb = (device: Device) =>
+    isNordicDevice(device) && device.usb?.product?.startsWith('KNOWN_USB_NAME')
+        ? usbDeviceInfo(device)
+        : null;
+
 const unknownDevice = (device: Device): DeviceInfo => ({
     name: device.usb?.product,
     icon: isNordicDevice(device) ? unknownNordicLogo : unknownLogo,
@@ -184,7 +201,7 @@ const unknownDevice = (device: Device): DeviceInfo => ({
 });
 
 export const deviceInfo = (device: Device): DeviceInfo =>
-    deviceByPca(device) || unknownDevice(device);
+    deviceByPca(device) || deviceByUsb(device) || unknownDevice(device);
 
 export const displayedDeviceName = (
     device: Device,
@@ -204,9 +221,7 @@ export const serialports = (device: Device) =>
 
 export const productPageUrl = (device: Device) =>
     deviceInfo(device).website.productPagePath &&
-    `https://www.nordicsemi.com/Software-and-tools/${
-        deviceInfo(device).website.productPagePath
-    }`;
+    `https://www.nordicsemi.com/${deviceInfo(device).website.productPagePath}`;
 
 export const buyOnlineUrl = (device: Device) =>
     deviceInfo(device).website.buyOnlineParams &&

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,0 +1,9 @@
+declare module '!!@svgr/webpack!*.svg' {
+    const svg: React.Component;
+    export default svg;
+}
+
+declare module '*.svg' {
+    const url: string;
+    export default url;
+}


### PR DESCRIPTION
Enable showing an own icon and links on the About pane for USB connected devices.

This PR does convert a first file from JavaScript to TypeScript: `deviceInfo`. While most is already prepared for that, the `webpack.config.js` in the launcher still needs two adjustments as described in the `Changelog.md`.