### PR TITLE
Add support for @nordicsemiconductor/nrf-device-lib-js

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 4.28.2
+### Updated
+- Added `@nordicsemiconductor/nrf-device-lib-js` in webpack.config.js
+
 ## 4.28.1
 ### Updated
 - Increase padding for `Card` component.

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -25,6 +25,7 @@ function createExternals() {
         'nrf-device-setup',
         'nrfconnect/core',
         'pc-nrfconnect-shared',
+        '@nordicsemiconductor/nrf-device-lib-js',
     ];
 
     // Libs provided by the app at runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.28.0",
+    "version": "4.28.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.28.1",
+    "version": "4.28.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR is to add scope for nrf-device-lib-js in webpack.