### PR TITLE
Enable import/no-cycle ESLint rule again

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.14.4
+### Updated
+- Revert change from 4.14.2: Enable `import/no-cycle` ESLint rule again
+
 ## 4.14.3
 ### Updated
 - Pin `eslint-plugin-import` version

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -60,8 +60,7 @@
         "import/extensions": ["off"],
         "no-undef": 1,
         "no-unused-vars": "off",
-        "prettier/prettier": "error",
-        "import/no-cycle": "off"
+        "prettier/prettier": "error"
     },
     "overrides": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.14.3",
+    "version": "4.14.4",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Disabling the rule it in 4.14.2 was not effective, the fix from 4.14.3 alone is sufficient.

This basically reverts #121.