### PR TITLE
Autoselect a device during development

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+## 4.14.0
+### Added
+- Enable automatically selecting a specified device when it is detected in an
+  app. To use this, set the environment variable `AUTOSELECT_DEVICE`, e.g. by
+  running the launcher with
+
+       AUTOSELECT_DEVICE=000680407810 npm run app
+
+  the device with the serial number 000680407810 is automatically selected
+  when apps using the new architecture see it for the first time. When one
+  deselects the device it is not automatically selected again. After
+  restarting the app, the device is automatically selected again.
+
 ## 4.13.0
 ### Updated
 - Replaced moment.js with date-fns library

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.13.0",
+    "version": "4.14.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -115,6 +115,8 @@
         ]
     },
     "typings": "./index.d.ts",
-    "eslintConfig": { "extends" : "./config/eslintrc.json" },
+    "eslintConfig": {
+        "extends": "./config/eslintrc.json"
+    },
     "prettier": "./config/prettier.config.js"
 }

--- a/src/Device/DeviceSelector/DeviceSelector.jsx
+++ b/src/Device/DeviceSelector/DeviceSelector.jsx
@@ -51,6 +51,7 @@ import DeviceSetup from '../DeviceSetup/DeviceSetup';
 import DeviceList from './DeviceList/DeviceList';
 import SelectDevice from './SelectDevice';
 import SelectedDevice from './SelectedDevice';
+import useAutoselectDevice from './useAutoselectDevice';
 
 const noop = () => {};
 const DeviceSelector = ({
@@ -101,6 +102,8 @@ const DeviceSelector = ({
         doStartWatchingDevices();
         return stopWatchingDevices;
     }, [doStartWatchingDevices]);
+
+    useAutoselectDevice(doSelectDevice);
 
     return (
         <div className="core19-device-selector">

--- a/src/Device/DeviceSelector/useAutoselectDevice.jsx
+++ b/src/Device/DeviceSelector/useAutoselectDevice.jsx
@@ -1,0 +1,56 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { getDevice } from '../deviceReducer';
+
+export default doSelectDevice => {
+    const alreadyTriedToAutoselect = useRef(false);
+
+    const autoselectDevice = useSelector(
+        getDevice(process.env.AUTOSELECT_DEVICE)
+    );
+
+    useEffect(() => {
+        if (alreadyTriedToAutoselect.current || autoselectDevice == null) {
+            return;
+        }
+
+        alreadyTriedToAutoselect.current = true;
+        doSelectDevice(autoselectDevice);
+    }, [autoselectDevice, doSelectDevice]);
+};

--- a/src/Device/deviceReducer.js
+++ b/src/Device/deviceReducer.js
@@ -88,7 +88,7 @@ const noDialogShown = {
 };
 
 const initialState = {
-    devices: [],
+    devices: {},
     selectedSerialNumber: null,
     deviceInfo: null,
     isSetupWaitingForUserInput: false,
@@ -167,11 +167,14 @@ const sorted = devices =>
         return displayedDeviceName(a) < displayedDeviceName(b) ? -1 : 1;
     });
 
+export const getDevice = serialNumber => state =>
+    state.device?.devices[serialNumber];
+
 export const sortedDevices = state =>
     sorted(Object.values(state.device.devices));
 
 export const deviceIsSelected = state =>
-    state.device != null && state.device.selectedSerialNumber != null;
+    state.device?.selectedSerialNumber != null;
 
 export const selectedDevice = state =>
     state.device.devices[state.device.selectedSerialNumber];


### PR DESCRIPTION
Enable automatically selecting a specified device when it is detected in an app. To use this, set the environment variable AUTOSELECT_DEVICE, e.g. by running the launcher with

    AUTOSELECT_DEVICE=000680407810 npm run app


the device with the serial number 000680407810 is automatically selected when apps using the new architecture see it for the first time. 

When one deselects the device it is not automatically selected again. After restarting the app, the device is automatically selected again.
