### PR TITLE
Use the app's package.json

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,16 @@
 ## 4.21.0
 ### Added
 - Property `reportUsageData` to component App.
+- Function `getPersistentStore` to get a persistent store, specific for the
+  app. The app name from `package.json` is used to identify the app.
 ### Steps to upgrade when using this package
 - If your app wants to report usage data, you can remove the code to call
   `usageData.init()` and instead set the property `reportUsageData` to the
   component `App`.
+- If your app already use a persistent store, you can switch to
+  `getPersistentStore()`, just be aware that if you currently use a different
+  name for the store than the app name from `package.json`, then the old
+  settings are either lost of you have to care for migrating them.
 
 ## 4.20.0
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 4.21.0
+### Added
+- Property `reportUsageData` to component App.
+### Steps to upgrade when using this package
+- If your app wants to report usage data, you can remove the code to call
+  `usageData.init()` and instead set the property `reportUsageData` to the
+  component `App`.
+
 ## 4.20.0
 ### Changed
 - Extended type definition `PackageJson`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare module 'pc-nrfconnect-shared' {
     import { Reducer, AnyAction } from 'redux';
     import React from 'react';
     import winston from 'winston';
+    import Store from 'electron-store';
 
     // State
 
@@ -554,4 +555,12 @@ declare module 'pc-nrfconnect-shared' {
     export function currentPane<AppState>(
         state: NrfConnectState<AppState>
     ): number;
+
+    // persistentStore.ts
+
+    /**
+     * Return a persistent store, specific for the app.
+     * The app name from package.json is used to identify the app.
+     */
+    export function getPersistentStore<StoreSchema>(): Store<StoreSchema>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,11 @@ declare module 'pc-nrfconnect-shared' {
          * application starts. Defaults to `true`.
          */
         showLogByDefault?: boolean;
+        /**
+         * Whether to initialise google analytics for usage data if the users
+         * opted in. Defaults to `false`.
+         */
+        reportUsageData?: boolean;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.20.0",
+    "version": "4.21.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -58,6 +58,8 @@ import ErrorDialog from '../ErrorDialog/ErrorDialog';
 import LogViewer from '../Log/LogViewer';
 import NavBar from '../NavBar/NavBar';
 import classNames from '../utils/classNames';
+import packageJson from '../utils/packageJson';
+import usageData from '../utils/usageData';
 import useHotKey from '../utils/useHotKey';
 import {
     currentPane as currentPaneSelector,
@@ -92,11 +94,25 @@ const convertLegacy = pane => {
     };
 };
 
+let usageDataAlreadyInitialised = false;
+const initialiseUsageData = async () => {
+    if (!usageDataAlreadyInitialised) {
+        usageDataAlreadyInitialised = true;
+        try {
+            await usageData.init(packageJson());
+        } catch (error) {
+            // No need to display the error message for the user
+            console.log(error);
+        }
+    }
+};
+
 const ConnectedApp = ({
     deviceSelect,
     panes,
     sidePanel,
     showLogByDefault = true,
+    reportUsageData = false,
 }) => {
     const allPanes = useMemo(
         () => [...panes, { name: 'About', Main: About }].map(convertLegacy),
@@ -124,6 +140,12 @@ const ConnectedApp = ({
 
     const isSidePanelVisible =
         useSelector(isSidePanelVisibleSelector) && currentSidePanel;
+
+    useEffect(() => {
+        if (reportUsageData) {
+            initialiseUsageData();
+        }
+    }, [reportUsageData]);
 
     return (
         <div className="core19-app">
@@ -186,6 +208,7 @@ ConnectedApp.propTypes = {
         .isRequired,
     sidePanel: node,
     showLogByDefault: bool,
+    reportUsageData: bool,
 };
 
 const noopReducer = (state = null) => state;

--- a/src/index.js
+++ b/src/index.js
@@ -76,3 +76,5 @@ export { default as classNames } from './utils/classNames';
 export { default as useHotKey } from './utils/useHotKey';
 
 export { currentPane, setCurrentPane } from './App/appLayout';
+
+export { getAppSpecificStore as getPersistentStore } from './utils/persistentStore';

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -38,26 +38,43 @@ import Store from 'electron-store';
 
 import packageJson from './packageJson';
 
-export const store = new Store({ name: 'pc-nrfconnect-shared' });
+const sharedStore = new Store({ name: 'pc-nrfconnect-shared' });
 
 export const persistNickname = (serialNumber: string, nickname: string) =>
-    store.set(`${serialNumber}.name`, nickname);
+    sharedStore.set(`${serialNumber}.name`, nickname);
 export const getPersistedNickname = (serialNumber: string) =>
-    store.get(`${serialNumber}.name`, '') as string;
+    sharedStore.get(`${serialNumber}.name`, '') as string;
 
 export const persistIsFavorite = (serialNumber: string, value: boolean) =>
-    store.set(`${serialNumber}.fav`, value);
+    sharedStore.set(`${serialNumber}.fav`, value);
 export const getPersistedIsFavorite = (serialNumber: string) =>
-    store.get(`${serialNumber}.fav`, false) as boolean;
+    sharedStore.get(`${serialNumber}.fav`, false) as boolean;
 
 export const persistIsSendingUsageData = (value: boolean) =>
-    store.set('isSendingUsageData', value);
+    sharedStore.set('isSendingUsageData', value);
 export const getIsSendingUsageData = () =>
-    store.get('isSendingUsageData', undefined) as boolean | undefined;
+    sharedStore.get('isSendingUsageData', undefined) as boolean | undefined;
 export const deleteIsSendingUsageData = () =>
-    store.delete('isSendingUsageData');
+    sharedStore.delete('isSendingUsageData');
+
+// This one must be initialised lazily, because the package.json is not read yet when this module is initialised
+let appSpecificStore: Store | undefined;
+
+interface sharedAppSpecificStoreSchema {
+    currentPane?: number;
+}
+
+export const getAppSpecificStore = <StoreSchema>() => {
+    if (appSpecificStore == null) {
+        appSpecificStore = new Store({ name: packageJson().name });
+    }
+
+    return appSpecificStore as Store<
+        StoreSchema | sharedAppSpecificStoreSchema
+    >;
+};
 
 export const persistCurrentPane = (currentPane: number) =>
-    store.set(`app.${packageJson().name}.currentPane`, currentPane);
+    getAppSpecificStore<never>().set(`currentPane`, currentPane);
 export const getPersistedCurrentPane = () =>
-    store.get(`app.${packageJson().name}.currentPane`) as number | undefined;
+    getAppSpecificStore<never>().get(`currentPane`);


### PR DESCRIPTION
This is part of [NCP-3569](https://projecttools.nordicsemi.no/jira/browse/NCP-3569).

https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/139/commits/089dc10d3bf83eba2da4b96136f817b75f0b6d59 in #139 previously added the ability to `shared` to read and use the content of the app's `package.json`. This PR uses this for two things: usage data and the persistent store, as described in the changelog:

### Added
- Property `reportUsageData` to component App.
- Function `getPersistentStore` to get a persistent store, specific for the
  app. The app name from `package.json` is used to identify the app.
### Steps to upgrade when using this package
- If your app wants to report usage data, you can remove the code to call
  `usageData.init()` and instead set the property `reportUsageData` to the
  component `App`.
- If your app already use a persistent store, you can switch to
  `getPersistentStore()`, just be aware that if you currently use a different
  name for the store than the app name from `package.json`, then the old
  settings are either lost of you have to care for migrating them.