### PR TITLE
Fix: Stacked opacity on nested disabled elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## 4.16.1
+### Fix
+- The opacity of disabled elements stacked up when they were nested. E.g.
+  in the following code the input had the opacity applied twice (making the
+  opacity squared), so it looked lighter than than supposed:
+
+       <div className="disabled">This <InlineInput disabled value="doubled"/></div>
 ## 4.16.0
 ### Added
 - The components `Slider`, `InlineInput` and `NumberInlineInput` now take a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.16.0",
+    "version": "4.16.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/shared.scss
+++ b/src/App/shared.scss
@@ -36,6 +36,11 @@ body {
 
 .disabled, :disabled {
     opacity: $disabled-opacity;
+
+    // To prevent opacity from stacking up
+    .disabled, :disabled {
+        opacity: 1;
+    }
 }
 
 // used when tabbing and space

--- a/src/InlineInput/inline-input.scss
+++ b/src/InlineInput/inline-input.scss
@@ -23,3 +23,10 @@
         opacity: $disabled-opacity;
     }
 }
+
+// To prevent opacity from stacking up
+.disabled, :disabled {
+    .inline-input.disabled {
+        opacity: 1;
+    }
+}

--- a/src/Slider/Ticks.jsx
+++ b/src/Slider/Ticks.jsx
@@ -35,7 +35,7 @@
  */
 
 import React from 'react';
-import { number } from 'prop-types';
+import { exact, number } from 'prop-types';
 import lodashRange from 'lodash.range';
 import classNames from '../utils/classNames';
 
@@ -65,7 +65,8 @@ const Ticks = ({ valueRange, range: { min, max, decimals = 0 } }) => {
 };
 Ticks.propTypes = {
     range: rangeShape.isRequired,
-    valueRange: { min: number.isRequired, max: number.isRequired }.isRequired,
+    valueRange: exact({ min: number.isRequired, max: number.isRequired })
+        .isRequired,
 };
 
 export default Ticks;


### PR DESCRIPTION
The opacity of disabled elements stacked up when they were nested. E.g.
in the following code the input had the opacity applied twice (making the
opacity squared), so it looked lighter than than supposed:
```jsx
       <div className="disabled">This <InlineInput disabled value="doubled"/></div>
```