### PR TITLE
Add app version to appJson file on publish

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## 4.28.2
+### Updated
+- Added app version to `apps.json` in the specified source, to be able to show the
+  current version in the launcher even for uninstalled apps.
+
 ## 4.28.1
 ### Updated
 - Increase padding for `Card` component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.28.0",
+    "version": "4.28.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.28.1",
+    "version": "4.28.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/nordic-publish.js
+++ b/scripts/nordic-publish.js
@@ -178,6 +178,20 @@ function putFile(local, remote) {
     });
 }
 
+function addVersionToAppJson(packageName, version) {
+    return new Promise((resolve, reject) => {
+        getFile('apps.json')
+            .then(content => {
+                const data = JSON.parse(content);
+                data[packageName].version = version;
+                putFile(Buffer.from(JSON.stringify(data, null, 4)), 'apps.json')
+                    .then(resolve)
+                    .catch(reject);
+            })
+            .catch(reject);
+    });
+}
+
 /**
  * Calculate SHASUM checksum of file
  *
@@ -272,6 +286,7 @@ Promise.resolve()
 
         return meta;
     })
+    .then(() => addVersionToAppJson(thisPackage.name, thisPackage.version))
     .then(meta => putFile(Buffer.from(JSON.stringify(meta)), thisPackage.name))
     .then(() => putFile(thisPackage.filename, thisPackage.filename))
     .then(() => uploadChangelog(thisPackage.name))


### PR DESCRIPTION
This PR starts to implement [https://trello.com/c/zdRvVOnt/171-add-versions-in-the-app-list-in-the-launcher](https://trello.com/c/zdRvVOnt/171-add-versions-in-the-app-list-in-the-launcher). This part will add the app version to the `apps.json` file in the given source on Release/publish. That version can then be displayed later in the launcher.

![image](https://user-images.githubusercontent.com/72191781/123973734-4df65380-d9bc-11eb-9df5-a2b0891ced76.png)
