### PR TITLE
Fix: Type of Toggle props were slightly wrong

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.22.2
+### Fixed
+- Type of `Toggle` props were slightly wrong.
+
 ## 4.22.1
 ### Fixed
 - Wrong current pane could crash the app: E.g. when an app previously had four

--- a/index.d.ts
+++ b/index.d.ts
@@ -400,13 +400,13 @@ declare module 'pc-nrfconnect-shared' {
         id?: string;
         title?: string;
         isToggled?: boolean;
-        onToggle: (isToggled: boolean) => void;
+        onToggle?: (isToggled: boolean) => void;
         variant?: 'primary' | 'secondary';
         barColor?: string;
-        barToggledColor?: string;
+        barColorToggled?: string;
         handleColor?: string;
         handleColorToggled?: string;
-        label: string;
+        label?: string;
         labelRight?: boolean;
         width?: string;
         disabled?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.22.1",
+    "version": "4.22.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
- `onToggle` is optional. It can be `undefined`, to use the toggle
  just for decoration or to show a current value.
- `barToggledColor` was wrong, correct is `barColorToggled`.
- `label` is optional. When `children` are specified the `label` is not
  used anyhow. If neither `children` nor a `label` is specified, then
  there simply will be no label.