### PR TITLE
Fix layout breakage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+## 4.25.0
+### Fixed
+- Remove namespace pollution by `Card` component, which broke the layout of the
+  Toolchain Manager.
+### Changed
+- This version enables CSS modules. To use them, the CSS filename needs to
+  include `.module.` and you need to import that CSS file and use its content
+  in your JSX files as you can see in the `Card` component.
+
 ## 4.24.0
 ### Added
 - Component `FactoryResetButton`. This component is also added to the `About` pane.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 ### Added
 - Component `FactoryResetButton`. This component is also added to the `About` pane.
 
+## 4.23.1
+### Changed
+- Allow overriding GA reporting and restore default functionality in `ErrorBoundary`
+  component.
+
 ## 4.23.0
 ### Added
 - Error robustness

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.24.0",
+    "version": "4.25.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4075,52 +4075,55 @@
             }
         },
         "css-loader": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.3.tgz",
-            "integrity": "sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.6.tgz",
+            "integrity": "sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==",
             "requires": {
-                "camelcase": "^5.3.1",
-                "cssesc": "^3.0.0",
-                "icss-utils": "^4.1.1",
-                "loader-utils": "^1.2.3",
-                "normalize-path": "^3.0.0",
-                "postcss": "^7.0.27",
-                "postcss-modules-extract-imports": "^2.0.0",
-                "postcss-modules-local-by-default": "^3.0.2",
-                "postcss-modules-scope": "^2.2.0",
-                "postcss-modules-values": "^3.0.0",
-                "postcss-value-parser": "^4.0.3",
-                "schema-utils": "^2.6.6",
-                "semver": "^6.3.0"
+                "icss-utils": "^5.1.0",
+                "loader-utils": "^2.0.0",
+                "postcss": "^8.2.15",
+                "postcss-modules-extract-imports": "^3.0.0",
+                "postcss-modules-local-by-default": "^4.0.0",
+                "postcss-modules-scope": "^3.0.0",
+                "postcss-modules-values": "^4.0.0",
+                "postcss-value-parser": "^4.1.0",
+                "schema-utils": "^3.0.0",
+                "semver": "^7.3.5"
             },
             "dependencies": {
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
                     "requires": {
-                        "minimist": "^1.2.0"
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+                },
+                "schema-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+                    "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
                     "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
+                        "@types/json-schema": "^7.0.6",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
                     }
                 },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
                 }
             }
         },
@@ -6667,12 +6670,9 @@
             }
         },
         "icss-utils": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-            "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-            "requires": {
-                "postcss": "^7.0.14"
-            }
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
         },
         "ieee754": {
             "version": "1.2.1",
@@ -9280,6 +9280,11 @@
             "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
             "optional": true
         },
+        "nanoid": {
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9844,71 +9849,50 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+            "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
             "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "colorette": "^1.2.2",
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
             }
         },
         "postcss-modules-extract-imports": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-            "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-            "requires": {
-                "postcss": "^7.0.5"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
         },
         "postcss-modules-local-by-default": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-            "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
             "requires": {
-                "icss-utils": "^4.1.1",
-                "postcss": "^7.0.32",
+                "icss-utils": "^5.0.0",
                 "postcss-selector-parser": "^6.0.2",
                 "postcss-value-parser": "^4.1.0"
             }
         },
         "postcss-modules-scope": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-            "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
             "requires": {
-                "postcss": "^7.0.6",
-                "postcss-selector-parser": "^6.0.0"
+                "postcss-selector-parser": "^6.0.4"
             }
         },
         "postcss-modules-values": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-            "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
             "requires": {
-                "icss-utils": "^4.0.0",
-                "postcss": "^7.0.6"
+                "icss-utils": "^5.0.0"
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
-            "integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
             "requires": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -11198,6 +11182,11 @@
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
         },
         "source-map-resolve": {
             "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.24.0",
+    "version": "4.25.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -43,7 +43,7 @@
         "babel-plugin-add-module-exports": "1.0.2",
         "commander": "5.1.0",
         "cross-env": "7.0.2",
-        "css-loader": "3.5.3",
+        "css-loader": "5.2.6",
         "date-fns": "^2.16.1",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.2",

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -37,15 +37,15 @@ import React from 'react';
 import Card from 'react-bootstrap/Card';
 import { element } from 'prop-types';
 
-import './card.scss';
+import styles from './card.module.scss';
 
 const NrfCard: React.FC<{
     title: React.ReactElement;
 }> = ({ children, title }) => (
-    <Card className="nrf-card">
-        <Card.Header className="header">
+    <Card className={styles.card}>
+        <Card.Header className={styles.header}>
             <Card.Title>
-                <span className="title">{title}</span>
+                <span className={styles.title}>{title}</span>
             </Card.Title>
         </Card.Header>
         <Card.Body>{children}</Card.Body>

--- a/src/Card/card.module.scss
+++ b/src/Card/card.module.scss
@@ -1,4 +1,4 @@
-.nrf-card {
+.card {
     &:nth-child(3n + 1) {
         margin-left: 0;
     }
@@ -12,14 +12,14 @@
     max-width: 20em;
     flex-shrink: 0;
     padding: 0.6em 0.6em;
+}
 
-    .header {
-        background-color: transparent;
-        text-align: center;
+.header {
+    background-color: transparent;
+    text-align: center;
+}
 
-        .title {
-            float: inherit;
-            padding-top: 5px;
-        }
-    }
+.title {
+    float: inherit;
+    padding-top: 5px;
 }

--- a/src/css.module.d.ts
+++ b/src/css.module.d.ts
@@ -1,0 +1,6 @@
+declare module '*.module.scss' {
+    const classNames: {
+        [className: string]: string;
+    };
+    export = classNames;
+}


### PR DESCRIPTION
For https://trello.com/c/IHlj9mlX/119-fix-layout-issue-introduced-for-the-toolchain-manager:

The CSS class name `nrf-card` used in the `Card` component clashed with a likewise class name in the toolchain manager.

To fix the problem but also demonstrate how we can prevent such problems in the future, this commit switches in the `Card` component from traditional CSS class names to [CSS modules](https://github.com/css-modules/css-modules).

If you want to use CSS modules anywhere, the CSS filename needs to include `.module.` and you need to import that CSS file and use its content in your JSX files as you can see in the `Card` component.
