### PR TITLE
Update nRF5340 links from PDK to DK

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.17.1
+### Changed
+- Updated nRF5340 links from PDK to DK.
+
 ## 4.17.0
 ### Added
 - Currently active pane: Selector `currentPane` to query it and action creator

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.17.0",
+    "version": "4.17.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -160,8 +160,8 @@ const devicesByPca: { [P in DevicePCA]: DeviceInfo } = {
         cores: 2,
         icon: nrf53logo,
         website: {
-            productPagePath: 'Software-and-tools/Development-Kits/nRF5340-PDK',
-            buyOnlineParams: 'search_token=nRF5340-PDK&series_token=nRF5340',
+            productPagePath: 'Software-and-tools/Development-Kits/nRF5340-DK',
+            buyOnlineParams: 'search_token=nRF5340-DK&series_token=nRF5340',
         },
     },
     PCA20020: {


### PR DESCRIPTION
Because the nRF5340 DK superseded the PDK.