### PR TITLE
Pin the prettier version to exact version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+## 4.28.0
+### Updated
+- Pin the version of prettier to be used to an exact version, as
+  [recommended in the prettier documentation](https://prettier.io/docs/en/install.html).
+### Steps to upgrade when using this package
+- If you are using an older prettier version than 2.3.0, upgrading to this
+  version of shared can likely cause linting to fail due to formatting errors.
+  The majority of these can be fixed automatically, by running
+  `npm run lint -- --fix`.
+
 ## 4.27.3
 ### Fixed
 - Exported `colors` object was empty.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.27.1",
+    "version": "4.28.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10296,9 +10296,9 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
         },
         "prettier": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-            "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+            "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA=="
         },
         "prettier-linter-helpers": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.27.3",
+    "version": "4.28.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -68,7 +68,7 @@
         "klaw": "3.0.0",
         "lodash.range": "3.2.0",
         "mousetrap": "1.6.5",
-        "prettier": "^2.1.1",
+        "prettier": "2.3.1",
         "prettysize": "2.0.0",
         "react-bootstrap": "1.0.1",
         "react-flip-toolkit": "7.0.12",


### PR DESCRIPTION
This is a practice [recommended in the prettier
documentation](https://prettier.io/docs/en/install.html). Not doing it
so far led to unwanted behaviour: When updating to any new version of
`pc-nrfconnect-shared` in an app or the launcher, the formatting might
change, even though it is not mentioned in the Changelog.

This could happen, because pc-nrfconnect-shared until this commit
only depended on version `^2.1.1` of prettier. If e.g. a version 2.2.0
of prettier was released, installing any new version of
pc-nrfconnect-shared led to also installing prettier 2.2.0.