### PR TITLE
fix: display thingy91 device name in select device

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Component `Dropdown`.
 ### Fixed
 - CSS issue where hidden content was scrollable
+- Correctly displays Thingy91 in `SELECT DEVICE`
 
 ## 4.28.3 - 2021-08-11
 ### Fixed

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -193,10 +193,17 @@ const ppkDeviceInfo = (device: Device): DeviceInfo => ({
     },
 });
 
-const deviceByUsb = (device: Device) =>
-    isNordicDevice(device) && device.usb?.product?.startsWith('PPK')
-        ? ppkDeviceInfo(device)
-        : null;
+const deviceByUsb = (device: Device) => {
+    if (isNordicDevice(device)) {
+        if (device.usb?.product?.startsWith('PPK')) {
+            return ppkDeviceInfo(device);
+        }
+        if (device.serialNumber.startsWith('THINGY91')) {
+            return devicesByPca.PCA20035;
+        }
+    }
+    return null;
+};
 
 const unknownDevice = (device: Device): DeviceInfo => ({
     name: device.usb?.product,


### PR DESCRIPTION
The thingy91 does not display a boardVersion, and therefore it is not
properly mapped to the PCA. This commit implements a soltuion to detect
the thingy91 from the serialNumber instead.

## Previously Unknown
![image](https://user-images.githubusercontent.com/34618612/132526544-9219c895-4041-42b4-b21b-353b6ee5bad3.png)


## Fix now display correct device name
![image](https://user-images.githubusercontent.com/34618612/132526505-ba2f3816-efeb-4b7b-8d69-4b031ecf70f8.png)
