### PR TITLE
Small fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Added
+- Currently active pane: Selector `currentPane` to query it and action creator
+  `setCurrentPane` to change it.
 ### Fix
 - When clicking on URLs in log entries the web site was not opened on macOS.
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Fix
+- When clicking on URLs in log entries the web site was not opened on macOS.
 ### Changed
 - Add links to product page and distributors for the PPK2.
 - Check stricter order of the imports during linting.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.17.0
 ### Added
 - Currently active pane: Selector `currentPane` to query it and action creator
   `setCurrentPane` to change it.

--- a/index.d.ts
+++ b/index.d.ts
@@ -457,4 +457,18 @@ declare module 'pc-nrfconnect-shared' {
      *     )
      */
     export function classNames(...className: unknown[]): string;
+
+    // appLayout.js
+
+    /**
+     * Create a Redux action to set the currently active pane.
+     */
+    export function setCurrentPane(currentPane: number): AnyAction;
+
+    /**
+     * A selector to determine the number of the currently active pane.
+     */
+    export function currentPane<AppState>(
+        state: NrfConnectState<AppState>
+    ): number;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.16.1",
+    "version": "4.17.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "semver": "7.3.2",
         "shasum": "1.0.2",
         "style-loader": "1.2.1",
-        "systeminformation": "4.26.4",
+        "systeminformation": "4.34.9",
         "typescript": "^3.9.7",
         "url-loader": "4.1.0",
         "webpack": "4.43.0",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -49,9 +49,9 @@ import LogViewer from '../Log/LogViewer';
 import NavBar from '../NavBar/NavBar';
 import useHotKey from '../utils/useHotKey';
 import {
-    currentPaneSelector,
-    isLogVisibleSelector,
-    isSidePanelVisibleSelector,
+    currentPane as currentPaneSelector,
+    isLogVisible as isLogVisibleSelector,
+    isSidePanelVisible as isSidePanelVisibleSelector,
     toggleLogVisible,
 } from './appLayout';
 import ConnectedToStore from './ConnectedToStore';

--- a/src/App/VisibilityBar.jsx
+++ b/src/App/VisibilityBar.jsx
@@ -43,8 +43,8 @@ import { clear, toggleAutoScroll } from '../Log/logActions';
 import { autoScroll as autoScrollSelector } from '../Log/logReducer';
 import logger from '../logging';
 import {
-    isLogVisibleSelector,
-    isSidePanelVisibleSelector,
+    isLogVisible as isLogVisibleSelector,
+    isSidePanelVisible as isSidePanelVisibleSelector,
     toggleLogVisible,
     toggleSidePanelVisible,
 } from './appLayout';

--- a/src/App/appLayout.js
+++ b/src/App/appLayout.js
@@ -66,7 +66,6 @@ export const reducer = (state = initialState, { type, currentPane }) => {
     }
 };
 
-export const isSidePanelVisibleSelector = state =>
-    state.appLayout.isSidePanelVisible;
-export const isLogVisibleSelector = state => state.appLayout.isLogVisible;
-export const currentPaneSelector = state => state.appLayout.currentPane;
+export const isSidePanelVisible = state => state.appLayout.isSidePanelVisible;
+export const isLogVisible = state => state.appLayout.isLogVisible;
+export const currentPane = state => state.appLayout.currentPane;

--- a/src/Log/LogEntry.jsx
+++ b/src/Log/LogEntry.jsx
@@ -36,8 +36,9 @@
 
 import React from 'react';
 import formatDate from 'date-fns/format';
-import { shell } from 'electron';
 import { number, shape, string } from 'prop-types';
+
+import { openUrl } from '../utils/open';
 
 import './log-entry.scss';
 
@@ -66,7 +67,7 @@ function hrefReplacer(str) {
                 href={href}
                 key={index}
                 tabIndex={index}
-                onClick={() => shell.openItem(href)}
+                onClick={() => openUrl(href)}
                 onKeyPress={() => {}}
             >
                 {href}

--- a/src/NavBar/NavMenu.jsx
+++ b/src/NavBar/NavMenu.jsx
@@ -38,7 +38,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { array, arrayOf } from 'prop-types';
 
-import { currentPaneSelector } from '../App/appLayout';
+import { currentPane as currentPaneSelector } from '../App/appLayout';
 import NavMenuItem from './NavMenuItem';
 
 const NavMenu = ({ panes }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -74,3 +74,5 @@ export { default as usageData } from './utils/usageData';
 export { default as classNames } from './utils/classNames';
 
 export { default as useHotKey } from './utils/useHotKey';
+
+export { currentPane, setCurrentPane } from './App/appLayout';


### PR DESCRIPTION
- At least on macOS (unsure about Linux, is no problem on Win 10) clicking on URLs in the log viewer did not open it in a browser
- In the PPK app we need to query and set the active pane and I think this also already came up in other apps. But this was not possible through an official API yet, so this adds an API for that.
- The `systeminformation` package had a security vulnerability for which @dependabot created #116. This makes that PR obsolete.