### PR TITLE
Fix/minor issues

### DIFF
--- a/src/About/ApplicationCard.jsx
+++ b/src/About/ApplicationCard.jsx
@@ -73,7 +73,11 @@ export default () => {
                 />
             </Section>
             <Section>
-                <FactoryResetButton label="Restore defaults..." />
+                <FactoryResetButton
+                    label="Restore defaults..."
+                    classNames="w-100"
+                    variant="secondary"
+                />
             </Section>
         </Card>
     );

--- a/src/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/ErrorBoundary/ErrorBoundary.jsx
@@ -147,6 +147,7 @@ class ErrorBoundary extends React.Component {
                         <FactoryResetButton
                             resetFn={restoreDefaults || this.restoreDefaults}
                             label="Restore default settings"
+                            variant="primary"
                         />
                     </div>
                 </div>

--- a/src/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/ErrorBoundary/ErrorBoundary.jsx
@@ -48,6 +48,7 @@ import { getAppSpecificStore as store } from '../utils/persistentStore';
 import { generateSystemReport } from '../utils/systemReport';
 import {
     init as initGA,
+    isEnabled,
     isInitialized as isGAInitialized,
     sendErrorReport,
 } from '../utils/usageData';
@@ -58,6 +59,9 @@ import './error-boundary.scss';
 const { getCurrentWindow } = require('electron').remote;
 
 const sendGAEvent = error => {
+    if (!isEnabled()) {
+        return;
+    }
     if (!isGAInitialized()) {
         initGA(packageJson()).then(() => sendErrorReport(error));
         return;

--- a/src/ErrorBoundary/ErrorBoundary.test.jsx
+++ b/src/ErrorBoundary/ErrorBoundary.test.jsx
@@ -45,6 +45,10 @@ import ErrorBoundary from './ErrorBoundary';
 
 jest.mock('../utils/systemReport');
 jest.mock('react-ga');
+jest.mock('../utils/usageData', () => ({
+    ...jest.requireActual('../utils/usageData'),
+    isEnabled: () => true,
+}));
 
 const SYSTEM_REPORT = 'system report';
 const OKBUTTONTEXT = 'Restore';

--- a/src/FactoryReset/FactoryResetButton.jsx
+++ b/src/FactoryReset/FactoryResetButton.jsx
@@ -47,7 +47,13 @@ import './factory-reset-button.scss';
 const DEFAULT_MODAL_TEXT =
     'By restoring defaults, all stored app-specific configuration values will be lost. This does not include configurations such as device renames and favorites. Are you sure you want to proceed?';
 
-const FactoryResetButton = ({ resetFn, label, modalText }) => {
+const FactoryResetButton = ({
+    resetFn,
+    label,
+    modalText,
+    variant,
+    classNames,
+}) => {
     const [isFactoryResetting, setIsFactoryResetting] = useState(false);
 
     const defaultResetFn = () => {
@@ -59,9 +65,9 @@ const FactoryResetButton = ({ resetFn, label, modalText }) => {
     return (
         <>
             <Button
-                variant="secondary"
+                variant={variant || 'secondary'}
                 onClick={() => setIsFactoryResetting(true)}
-                className="w-100"
+                className={classNames}
             >
                 {label}
             </Button>
@@ -82,6 +88,8 @@ FactoryResetButton.propTypes = {
     resetFn: func,
     label: string.isRequired,
     modalText: string,
+    variant: string,
+    classNames: string,
 };
 
 export default FactoryResetButton;


### PR DESCRIPTION
This PR addresses two seperate issues:

1.  GA events were sent even when the user had not consented.
2. `Restore defaults` button styling inside `ErrorBoundary` component was broken.
![image](https://user-images.githubusercontent.com/72191781/122009325-429b0980-cdba-11eb-9d7b-d37213f23f2b.png)
