### PR TITLE
Fix small typescript issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ declare module 'pc-nrfconnect-shared' {
         nordicUsb?: boolean;
         seggerUsb?: boolean;
         nordicDfu?: boolean;
-        serialPort?: boolean;
+        serialport?: boolean;
         jlink?: boolean;
     }
 
@@ -182,7 +182,7 @@ declare module 'pc-nrfconnect-shared' {
         needSerialPort?: boolean;
     }
 
-    interface Serialport {
+    export interface Serialport {
         path: string;
         manufacturer: string;
         productId: string;


### PR DESCRIPTION
Two really small things, do not justify a release or even a changelog entry:

- Typo on `serialPort` (`p` should be small)
- Export interface `Serialport` (because it is needed e.g. in RSSI app)