### PR TITLE
Fix: Not defining an app reducer led to an error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.17.2
+### Fix
+- Not defining an app reducer led to an error.
+
 ## 4.17.1
 ### Changed
 - Updated nRF5340 links from PDK to DK.

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare module 'pc-nrfconnect-shared' {
          * this is the root reducer to handle that. It will handle the
          * slice of state under the name `app`.
          */
-        appReducer: Reducer<any, AnyAction>;
+        appReducer?: Reducer<any, AnyAction>;
         /**
          * The React element that appears in the upper left corner of the app.
          * Apps usually utilise the component `DeviceSelector` for this.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.17.1",
+    "version": "4.17.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -134,7 +134,7 @@ ConnectedApp.propTypes = {
     showLogByDefault: bool,
 };
 
-const noopReducer = state => state;
+const noopReducer = (state = null) => state;
 const App = ({ appReducer = noopReducer, ...props }) => (
     <ConnectedToStore appReducer={appReducer}>
         <ConnectedApp {...props} />


### PR DESCRIPTION
Not defining an app reducer ([as done in the boilerplate project](https://github.com/NordicSemiconductor/pc-nrfconnect-boilerplate/blob/master/src/index.jsx#L49)) actually led to an error. 🤦