### PR TITLE
Disable import/no-cycle ESLint rule

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.14.1
+### Updated
+- Disabled `import/no-cycle` ESLint rule
+
 ## 4.14.0
 ### Added
 - Enable automatically selecting a specified device when it is detected in an

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -60,7 +60,8 @@
         "import/extensions": ["off"],
         "no-undef": 1,
         "no-unused-vars": "off",
-        "prettier/prettier": "error"
+        "prettier/prettier": "error",
+        "import/no-cycle": "off"
     },
     "overrides": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.14.0",
+    "version": "4.14.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
As per this issue, there's a recent bug in the AirBnB ESLint package (or somewhere along the crazy dependency web) that is breaking the `import/no-cycle` rule.

Unfortunately this is breaking our pipelines, so we should disable it for now (or live on the edge and keep it disabled - DLBÉG).