### PR TITLE
Enhance lint configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 package-lock.json
 jest.json
 pc-nrfconnect-shared-*.tgz
-.eslintrc

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Updated
+- Enhance lint configuration by specifying it in `package.json`.
+
 ## 4.11.0
 ### Added
 - Added icon for a PPK

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "main": "src",
     "scripts": {
         "lint": "node ./bin/nrfconnect-scripts.js lint .",
-        "lint-init": "cp ./config/eslintrc.json .eslintrc",
         "test": "jest --testResultsProcessor jest-bamboo-formatter src",
         "test-watch": "jest --watch src"
     },
@@ -116,5 +115,6 @@
         ]
     },
     "typings": "./index.d.ts",
+    "eslintConfig": { "extends" : "./config/eslintrc.json" },
     "prettier": "./config/prettier.config.js"
 }


### PR DESCRIPTION
Specify the ESLint configuration in `package.json`, making it unnecessary to either copy it to the main package folder or configure other tools to pick it up at `config/eslintrc.json`.

This also makes it unnecessary to run `lint-init`, so that script is also removed from `package.json`.

I do not think there is value in releasing this as a version on its own, so I just added an entry to `Changelog.md` but not increased the version. 