### PR TITLE
Log the versions of our low level libraries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Log the versions of our low level libraries.
 
 ## 4.28.2 - 2021-07-19
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,7 +1767,7 @@
         "@nordicsemiconductor/nrf-device-lib-js": {
             "version": "0.3.12",
             "resolved": "https://npm.nordicsemi.no/@nordicsemiconductor%2fnrf-device-lib-js/-/nrf-device-lib-js-0.3.12.tgz",
-            "integrity": "sha512-91SJwqgml3j7UdjuA1ZtaRHhP0nPLT4CdlHTDF3XSxqHQBscc44nisCUrq835tfzRCIybK/Mex3RlllmgQAW4w==",
+            "integrity": "sha512-CtyozRpEZopBiM/QUUj9JuvucK1hhqz4i87+ATREHDwTpmXzCK2YEJ4TytP7DFrAqDPIVYvzWmdE96gR61mugw==",
             "dev": true,
             "requires": {
                 "axios": "0.21.1",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -59,6 +59,7 @@ import ErrorDialog from '../ErrorDialog/ErrorDialog';
 import LogViewer from '../Log/LogViewer';
 import NavBar from '../NavBar/NavBar';
 import classNames from '../utils/classNames';
+import logLibVersions from '../utils/logLibVersions';
 import packageJson from '../utils/packageJson';
 import usageData from '../utils/usageData';
 import useHotKey from '../utils/useHotKey';
@@ -74,6 +75,8 @@ import VisibilityBar from './VisibilityBar';
 
 import './shared.scss';
 import './app.scss';
+
+logLibVersions();
 
 let warnedAboutLegacyPanes = false;
 const convertLegacy = pane => {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -1,0 +1,80 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import nrfdl, { SemanticVersion } from '@nordicsemiconductor/nrf-device-lib-js';
+
+import { deviceLibContext } from '../Device/deviceLister';
+import logger from '../logging';
+
+export default async () => {
+    try {
+        const versions = await nrfdl.getModuleVersions(deviceLibContext);
+
+        // Get @nordicsemiconductor/nrf-device-lib-js version
+        const nrfdlJsVersion = versions.find(
+            (v: nrfdl.ModuleVersion) => v.moduleName === 'nrfdl-js'
+        )!.version as SemanticVersion;
+        const nrfdlJsVersionString = `${nrfdlJsVersion.major}.${nrfdlJsVersion.minor}.${nrfdlJsVersion.patch}`;
+        logger.info(
+            'Using @nordicsemiconductor/nrf-device-lib-js version',
+            nrfdlJsVersionString
+        );
+
+        // Get nrf-device-lib version
+        const nrfdlVersion = versions.find(
+            (v: nrfdl.ModuleVersion) => v.moduleName === 'nrfdl'
+        )!.version as SemanticVersion;
+        const nrfdlVersionString = `${nrfdlVersion.major}.${nrfdlVersion.minor}.${nrfdlVersion.patch}`;
+        logger.info('Using nrf-device-lib version', nrfdlVersionString);
+
+        // Get nrfjprog dll version
+        const nrfjprogVersion = versions.find(
+            (v: nrfdl.ModuleVersion) => v.moduleName === 'nrfjprog_dll'
+        )!.version as SemanticVersion;
+        const nrfjprogVersionString = `${nrfjprogVersion.major}.${nrfjprogVersion.minor}.${nrfjprogVersion.patch}`;
+        logger.info('Using nrfjprog dll version', nrfjprogVersionString);
+
+        // Get jLink dll version
+        const jlinkVersion = versions.find(
+            (v: nrfdl.ModuleVersion) => v.moduleName === 'jlink_dll'
+        )!.version as SemanticVersion;
+        logger.info('Using JLink version', jlinkVersion);
+    } catch (error) {
+        logger.error(
+            `Failed to get the library versions: ${error.message || error}`
+        );
+    }
+};

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -47,9 +47,12 @@ const logVersion = (
     moduleName: string,
     description: string
 ) => {
-    const nrfdlJsVersion = versions.find(v => v.moduleName === moduleName)!
-        .version as SemanticVersion;
-    const nrfdlJsVersionString = `${nrfdlJsVersion.major}.${nrfdlJsVersion.minor}.${nrfdlJsVersion.patch}`;
+    const nrfdlJsVersion = versions.find(v => v.moduleName === moduleName)
+        ?.version as SemanticVersion;
+    const nrfdlJsVersionString =
+        nrfdlJsVersion == null
+            ? 'Unknown'
+            : `${nrfdlJsVersion.major}.${nrfdlJsVersion.minor}.${nrfdlJsVersion.patch}`;
     logger.verbose(`Using ${description} version: ${nrfdlJsVersionString}`);
 };
 

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -34,26 +34,32 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import nrfdl, {
-    ModuleVersion,
-    SemanticVersion,
-} from '@nordicsemiconductor/nrf-device-lib-js';
+import nrfdl, { ModuleVersion } from '@nordicsemiconductor/nrf-device-lib-js';
 
 import { deviceLibContext } from '../Device/deviceLister';
 import logger from '../logging';
+
+const describe = (version?: ModuleVersion) => {
+    if (version == null) {
+        return 'Unknown';
+    }
+
+    switch (version.versionFormat) {
+        case 'incremental':
+        case 'string':
+            return version.version;
+        case 'semantic':
+            return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
+    }
+};
 
 const logVersion = (
     versions: ModuleVersion[],
     moduleName: string,
     description: string
 ) => {
-    const nrfdlJsVersion = versions.find(v => v.moduleName === moduleName)
-        ?.version as SemanticVersion;
-    const nrfdlJsVersionString =
-        nrfdlJsVersion == null
-            ? 'Unknown'
-            : `${nrfdlJsVersion.major}.${nrfdlJsVersion.minor}.${nrfdlJsVersion.patch}`;
-    logger.verbose(`Using ${description} version: ${nrfdlJsVersionString}`);
+    const version = versions.find(v => v.moduleName === moduleName);
+    logger.verbose(`Using ${description} version: ${describe(version)}`);
 };
 
 export default async () => {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -34,44 +34,37 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import nrfdl, { SemanticVersion } from '@nordicsemiconductor/nrf-device-lib-js';
+import nrfdl, {
+    ModuleVersion,
+    SemanticVersion,
+} from '@nordicsemiconductor/nrf-device-lib-js';
 
 import { deviceLibContext } from '../Device/deviceLister';
 import logger from '../logging';
+
+const logVersion = (
+    versions: ModuleVersion[],
+    moduleName: string,
+    description: string
+) => {
+    const nrfdlJsVersion = versions.find(v => v.moduleName === moduleName)!
+        .version as SemanticVersion;
+    const nrfdlJsVersionString = `${nrfdlJsVersion.major}.${nrfdlJsVersion.minor}.${nrfdlJsVersion.patch}`;
+    logger.verbose(`Using ${description} version: ${nrfdlJsVersionString}`);
+};
 
 export default async () => {
     try {
         const versions = await nrfdl.getModuleVersions(deviceLibContext);
 
-        // Get @nordicsemiconductor/nrf-device-lib-js version
-        const nrfdlJsVersion = versions.find(
-            (v: nrfdl.ModuleVersion) => v.moduleName === 'nrfdl-js'
-        )!.version as SemanticVersion;
-        const nrfdlJsVersionString = `${nrfdlJsVersion.major}.${nrfdlJsVersion.minor}.${nrfdlJsVersion.patch}`;
-        logger.info(
-            'Using @nordicsemiconductor/nrf-device-lib-js version',
-            nrfdlJsVersionString
+        logVersion(
+            versions,
+            'nrfdl-js',
+            '@nordicsemiconductor/nrf-device-lib-js'
         );
-
-        // Get nrf-device-lib version
-        const nrfdlVersion = versions.find(
-            (v: nrfdl.ModuleVersion) => v.moduleName === 'nrfdl'
-        )!.version as SemanticVersion;
-        const nrfdlVersionString = `${nrfdlVersion.major}.${nrfdlVersion.minor}.${nrfdlVersion.patch}`;
-        logger.info('Using nrf-device-lib version', nrfdlVersionString);
-
-        // Get nrfjprog dll version
-        const nrfjprogVersion = versions.find(
-            (v: nrfdl.ModuleVersion) => v.moduleName === 'nrfjprog_dll'
-        )!.version as SemanticVersion;
-        const nrfjprogVersionString = `${nrfjprogVersion.major}.${nrfjprogVersion.minor}.${nrfjprogVersion.patch}`;
-        logger.info('Using nrfjprog dll version', nrfjprogVersionString);
-
-        // Get jLink dll version
-        const jlinkVersion = versions.find(
-            (v: nrfdl.ModuleVersion) => v.moduleName === 'jlink_dll'
-        )!.version as SemanticVersion;
-        logger.info('Using JLink version', jlinkVersion);
+        logVersion(versions, 'nrfdl', 'nrf-device-lib');
+        logVersion(versions, 'nrfjprog_dll', 'nrfjprog dll');
+        logVersion(versions, 'jlink_dll', 'JLink');
     } catch (error) {
         logger.error(
             `Failed to get the library versions: ${error.message || error}`


### PR DESCRIPTION
In the programmer app we already log the library versions. But this should rather be done here in shared, so that it happens for all apps. 