### PR TITLE
Feature: Side panel per pane

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,28 @@
+## Unreleased
+### Added
+- Allow different side panels per pane. If a pane should show a special side
+  panel it can be defined in the list of panes. If no side panel is defined for
+  a pane, the general side panel defined for the whole app is used. E.g. in an
+  app defined like the following on the pane Dashboard (and also the pane About)
+  the normal `SidePanel` component is shown, while on the pane Terminal the
+  `TerminalSidePanel` is shown.
+  ```jsx
+  <App
+    sidePanel={<SidePanel />}
+    panes={[
+      {
+        name: 'Dashboard',
+        Main: Dashboard,
+      },
+      {
+        name: 'Terminal',
+        Main: Terminal
+        SidePanel: TerminalSidePanel,
+      },
+    ]}
+  />
+  ```
+
 ## 4.19.0
 ### Added
 - Shared styles can now be imported in SCSS from

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ declare module 'pc-nrfconnect-shared' {
     interface Pane {
         name: string;
         Main: React.FC<PaneProps>;
+        SidePanel?: React.FC;
     }
 
     /**

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -102,8 +102,6 @@ const ConnectedApp = ({
         () => [...panes, { name: 'About', Main: About }].map(convertLegacy),
         [panes]
     );
-    const isSidePanelVisible =
-        useSelector(isSidePanelVisibleSelector) && sidePanel;
     const isLogVisible = useSelector(isLogVisibleSelector);
     const currentPane = useSelector(currentPaneSelector);
     const dispatch = useDispatch();
@@ -120,6 +118,13 @@ const ConnectedApp = ({
         dispatch(setPanes(allPanes));
     }, [dispatch, allPanes]);
 
+    const SidePanelComponent = allPanes[currentPane].SidePanel;
+    const currentSidePanel =
+        SidePanelComponent != null ? <SidePanelComponent /> : sidePanel;
+
+    const isSidePanelVisible =
+        useSelector(isSidePanelVisibleSelector) && currentSidePanel;
+
     return (
         <div className="core19-app">
             <NavBar deviceSelect={deviceSelect} />
@@ -130,7 +135,7 @@ const ConnectedApp = ({
                         isSidePanelVisible || 'hidden'
                     )}
                 >
-                    {sidePanel}
+                    {currentSidePanel}
                 </div>
                 <div className="core19-main-and-log">
                     <Carousel
@@ -172,6 +177,7 @@ const LegacyPanePropType = array;
 const PanePropType = exact({
     name: string.isRequired,
     Main: elementType.isRequired,
+    SidePanel: elementType,
 });
 
 ConnectedApp.propTypes = {

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -103,7 +103,8 @@ const ConnectedApp = ({
         () => [...panes, { name: 'About', Main: About }].map(convertLegacy),
         [panes]
     );
-    const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
+    const isSidePanelVisible =
+        useSelector(isSidePanelVisibleSelector) && sidePanel;
     const isLogVisible = useSelector(isLogVisibleSelector);
     const currentPane = useSelector(currentPaneSelector);
     const dispatch = useDispatch();
@@ -126,7 +127,7 @@ const ConnectedApp = ({
             <div className="core19-app-content">
                 <div
                     className={`core19-side-panel-container ${hiddenUnless(
-                        sidePanel && isSidePanelVisible
+                        isSidePanelVisible
                     )}`}
                 >
                     {sidePanel}

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -57,6 +57,7 @@ import AppReloadDialog from '../AppReload/AppReloadDialog';
 import ErrorDialog from '../ErrorDialog/ErrorDialog';
 import LogViewer from '../Log/LogViewer';
 import NavBar from '../NavBar/NavBar';
+import classNames from '../utils/classNames';
 import useHotKey from '../utils/useHotKey';
 import {
     currentPane as currentPaneSelector,
@@ -70,8 +71,6 @@ import VisibilityBar from './VisibilityBar';
 
 import './shared.scss';
 import './app.scss';
-
-const hiddenUnless = isVisible => (isVisible ? '' : 'hidden');
 
 let warnedAboutLegacyPanes = false;
 const convertLegacy = pane => {
@@ -126,9 +125,10 @@ const ConnectedApp = ({
             <NavBar deviceSelect={deviceSelect} />
             <div className="core19-app-content">
                 <div
-                    className={`core19-side-panel-container ${hiddenUnless(
-                        isSidePanelVisible
-                    )}`}
+                    className={classNames(
+                        'core19-side-panel-container',
+                        isSidePanelVisible || 'hidden'
+                    )}
                 >
                     {sidePanel}
                 </div>
@@ -150,9 +150,10 @@ const ConnectedApp = ({
                         ))}
                     </Carousel>
                     <div
-                        className={`core19-log-viewer ${hiddenUnless(
-                            isLogVisible
-                        )}`}
+                        className={classNames(
+                            'core19-log-viewer',
+                            isLogVisible || 'hidden'
+                        )}
                     >
                         <LogViewer />
                     </div>


### PR DESCRIPTION
This is part of [NCP-3569](https://projecttools.nordicsemi.no/jira/browse/NCP-3569).

This enables apps to define side panels that can vary by pane, as [described in the Changelog](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/blob/18b81709777c8464d994fe9e65505e2bc96a5fce/Changelog.md#added). 

A very simple demonstration is [the branch `demonstration/sidepanel_per_pane` in PPK](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/compare/demonstration/sidepanel_per_pane) (requires a launcher that also uses a version of `shared` that incorporates this change).