### PR TITLE
Pin eslint-plugin-import version to 2.22.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.14.3
+### Updated
+- Pin `eslint-plugin-import` version
+
 ## 4.14.2
 ### Updated
 - Disabled `import/no-cycle` ESLint rule

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "eslint-config-airbnb": "18.1.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-loader": "4.0.2",
-        "eslint-plugin-import": "2.22.1",
+        "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jsx-a11y": "6.2.3",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.14.2",
+    "version": "4.14.3",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -48,7 +48,7 @@
         "eslint-config-airbnb": "18.1.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-loader": "4.0.2",
-        "eslint-plugin-import": "2.20.2",
+        "eslint-plugin-import": "2.22.1",
         "eslint-plugin-jsx-a11y": "6.2.3",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "7.20.0",


### PR DESCRIPTION
Should fix the breaking change in a recent ESLint version that stopped our pipelines working.
See https://github.com/airbnb/javascript/issues/2331 for more info.