### PR TITLE
Missing export

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.21.1
+### Fixed
+- Exported colors were missing definitions for `black` and `white`.
+
 ## 4.21.0
 ### Added
 - Property `reportUsageData` to component App.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## 4.21.1
 ### Fixed
 - Exported colors were missing definitions for `black` and `white`.
+- The build scripts did not return a non-zero exit status on build errors.
 
 ## 4.21.0
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -414,6 +414,9 @@ declare module 'pc-nrfconnect-shared' {
         nordicBlue: string;
         blueSlate: string;
 
+        white: string;
+        black: string;
+
         primary: string;
         primaryDarkened: string;
         secondary: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.21.0",
+    "version": "4.21.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,18 +41,16 @@
 const path = require('path');
 const webpack = require('webpack');
 
-function getConfig() {
-    let config;
+const getConfig = () => {
     try {
         // Using custom webpack.config.js if it exists in project
-        config = require(path.join(process.cwd(), './webpack.config.js'));
+        return require(path.join(process.cwd(), './webpack.config.js'));
     } catch (err) {
-        config = require('../config/webpack.config.js');
+        return require('../config/webpack.config.js');
     }
-    return config;
-}
+};
 
-function handleOutput(err, stats) {
+const handleOutput = (err, stats) => {
     if (err) {
         console.error(err.stack || err);
         if (err.details) {
@@ -77,7 +75,7 @@ function handleOutput(err, stats) {
             colors: true, //  Shows colors in the console
         })
     );
-}
+};
 
 const args = process.argv.slice(2);
 if (args[0] === '--watch') {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -75,6 +75,8 @@ const handleOutput = (err, stats) => {
             colors: true, //  Shows colors in the console
         })
     );
+
+    process.exitCode = stats.hasErrors() ? 1 : 0;
 };
 
 const args = process.argv.slice(2);

--- a/src/utils/colors.scss
+++ b/src/utils/colors.scss
@@ -7,6 +7,9 @@
     nordicBlue: $nordic-blue;
     blueSlate: $blue-slate;
 
+    white: $white;
+    black: $black;
+
     primary: $primary;
     primaryDarkened: $primary-darkened;
     secondary: $secondary;


### PR DESCRIPTION
`$white` and `$black` are also used in some projects, so they are also had to be exported.

Also: When running `npm run webpack` or `npm run build` a build error did not lead to a non zero exit status to signal the error. This was corrected.