### PR TITLE
Exclude node-modules from eslint-loader to prevent warning bonanza

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -80,6 +80,13 @@ module.exports = {
                                 './node_modules/pc-nrfconnect-shared/config/babel.config.js',
                         },
                     },
+                ],
+                exclude: /node_modules\/(?!pc-nrfconnect-shared\/)/,
+            },
+            {
+                enforce: 'pre',
+                test: /\.(jsx?|tsx?)$/,
+                use: [
                     {
                         loader: require.resolve('eslint-loader'),
                         options: {
@@ -87,7 +94,7 @@ module.exports = {
                         },
                     },
                 ],
-                exclude: /node_modules\/(?!pc-nrfconnect-shared\/)/,
+                exclude: /node_modules/,
             },
             {
                 test: /\.scss|\.css$/,


### PR DESCRIPTION
Build logs get spammed with warnings because eslint-loader is looking through node_modules and failing to locate files. So split up babel-loader and eslint-loader rules so that we can exclude node_modules correctly.