### PR TITLE
Check stricter order of the imports during linting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,14 @@
 ## Unreleased
 ### Changed
 - Add links to product page and distributors for the PPK2.
+- Check stricter order of the imports during linting.
+### Steps to upgrade when using this package
+- The stricter check for order of the imports while linting will probably
+  make your linting fail after upgrading. So it is recommended to run
+  `npm run lint -- --fix` once after updating, checking all the changes (most
+  will be ok but there are very seldom cases where order is important like in
+  `test/setupTests.js` in this project) and then commit all these small order
+  changes.
 
 ## 4.16.1
 ### Fix

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -61,7 +61,34 @@
         "import/extensions": ["off"],
         "no-undef": 1,
         "no-unused-vars": "off",
-        "prettier/prettier": "error"
+        "prettier/prettier": "error",
+        "import/order": "off",
+        "simple-import-sort/imports": [
+            "error",
+            {
+                /* This configures the order of the imports.
+                   The obscure format using regexps is described at
+                   https://github.com/lydell/eslint-plugin-simple-import-sort#custom-grouping
+                   and there are examples at
+                   https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/examples/.eslintrc.js
+                */
+                "groups": [
+                    // First all side effect imports. That strange token is
+                    // described in the eslint-plugin-simple-import-sort docs
+                    ["^\\u0000"],
+
+                    // All package imports (starting with a letter, optionally
+                    // prepended by an '@'), with React packages coming first.
+                    ["^react", "^@?\\w"],
+
+                    // All relative imports (starting with a '.')
+                    ["^\\."],
+
+                    // All styles imports (ending with '.css' or '.scss')
+                    ["^.+\\.s?css$"]
+                ]
+            }
+        ]
     },
     "overrides": [
         {
@@ -81,7 +108,13 @@
             }
         }
     ],
