### PR TITLE
Fix/css issue after chromium upgrade

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Log the versions of our low level libraries.
 - Component `Dropdown`.
+### Fixed
+- CSS issue where hidden content was scrollable
 
 ## 4.28.3 - 2021-08-11
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.29.0",
+    "version": "4.29.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/app.scss
+++ b/src/App/app.scss
@@ -1,4 +1,4 @@
-@import "../variables";
+@import '../variables';
 
 .core19-app {
     background-color: $gray-50;
@@ -42,12 +42,16 @@
             overflow: hidden;
             width: 100%;
 
-            margin-bottom: 0;
-            transition: margin-bottom $normal-transition;
+            max-height: $log-viewer-height;
+            transition: max-height $normal-transition;
 
-            &.hidden { margin-bottom: -$log-viewer-height; }
+            &.hidden {
+                max-height: 0;
+            }
 
-            &:hover { color: $gray-100; }
+            &:hover {
+                color: $gray-100;
+            }
         }
     }
 
@@ -59,7 +63,9 @@
         margin-left: 0;
         transition: margin-left $normal-transition;
 
-        &.hidden { margin-left: -$side-panel-width; }
+        &.hidden {
+            margin-left: -$side-panel-width;
+        }
 
         overflow-y: overlay;
         @include scrollbars($gray-50);

--- a/src/App/shared.scss
+++ b/src/App/shared.scss
@@ -1,22 +1,25 @@
-$roboto-font-path: "~roboto-fontface/fonts" !default;
-@import "~roboto-fontface/css/roboto/sass/roboto-fontface";
+$roboto-font-path: '~roboto-fontface/fonts' !default;
+@import '~roboto-fontface/css/roboto/sass/roboto-fontface';
 
-@import "~@mdi/font/css/materialdesignicons.min.css";
-@import "../variables";
-@import "~bootstrap/scss/bootstrap";
+@import '~@mdi/font/css/materialdesignicons.min.css';
+@import '../variables';
+@import '~bootstrap/scss/bootstrap';
 
 @each $color, $value in $theme-colors {
     .btn-#{$color} {
         border-color: $gray-200;
 
-        &.disabled,&:disabled {
+        &.disabled,
+        &:disabled {
             color: $gray-300;
             border-color: $gray-100;
         }
     }
 }
 
-html, body, #webapp {
+html,
+body,
+#webapp {
     height: 100%;
 
     .core19-app {
@@ -34,11 +37,13 @@ body {
     border-radius: 0px;
 }
 
-.disabled, :disabled {
+.disabled,
+:disabled {
     opacity: $disabled-opacity;
 
     // To prevent opacity from stacking up
-    .disabled, :disabled {
+    .disabled,
+    :disabled {
         opacity: 1;
     }
 }

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import FormLabel from 'react-bootstrap/FormLabel';
 import { arrayOf, bool, func, number, string } from 'prop-types';
 


### PR DESCRIPTION
This PR implements a fix for https://trello.com/c/IIuVvkIP/232-bug-possibly-related-to-log-in-apps-using-the-new-architecture

Likely this was caused by [this issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1150451#c9) introduced after upgrading Chromium past v86. How the bug looks in our apps can be seen [here](https://www.loom.com/share/3e531fe4dd2f4e7a8cfc3be3112d8c06).

I am not sure about the best approach to fix issue, but for this fix I tried using `max-height` instead of `margin-bottom` to control the size/position of the log window, which looks good to me at least.
