### PR TITLE
Turn off rule to allow explicit export without default

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -14,6 +14,7 @@
         "react/jsx-one-expression-per-line": "off",
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
+        "import/prefer-default-export": "off",
         "react/jsx-filename-extension": [1, { "extensions": [".jsx", ".tsx"] }],
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "error",


### PR DESCRIPTION
Turn of rule that requires a default export if there is only a single export. No code is expected to be able to break from this change.