### PR TITLE
Add hot reloading

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -11,7 +11,6 @@ module.exports = api => {
             '@babel/plugin-transform-spread',
             '@babel/plugin-proposal-object-rest-spread',
             '@babel/plugin-proposal-optional-chaining',
-            'react-refresh/babel'
         ],
     };
 };

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -11,6 +11,7 @@ module.exports = api => {
             '@babel/plugin-transform-spread',
             '@babel/plugin-proposal-object-rest-spread',
             '@babel/plugin-proposal-optional-chaining',
+            'react-refresh/babel'
         ],
     };
 };

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const fs = require('fs');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
 const { dependencies } = require(path.join(process.cwd(), 'package.json'));
 
@@ -113,6 +114,7 @@ module.exports = {
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
     },
     plugins: [
+        new ReactRefreshWebpackPlugin(),
         new webpack.DefinePlugin({
             'process.env': {
                 NODE_ENV: JSON.stringify(nodeEnv),

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@babel/plugin-transform-spread": "7.10.0",
         "@babel/preset-react": "7.10.0",
         "@babel/preset-typescript": "^7.10.4",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.2",
         "@svgr/webpack": "5.4.0",
         "@testing-library/jest-dom": "5.8.0",
         "@testing-library/react": "10.0.4",
@@ -70,6 +71,7 @@
         "react-flip-toolkit": "7.0.12",
         "react-ga": "2.7.0",
         "react-markdown": "4.3.1",
+        "react-refresh": "^0.8.3",
         "react-test-renderer": "16.13.1",
         "redux": "4.0.5",
         "redux-devtools-extension": "2.13.8",
@@ -81,9 +83,12 @@
         "shasum": "1.0.2",
         "style-loader": "1.2.1",
         "systeminformation": "4.26.4",
+        "type-fest": "^0.18.0",
         "typescript": "^3.9.7",
         "url-loader": "4.1.0",
         "webpack": "4.43.0",
+        "webpack-cli": "^4.0.0",
+        "webpack-dev-server": "^3.11.0",
         "winston": "3.2.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "react-flip-toolkit": "7.0.12",
         "react-ga": "2.7.0",
         "react-markdown": "4.3.1",
-        "react-refresh": "^0.8.3",
+        "react-refresh": "^0.9.0",
         "react-test-renderer": "16.13.1",
         "redux": "4.0.5",
         "redux-devtools-extension": "2.13.8",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -82,7 +82,7 @@ function handleOutput(err, stats) {
 
 async function launchDevServer() {
     try {
-        const port = 8080;
+        const port = 5004;
         const config = getConfig();
         const compiler = webpack(config);
         const server = new WebpackDevServer(compiler, config.devServer);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -80,23 +80,27 @@ function handleOutput(err, stats) {
     );
 }
 
-function launchDevServer() {
-    const config = getConfig();
-    const compiler = webpack(config);
-    const server = new WebpackDevServer(compiler, config.devServer);
+async function launchDevServer() {
+    try {
+        const port = 8080;
+        const config = getConfig();
+        const compiler = webpack(config);
+        const server = new WebpackDevServer(compiler, config.devServer);
 
-    server.listen('8080', 'localhost', e => {
-        console.info('Starting local hot-reloading server');
-        if (e) {
-            console.error(e);
-        }
-    });
+        server.listen(port, 'localhost', e => {
+            console.info(`Starting local hot-reloading server on port ${port}`);
+            if (e) {
+                console.error(e);
+            }
+        });
+    } catch (e) {
+        console.error(e);
+    }
 }
 
 const args = process.argv.slice(2);
 if (args[0] === '--watch') {
     launchDevServer();
-    // webpack(getConfig()).watch({}, handleOutput);
 } else if (args[0] === '--dev') {
     process.env.NODE_ENV = 'development';
     webpack(getConfig()).run(handleOutput);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -40,6 +40,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const WebpackDevServer = require('webpack-dev-server');
 
 function getConfig() {
     let config;
@@ -79,9 +80,23 @@ function handleOutput(err, stats) {
     );
 }
 
+function launchDevServer() {
+    const config = getConfig();
+    const compiler = webpack(config);
+    const server = new WebpackDevServer(compiler, config.devServer);
+
+    server.listen('8080', 'localhost', e => {
+        console.info('Starting local hot-reloading server');
+        if (e) {
+            console.error(e);
+        }
+    });
+}
+
 const args = process.argv.slice(2);
 if (args[0] === '--watch') {
-    webpack(getConfig()).watch({}, handleOutput);
+    launchDevServer();
+    // webpack(getConfig()).watch({}, handleOutput);
 } else if (args[0] === '--dev') {
     process.env.NODE_ENV = 'development';
     webpack(getConfig()).run(handleOutput);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -82,7 +82,7 @@ function handleOutput(err, stats) {
 
 async function launchDevServer() {
     try {
-        const port = 5004;
+        const port = process.env.PORT || 5004;
         const config = getConfig();
         const compiler = webpack(config);
         const server = new WebpackDevServer(compiler, config.devServer);


### PR DESCRIPTION
In tandem with the PR for launcher, this PR adds support for hot-loading when developing the launcher.

Here we replace the normal call to `webpack` with one to `webpack-dev-server`.

The port is fixed to 8080. It would be nice to be able to pass this in as an environment variable, but the issue then is that there is no way for the `launcher.html` to know about this (since it is just a static file, not a template). We thus can't link to the correct file in the `script` tag.