### PR TITLE
Prevent esModule syntax from url-loader

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.21.2
+### Fixed
+- `url-loader` changed their export, which broke code that imported images.
+
 ## 4.21.1
 ### Fixed
 - Exported colors were missing definitions for `black` and `white`.

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -113,6 +113,9 @@ module.exports = {
             {
                 test: /\.(png|gif|ttf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
                 loader: require.resolve('url-loader'),
+                options: {
+                    esModule: false,
+                },
             },
         ],
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.21.1",
+    "version": "4.21.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -59,7 +59,6 @@
         "eslint-plugin-react-hooks": "4.0.4",
         "eslint-plugin-simple-import-sort": "7.0.0",
         "eslint-webpack-plugin": "^2.1.0",
-        "file-loader": "6.0.0",
         "focus-visible": "5.1.0",
         "ftp": "0.3.10",
         "husky": "4.2.5",


### PR DESCRIPTION
In a recent major release of `url-loader` it started using ES module syntax by default. This breaks some of our imports, so we prefer to not utilize this behavior for now.