### PR TITLE
Fix: Missing prop type for pane components

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## 4.17.3
+### Fix
+- Property `active` was missing in the TypeScript definition of the pane
+  components.
+
 ## 4.17.2
 ### Fix
 - Not defining an app reducer led to an error.

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,9 @@ declare module 'pc-nrfconnect-shared' {
     export const logger: winston.Logger;
 
     // App.jsx
+    export interface PaneProps {
+        active: boolean;
+    }
 
     /**
      * Props for the `App` component.
@@ -106,7 +109,7 @@ declare module 'pc-nrfconnect-shared' {
          *
          * `[['Connection Map', ConnectionMap], ['Server Setup', ServerSetup]]`
          */
-        panes: readonly (readonly [string, React.FC])[];
+        panes: readonly (readonly [string, React.FC<PaneProps>])[];
         /**
          * Describes whether the log will show automatically when the
          * application starts. Defaults to `true`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.17.2",
+    "version": "4.17.3",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The TypeScript definition did not specify that pane components can get a property `active`.