-    "plugins": ["react", "import", "react-hooks", "prettier"],
+    "plugins": [
+        "react",
+        "import",
+        "react-hooks",
+        "prettier",
+        "simple-import-sort"
+    ],
     "env": {
         "es6": true,
         "browser": true,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "7.20.0",
         "eslint-plugin-react-hooks": "4.0.4",
+        "eslint-plugin-simple-import-sort": "7.0.0",
         "eslint-webpack-plugin": "^2.1.0",
         "file-loader": "6.0.0",
         "focus-visible": "5.1.0",

--- a/src/About/About.jsx
+++ b/src/About/About.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+
 import ApplicationCard from './ApplicationCard';
 import DeviceCard from './DeviceCard';
 import SupportCard from './SupportCard';

--- a/src/About/AboutButton.jsx
+++ b/src/About/AboutButton.jsx
@@ -35,8 +35,9 @@
  */
 
 import React from 'react';
-import { func, string } from 'prop-types';
 import Button from 'react-bootstrap/Button';
+import { func, string } from 'prop-types';
+
 import { openUrl } from '../utils/open';
 
 import './about-button.scss';

--- a/src/About/ApplicationCard.jsx
+++ b/src/About/ApplicationCard.jsx
@@ -36,6 +36,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { ipcRenderer } from 'electron';
+
 import AboutButton from './AboutButton';
 import Card from './Card';
 import Section from './Section';

--- a/src/About/DeviceCard.jsx
+++ b/src/About/DeviceCard.jsx
@@ -36,19 +36,19 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
+
+import {
+    buyOnlineUrl,
+    deviceInfo,
+    productPageUrl,
+} from '../Device/deviceInfo/deviceInfo';
+import {
+    deviceInfo as deviceInfoSelector,
+    selectedDevice,
+} from '../Device/deviceReducer';
 import AboutButton from './AboutButton';
 import Card from './Card';
 import Section from './Section';
-
-import {
-    selectedDevice,
-    deviceInfo as deviceInfoSelector,
-} from '../Device/deviceReducer';
-import {
-    deviceInfo,
-    productPageUrl,
-    buyOnlineUrl,
-} from '../Device/deviceInfo/deviceInfo';
 
 const memorySize = memoryInBytes => {
     if (memoryInBytes == null) {

--- a/src/About/SupportCard.jsx
+++ b/src/About/SupportCard.jsx
@@ -36,12 +36,13 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import systemReport from '../utils/systemReport';
+
 import {
-    sortedDevices,
     deviceInfo,
     selectedSerialNumber,
+    sortedDevices,
 } from '../Device/deviceReducer';
+import systemReport from '../utils/systemReport';
 import AboutButton from './AboutButton';
 import Card from './Card';
 import Section from './Section';

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -34,30 +34,28 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useEffect } from 'react';
-import { array, arrayOf, func, node, bool } from 'prop-types';
-import { useSelector, useDispatch } from 'react-redux';
-
-import { ipcRenderer } from 'electron';
-import Carousel from 'react-bootstrap/Carousel';
-
 import 'focus-visible';
 
-import LogViewer from '../Log/LogViewer';
+import React, { useEffect } from 'react';
+import Carousel from 'react-bootstrap/Carousel';
+import { useDispatch, useSelector } from 'react-redux';
+import { ipcRenderer } from 'electron';
+import { array, arrayOf, bool, func, node } from 'prop-types';
+
 import About from '../About/About';
-import ErrorDialog from '../ErrorDialog/ErrorDialog';
 import AppReloadDialog from '../AppReload/AppReloadDialog';
+import ErrorDialog from '../ErrorDialog/ErrorDialog';
+import LogViewer from '../Log/LogViewer';
 import NavBar from '../NavBar/NavBar';
 import useHotKey from '../utils/useHotKey';
-
-import VisibilityBar from './VisibilityBar';
-import ConnectedToStore from './ConnectedToStore';
 import {
-    isSidePanelVisibleSelector,
-    isLogVisibleSelector,
     currentPaneSelector,
+    isLogVisibleSelector,
+    isSidePanelVisibleSelector,
     toggleLogVisible,
 } from './appLayout';
+import ConnectedToStore from './ConnectedToStore';
+import VisibilityBar from './VisibilityBar';
 
 import './shared.scss';
 import './app.scss';

--- a/src/App/App.test.jsx
+++ b/src/App/App.test.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+
 import render from '../../test/testrenderer';
 import App from './App';
 

--- a/src/App/ConnectedToStore.jsx
+++ b/src/App/ConnectedToStore.jsx
@@ -34,9 +34,9 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 import React from 'react';
+import { Provider } from 'react-redux';
 import { func, node } from 'prop-types';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
-import { Provider } from 'react-redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
 

--- a/src/App/VisibilityBar.jsx
+++ b/src/App/VisibilityBar.jsx
@@ -35,17 +35,18 @@
  */
 
 import React from 'react';
-import { bool } from 'prop-types';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
-import { autoScroll as autoScrollSelector } from '../Log/logReducer';
+import { bool } from 'prop-types';
+
 import { clear, toggleAutoScroll } from '../Log/logActions';
+import { autoScroll as autoScrollSelector } from '../Log/logReducer';
 import logger from '../logging';
 import {
-    isSidePanelVisibleSelector,
     isLogVisibleSelector,
-    toggleSidePanelVisible,
+    isSidePanelVisibleSelector,
     toggleLogVisible,
+    toggleSidePanelVisible,
 } from './appLayout';
 
 import './visibility-bar.scss';

--- a/src/AppReload/AppReloadDialog.jsx
+++ b/src/AppReload/AppReloadDialog.jsx
@@ -35,7 +35,7 @@
  */
 
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { remote } from 'electron';
 
 import ConfirmationDialog from '../Dialog/ConfirmationDialog';

--- a/src/AppReload/appReloadDialogReducer.js
+++ b/src/AppReload/appReloadDialogReducer.js
@@ -35,8 +35,8 @@
  */
 
 import {
-    APP_RELOAD_DIALOG_SHOW,
     APP_RELOAD_DIALOG_HIDE,
+    APP_RELOAD_DIALOG_SHOW,
 } from './appReloadDialogActions';
 
 const initialState = {

--- a/src/Device/DeviceSelector/BasicDeviceInfo.jsx
+++ b/src/Device/DeviceSelector/BasicDeviceInfo.jsx
@@ -35,13 +35,14 @@
  */
 
 import React from 'react';
-import { func, node, shape } from 'prop-types';
 import { useDispatch } from 'react-redux';
+import { func, node, shape } from 'prop-types';
+
 import InlineInput from '../../InlineInput/InlineInput';
-import { displayedDeviceName } from '../deviceInfo/deviceInfo';
 import { resetDeviceNickname, setDeviceNickname } from '../deviceActions';
-import deviceShape from './deviceShape';
+import { displayedDeviceName } from '../deviceInfo/deviceInfo';
 import DeviceIcon from './DeviceIcon';
+import deviceShape from './deviceShape';
 
 import './basic-device-info.scss';
 

--- a/src/Device/DeviceSelector/DeviceIcon.jsx
+++ b/src/Device/DeviceSelector/DeviceIcon.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+
 import { deviceInfo } from '../deviceInfo/deviceInfo';
 import deviceShape from './deviceShape';
 

--- a/src/Device/DeviceSelector/DeviceList/AnimatedList.jsx
+++ b/src/Device/DeviceSelector/DeviceList/AnimatedList.jsx
@@ -35,8 +35,9 @@
  */
 
 import React from 'react';
+import { Flipped, Flipper, spring } from 'react-flip-toolkit';
 import { arrayOf, node, string } from 'prop-types';
-import { Flipper, Flipped, spring } from 'react-flip-toolkit';
+
 import deviceShape from '../deviceShape';
 
 const changesOnReorder = devices =>

--- a/src/Device/DeviceSelector/DeviceList/Device.jsx
+++ b/src/Device/DeviceSelector/DeviceList/Device.jsx
@@ -34,16 +34,16 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useState, useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { bool, func } from 'prop-types';
 
 import PseudoButton from '../../../PseudoButton/PseudoButton';
 import classNames from '../../../utils/classNames';
-import deviceShape from '../deviceShape';
 import BasicDeviceInfo from '../BasicDeviceInfo';
+import deviceShape from '../deviceShape';
 import { FavoriteIndicator } from '../Favorite';
-import MoreDeviceInfo from './MoreDeviceInfo';
 import EditDeviceButtons from './EditDeviceButtons';
+import MoreDeviceInfo from './MoreDeviceInfo';
 
 import './device.scss';
 

--- a/src/Device/DeviceSelector/DeviceList/DeviceList.jsx
+++ b/src/Device/DeviceSelector/DeviceList/DeviceList.jsx
@@ -35,13 +35,13 @@
  */
 
 import React from 'react';
-import { bool, func } from 'prop-types';
 import { useSelector } from 'react-redux';
+import { bool, func } from 'prop-types';
 
 import classNames from '../../../utils/classNames';
 import { sortedDevices } from '../../deviceReducer';
+import { AnimatedItem, AnimatedList } from './AnimatedList';
 import Device from './Device';
-import { AnimatedList, AnimatedItem } from './AnimatedList';
 
 import './device-list.scss';
 

--- a/src/Device/DeviceSelector/DeviceList/EditDeviceButtons.jsx
+++ b/src/Device/DeviceSelector/DeviceList/EditDeviceButtons.jsx
@@ -35,8 +35,8 @@
  */
 
 import React from 'react';
-import { func } from 'prop-types';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import { func } from 'prop-types';
 
 import deviceShape from '../deviceShape';
 import { MakeDeviceFavorite } from '../Favorite';

--- a/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.jsx
+++ b/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.jsx
@@ -37,7 +37,7 @@
 import React from 'react';
 import { arrayOf, node, shape, string } from 'prop-types';
 
-import { serialports, displayedDeviceName } from '../../deviceInfo/deviceInfo';
+import { displayedDeviceName, serialports } from '../../deviceInfo/deviceInfo';
 import deviceShape from '../deviceShape';
 
 import './more-device-info.scss';

--- a/src/Device/DeviceSelector/DeviceList/RenameDevice.jsx
+++ b/src/Device/DeviceSelector/DeviceList/RenameDevice.jsx
@@ -36,6 +36,7 @@
 
 import React from 'react';
 import { func } from 'prop-types';
+
 import PseudoButton from '../../../PseudoButton/PseudoButton';
 
 import './rename-device.scss';

--- a/src/Device/DeviceSelector/DeviceSelector.jsx
+++ b/src/Device/DeviceSelector/DeviceSelector.jsx
@@ -35,8 +35,8 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { bool, exact, func, object } from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
+import { bool, exact, func, object } from 'prop-types';
 
 import {
     deselectDevice,
@@ -47,7 +47,6 @@ import {
 } from '../deviceActions';
 import { deviceIsSelected as deviceIsSelectedSelector } from '../deviceReducer';
 import DeviceSetup from '../DeviceSetup/DeviceSetup';
-
 import DeviceList from './DeviceList/DeviceList';
 import SelectDevice from './SelectDevice';
 import SelectedDevice from './SelectedDevice';

--- a/src/Device/DeviceSelector/Favorite.jsx
+++ b/src/Device/DeviceSelector/Favorite.jsx
@@ -36,6 +36,7 @@
 
 import React from 'react';
 import { useDispatch } from 'react-redux';
+
 import PseudoButton from '../../PseudoButton/PseudoButton';
 import { toggleDeviceFavorited } from '../deviceActions';
 import deviceShape from './deviceShape';

--- a/src/Device/DeviceSelector/SelectedDevice.jsx
+++ b/src/Device/DeviceSelector/SelectedDevice.jsx
@@ -35,8 +35,8 @@
  */
 
 import React from 'react';
-import { func } from 'prop-types';
 import { useSelector } from 'react-redux';
+import { func } from 'prop-types';
 
 import PseudoButton from '../../PseudoButton/PseudoButton';
 import { selectedDevice } from '../deviceReducer';

--- a/src/Device/DeviceSelector/useAutoselectDevice.jsx
+++ b/src/Device/DeviceSelector/useAutoselectDevice.jsx
@@ -36,6 +36,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
+
 import { getDevice } from '../deviceReducer';
 
 export default doSelectDevice => {

--- a/src/Device/DeviceSetup/DeviceSetup.js
+++ b/src/Device/DeviceSetup/DeviceSetup.js
@@ -35,6 +35,7 @@
  */
 
 import { connect } from 'react-redux';
+
 import { receiveDeviceSetupInput } from '../deviceActions';
 import DeviceSetupView from './DeviceSetupView';
 

--- a/src/Device/DeviceSetup/DeviceSetupView.jsx
+++ b/src/Device/DeviceSetup/DeviceSetupView.jsx
@@ -35,9 +35,9 @@
  */
 
 import React from 'react';
-
-import { arrayOf, bool, func, string } from 'prop-types';
 import Form from 'react-bootstrap/Form';
+import { arrayOf, bool, func, string } from 'prop-types';
+
 import ConfirmationDialog from '../../Dialog/ConfirmationDialog';
 
 /**

--- a/src/Device/deviceActions.js
+++ b/src/Device/deviceActions.js
@@ -36,8 +36,9 @@
 
 import DeviceLister from 'nrf-device-lister'; // eslint-disable-line import/no-unresolved
 import nrfDeviceSetup from 'nrf-device-setup';
-import logger from '../logging';
+
 import { showDialog as showAppReloadDialog } from '../AppReload/appReloadDialogActions';
+import logger from '../logging';
 
 /**
  * Indicates that a device has been selected.

--- a/src/Device/deviceReducer.js
+++ b/src/Device/deviceReducer.js
@@ -40,19 +40,19 @@ import {
     persistIsFavorite,
     persistNickname,
 } from '../utils/persistentStore';
-import { displayedDeviceName } from './deviceInfo/deviceInfo';
 import {
-    DEVICES_DETECTED,
-    DEVICE_SELECTED,
     DEVICE_DESELECTED,
+    DEVICE_FAVORITE_TOGGLED,
+    DEVICE_NICKNAME_RESET,
+    DEVICE_NICKNAME_SET,
+    DEVICE_SELECTED,
     DEVICE_SETUP_COMPLETE,
     DEVICE_SETUP_ERROR,
-    DEVICE_SETUP_INPUT_REQUIRED,
     DEVICE_SETUP_INPUT_RECEIVED,
-    DEVICE_FAVORITE_TOGGLED,
-    DEVICE_NICKNAME_SET,
-    DEVICE_NICKNAME_RESET,
+    DEVICE_SETUP_INPUT_REQUIRED,
+    DEVICES_DETECTED,
 } from './deviceActions';
+import { displayedDeviceName } from './deviceInfo/deviceInfo';
 
 const withPersistedData = devices =>
     devices.map(device => ({

--- a/src/Dialog/ConfirmationDialog.jsx
+++ b/src/Dialog/ConfirmationDialog.jsx
@@ -34,10 +34,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { arrayOf, bool, func, node, oneOfType, string } from 'prop-types';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
+import { arrayOf, bool, func, node, oneOfType, string } from 'prop-types';
 
 import Spinner from './Spinner';
 

--- a/src/Dialog/ConfirmationDialog.test.jsx
+++ b/src/Dialog/ConfirmationDialog.test.jsx
@@ -38,7 +38,6 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
 import render from '../../test/testrenderer';
-
 import ConfirmationDialog from './ConfirmationDialog';
 
 const noop = () => {};

--- a/src/Dialog/Spinner.jsx
+++ b/src/Dialog/Spinner.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+
 import spinnerImg from './ajax-loader.gif';
 
 export default () => (

--- a/src/ErrorDialog/ErrorDialog.jsx
+++ b/src/ErrorDialog/ErrorDialog.jsx
@@ -35,16 +35,16 @@
  */
 
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 import ReactMarkdown from 'react-markdown';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { hideDialog } from './errorDialogActions';
 import {
+    errorResolutions as errorResolutionsSelector,
     isVisible as isVisibleSelector,
     messages as messagesSelector,
-    errorResolutions as errorResolutionsSelector,
 } from './errorDialogReducer';
 
 import './error.scss';

--- a/src/ErrorDialog/ErrorDialog.test.jsx
+++ b/src/ErrorDialog/ErrorDialog.test.jsx
@@ -38,7 +38,6 @@ import React from 'react';
 import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react';
 
 import render from '../../test/testrenderer';
-
 import ErrorDialog from './ErrorDialog';
 import { showDialog } from './errorDialogActions';
 

--- a/src/ErrorDialog/errorDialogReducer.js
+++ b/src/ErrorDialog/errorDialogReducer.js
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { ERROR_DIALOG_SHOW, ERROR_DIALOG_HIDE } from './errorDialogActions';
+import { ERROR_DIALOG_HIDE, ERROR_DIALOG_SHOW } from './errorDialogActions';
 
 const initialState = {
     messages: [],

--- a/src/ErrorDialog/errorDialogReducer.test.js
+++ b/src/ErrorDialog/errorDialogReducer.test.js
@@ -34,8 +34,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import reducer from './errorDialogReducer';
 import { hideDialog, showDialog } from './errorDialogActions';
+import reducer from './errorDialogReducer';
 
 const initialState = reducer(undefined, {});
 

--- a/src/InlineInput/InlineInput.jsx
+++ b/src/InlineInput/InlineInput.jsx
@@ -36,6 +36,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { bool, func, string } from 'prop-types';
+
 import classNames from '../utils/classNames';
 
 import './inline-input.scss';

--- a/src/InlineInput/NumberInlineInput.jsx
+++ b/src/InlineInput/NumberInlineInput.jsx
@@ -37,8 +37,8 @@
 import React from 'react';
 import { bool, func, number } from 'prop-types';
 
-import InlineInput from './InlineInput';
 import rangeShape from '../Slider/rangeShape';
+import InlineInput from './InlineInput';
 
 import './number-inline-input.scss';
 

--- a/src/Log/LogEntry.jsx
+++ b/src/Log/LogEntry.jsx
@@ -35,9 +35,9 @@
  */
 
 import React from 'react';
-import { shape, number, string } from 'prop-types';
-import { shell } from 'electron';
 import formatDate from 'date-fns/format';
+import { shell } from 'electron';
+import { number, shape, string } from 'prop-types';
 
 import './log-entry.scss';
 

--- a/src/Log/LogViewer.jsx
+++ b/src/Log/LogViewer.jsx
@@ -34,8 +34,9 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useRef, useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
+
 import LogEntry from './LogEntry';
 import { useLogListener } from './logListener';
 import {

--- a/src/Log/logListener.js
+++ b/src/Log/logListener.js
@@ -34,9 +34,9 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { ipcRenderer } from 'electron';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { ipcRenderer } from 'electron';
 
 import logger from '../logging';
 import { getAppDataDir } from '../utils/appDirs';

--- a/src/Logo/Logo.jsx
+++ b/src/Logo/Logo.jsx
@@ -35,15 +35,15 @@
  */
 
 import React from 'react';
-import { bool } from 'prop-types';
 import { useSelector } from 'react-redux';
+import { bool } from 'prop-types';
 
-import { openUrl } from '../utils/open';
 import { deviceIsSelected as deviceIsSelectedSelector } from '../Device/deviceReducer';
-
-import logoUniform from './nordic-logo-white-icon-only.png';
-import logoDisconnected from './nordic-logo-gray-icon-only.png';
+import { openUrl } from '../utils/open';
 import logoConnected from './nordic-logo-blue-icon-only.png';
+import logoDisconnected from './nordic-logo-gray-icon-only.png';
+import logoUniform from './nordic-logo-white-icon-only.png';
+
 import './logo.scss';
 
 const goToNRFConnectWebsite = () =>

--- a/src/NavBar/NavMenu.jsx
+++ b/src/NavBar/NavMenu.jsx
@@ -35,8 +35,8 @@
  */
 
 import React from 'react';
-import { array, arrayOf } from 'prop-types';
 import { useSelector } from 'react-redux';
+import { array, arrayOf } from 'prop-types';
 
 import { currentPaneSelector } from '../App/appLayout';
 import NavMenuItem from './NavMenuItem';

--- a/src/NavBar/NavMenu.test.jsx
+++ b/src/NavBar/NavMenu.test.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+
 import render from '../../test/testrenderer';
 import NavMenu from './NavMenu';
 

--- a/src/NavBar/NavMenuItem.jsx
+++ b/src/NavBar/NavMenuItem.jsx
@@ -35,12 +35,12 @@
  */
 
 import React from 'react';
-import { bool, number, string } from 'prop-types';
-import { useDispatch } from 'react-redux';
 import Button from 'react-bootstrap/Button';
+import { useDispatch } from 'react-redux';
+import { bool, number, string } from 'prop-types';
 
-import classNames from '../utils/classNames';
 import { setCurrentPane } from '../App/appLayout';
+import classNames from '../utils/classNames';
 
 import './nav-menu-item.scss';
 

--- a/src/SidePanel/Group.tsx
+++ b/src/SidePanel/Group.tsx
@@ -35,17 +35,16 @@
  */
 
 import React, { useContext, useRef } from 'react';
-import { bool, func, string } from 'prop-types';
-
 import Accordion from 'react-bootstrap/Accordion';
 // @ts-expect-error: React-Bootstrap misses a type definition in the version we currently use
 import AccordionContext from 'react-bootstrap/AccordionContext';
 import { useAccordionToggle } from 'react-bootstrap/AccordionToggle';
+import { bool, func, string } from 'prop-types';
 
 import PseudoButton from '../PseudoButton/PseudoButton';
+import classNames from '../utils/classNames';
 
 import './group.scss';
-import classNames from '../utils/classNames';
 
 const Heading: React.FC<{
     label?: string;

--- a/src/Slider/Handle.jsx
+++ b/src/Slider/Handle.jsx
@@ -36,14 +36,14 @@
 
 import React, { useRef, useState } from 'react';
 import { bool, func, number } from 'prop-types';
-import classNames from '../utils/classNames';
 
-import rangeShape from './rangeShape';
+import classNames from '../utils/classNames';
 import {
     constrainedToPercentage,
     fromPercentage,
     toPercentage,
 } from './percentage';
+import rangeShape from './rangeShape';
 
 import './handle.scss';
 

--- a/src/Slider/Slider.jsx
+++ b/src/Slider/Slider.jsx
@@ -36,14 +36,14 @@
 
 import React from 'react';
 import { arrayOf, bool, func, number, string } from 'prop-types';
-import classNames from '../utils/classNames';
 
+import classNames from '../utils/classNames';
 import Bar from './Bar';
 import Handle from './Handle';
-import useWidthObserver from './useWidthObserver';
-import rangeShape from './rangeShape';
 import { toPercentage } from './percentage';
+import rangeShape from './rangeShape';
 import Ticks from './Ticks';
+import useWidthObserver from './useWidthObserver';
 
 import './slider.scss';
 

--- a/src/Slider/Ticks.jsx
+++ b/src/Slider/Ticks.jsx
@@ -35,10 +35,10 @@
  */
 
 import React from 'react';
-import { exact, number } from 'prop-types';
 import lodashRange from 'lodash.range';
-import classNames from '../utils/classNames';
+import { exact, number } from 'prop-types';
 
+import classNames from '../utils/classNames';
 import rangeShape from './rangeShape';
 
 import './ticks.scss';

--- a/src/Toggle/Toggle.jsx
+++ b/src/Toggle/Toggle.jsx
@@ -34,8 +34,9 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { bool, func, node, oneOf, string } from 'prop-types';
 import React, { useState } from 'react';
+import { bool, func, node, oneOf, string } from 'prop-types';
+
 import classNames from '../utils/classNames';
 
 import './toggle.scss';

--- a/src/coreReducers.js
+++ b/src/coreReducers.js
@@ -34,11 +34,11 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { reducer as appLayout } from './App/appLayout';
 import appReloadDialog from './AppReload/appReloadDialogReducer';
 import device from './Device/deviceReducer';
 import errorDialog from './ErrorDialog/errorDialogReducer';
 import log from './Log/logReducer';
-import { reducer as appLayout } from './App/appLayout';
 
 export default {
     appLayout,

--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -34,9 +34,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { createLogger, format, transports } from 'winston';
-import { SPLAT } from 'triple-beam';
 import path from 'path';
+import { SPLAT } from 'triple-beam';
+import { createLogger, format, transports } from 'winston';
+
 import { openFile } from '../utils/open';
 import AppTransport from './appTransport';
 import ConsoleTransport from './consoleTransport';

--- a/src/utils/open.js
+++ b/src/utils/open.js
@@ -34,10 +34,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import childProcess from 'child_process';
+import { shell } from 'electron';
 import fs from 'fs';
 import os from 'os';
-import { shell } from 'electron';
-import childProcess from 'child_process';
 
 /**
  * Open a file in the default text application, depending on the user's OS.

--- a/src/utils/systemReport.js
+++ b/src/utils/systemReport.js
@@ -34,11 +34,12 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import si from 'systeminformation';
-import path from 'path';
 import fs from 'fs';
 import { EOL } from 'os';
+import path from 'path';
 import pretty from 'prettysize';
+import si from 'systeminformation';
+
 import logger from '../logging';
 import { getAppDataDir } from './appDirs';
 import { openFile } from './open';

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -1,3 +1,7 @@
+/* eslint-disable simple-import-sort/imports --
+   sorting the import order must be disabled for this file because enzyme
+   and testing-library are sensitive to the order in which they are run
+*/
 import enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/test/testrenderer.jsx
+++ b/test/testrenderer.jsx
@@ -35,9 +35,10 @@
  */
 
 import React from 'react';
-import { createStore, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
+import { combineReducers, createStore } from 'redux';
+
 import coreReducers from '../src/coreReducers';
 
 const createPreparedStore = actions => {


### PR DESCRIPTION
This enforces a stricter check for the order of the imports and
consequently updates all files where the order was not correct. Mostly
this order is what we already do, but we did deviate a bit from it in a
lot of places.

TL;DR: First group, then sort alphabetically.

The main rule is to split the imports into four groups in this order:
1. Very rare: Side effect imports (like `import 'focus-visible'`)
2. Normal package imports (like `import React from 'react'`)
3. Relative imports (like `import logger from '../logging'`)
4. Style imports (like `import './about.scss'`)

These groups are all separated by newlines.

Within these groups the imports are ordered alphabetically by the "from"
(`prop-types` before `redux`) and the imported items themselves are also
ordered alphabetically (`arrayOf` before `node`).

There is one special case for the ordering of package names: The package
`react` and all other packages beginning with `react` will be at the
beginning of their group. This respects the current habit of putting the
React import at the top.

You can see how these rules play out in the files in this project, best
in a file with many imports such as `App.jsx`.

The rather obscure configuration is commented in `eslintrc.json`. Even
though the JSON file format normally does not allow comments, ESLint
explicitly allows them in their configuration. This means some editors
might complain about the comments, but I preferred that to converting
the configuration to plain JavaScript, since that would have been
another breaking change for all packages using this package.