### PR TITLE
Fix/version log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.28.3",
+    "version": "4.29.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -44,13 +44,24 @@ const describe = (version?: ModuleVersion) => {
         return 'Unknown';
     }
 
-    switch (version.versionFormat) {
-        case 'incremental':
-        case 'string':
-            return version.version;
-        case 'semantic':
-            return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
-    }
+    // TODO: the format is updating in nrf-device-lib-js,
+    // and will be update in a newer version than v0.3.12
+    // switch (version.versionFormat) {
+    //     case 'incremental':
+    //     case 'string':
+    //         return version.version;
+    //     case 'semantic':
+    //         return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
+    // }
+
+    if (version.version)
+        return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
+    if (version.semantic)
+        return `${version.semantic.major}.${version.semantic.minor}.${version.semantic.patch}`;
+    if (version.incremental) return version.incremental;
+    if (version.string) return version.string;
+
+    return 'Unknown';
 };
 
 const logVersion = (

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -39,7 +39,8 @@ import nrfdl, { ModuleVersion } from '@nordicsemiconductor/nrf-device-lib-js';
 import { getDeviceLibContext } from '../Device/deviceLister';
 import logger from '../logging';
 
-const describe = (version?: ModuleVersion) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const describe = (version?: any) => {
     if (version == null) {
         return 'Unknown';
     }

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -45,7 +45,7 @@ const describe = (version?: ModuleVersion) => {
     }
 
     // TODO: the format is updating in nrf-device-lib-js,
-    // and will be update in a newer version than v0.3.12
+    // and will be updated in a newer version than v0.3.12
     // switch (version.versionFormat) {
     //     case 'incremental':
     //     case 'string':


### PR DESCRIPTION
This PR is to fix logging module versions.
This is how it looks like
![bilde](https://user-images.githubusercontent.com/4866953/131138883-54f80d5c-a494-4aa4-9acb-569d8aed7e83.png)

The current format is not consistent for different modules, they will be updated in a new version of nrf-device-lib-js
![MicrosoftTeams-image](https://user-images.githubusercontent.com/4866953/131136356-71f7a9d3-d357-4a32-875c-bbf43f33e1d5.png)
