### PR TITLE
Wrong current pane could crash the app.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## 4.22.1
+### Fixed
+- Wrong current pane could crash the app: E.g. when an app previously had four
+  panes, it was persisted that the user was previously on the last pane and a
+  new release of the app has just a single pane then the app crashes when that
+  user opens the app again.
+
 ## 4.22.0
 ### Added
 - Component `Card`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.22.0",
+    "version": "4.22.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/appLayout.js
+++ b/src/App/appLayout.js
@@ -94,5 +94,7 @@ export const reducer = (
 
 export const isSidePanelVisible = state => state.appLayout.isSidePanelVisible;
 export const isLogVisible = state => state.appLayout.isLogVisible;
-export const currentPane = state => state.appLayout.currentPane;
 export const panes = state => state.appLayout.panes;
+
+export const currentPane = ({ appLayout }) =>
+    appLayout.currentPane >= appLayout.panes.length ? 0 : appLayout.currentPane;


### PR DESCRIPTION
E.g. when an app previously had four panes, it was persisted that the user was
previously on the last pane and a new release of the app has just a single pane
then the app crashes when that user opens the app again.