### PR TITLE
Allow overriding of reporting and factory reset in error boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.22.2",
+    "version": "4.23.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.23.0",
+    "version": "4.23.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR is in preparation for the changes in Launcher which will implement [https://trello.com/c/Ktagc7cB/74-add-error-boundaries-to-launcher-itself](https://trello.com/c/Ktagc7cB/74-add-error-boundaries-to-launcher-itself). 

The changes allow for overriding GA event sending and factory reset / restoring default settings.