### PR TITLE
Expose documentation url as a prop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSS issue where hidden content was scrollable
 - Correctly displays Thingy91 in `SELECT DEVICE`
 
+## 4.29.2
+### Changed
+- Exposed a way for apps to configure documentation url.
+
 ## 4.28.3 - 2021-08-11
 ### Fixed
 - Correct a typing for devices

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSS issue where hidden content was scrollable
 - Correctly displays Thingy91 in `SELECT DEVICE`
 
-## 4.29.2
+## 4.29.2 - 2021-09-14
 ### Changed
 - Exposed a way for apps to configure documentation url.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,6 +130,12 @@ declare module 'pc-nrfconnect-shared' {
          * opted in. Defaults to `false`.
          */
         reportUsageData?: boolean;
+
+        /**
+         * Url used to redirect the user to the given to the apps homepage or
+         * documentations url.
+         */
+        documentationUrl?: string;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.29.0",
+    "version": "4.29.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "4.29.1",
+    "version": "4.29.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -117,6 +117,7 @@ const ConnectedApp = ({
     sidePanel,
     showLogByDefault = true,
     reportUsageData = false,
+    documentationUrl,
 }) => {
     const allPanes = useMemo(
         () => [...panes, { name: 'About', Main: About }].map(convertLegacy),
@@ -153,7 +154,10 @@ const ConnectedApp = ({
 
     return (
         <div className="core19-app">
-            <NavBar deviceSelect={deviceSelect} />
+            <NavBar
+                deviceSelect={deviceSelect}
+                documentationUrl={documentationUrl}
+            />
             <div className="core19-app-content">
                 <div
                     className={classNames(
@@ -213,6 +217,7 @@ ConnectedApp.propTypes = {
     sidePanel: node,
     showLogByDefault: bool,
     reportUsageData: bool,
+    documentationUrl: string,
 };
 
 const noopReducer = (state = null) => state;

--- a/src/Logo/Logo.jsx
+++ b/src/Logo/Logo.jsx
@@ -36,7 +36,7 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { bool } from 'prop-types';
+import { bool, string } from 'prop-types';
 
 import { deviceIsSelected as deviceIsSelectedSelector } from '../Device/deviceReducer';
 import { openUrl } from '../utils/open';
@@ -46,8 +46,7 @@ import logoUniform from './nordic-logo-white-icon-only.png';
 
 import './logo.scss';
 
-const goToNRFConnectWebsite = () =>
-    openUrl('http://www.nordicsemi.com/nRFConnect');
+const goToNRFConnectWebsite = url => () => openUrl(url);
 
 const chooseLogo = (changeWithDeviceState, deviceIsSelected) => {
     if (!changeWithDeviceState) {
@@ -57,7 +56,10 @@ const chooseLogo = (changeWithDeviceState, deviceIsSelected) => {
     return deviceIsSelected ? logoConnected : logoDisconnected;
 };
 
-const Logo = ({ changeWithDeviceState = false }) => {
+const Logo = ({
+    changeWithDeviceState = false,
+    documentationUrl = 'http://www.nordicsemi.com/nRFConnect',
+}) => {
     const deviceIsSelected = useSelector(deviceIsSelectedSelector);
     const logo = chooseLogo(changeWithDeviceState, deviceIsSelected);
     return (
@@ -67,13 +69,13 @@ const Logo = ({ changeWithDeviceState = false }) => {
             alt="Nordic Semiconductor logo"
             // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
             role="link"
-            onClick={goToNRFConnectWebsite}
+            onClick={goToNRFConnectWebsite(documentationUrl)}
             onKeyPress={() => {}}
             tabIndex="0"
         />
     );
 };
 
-Logo.propTypes = { changeWithDeviceState: bool };
+Logo.propTypes = { changeWithDeviceState: bool, documentationUrl: string };
 
 export default Logo;

--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -35,25 +35,26 @@
  */
 
 import React from 'react';
-import { node } from 'prop-types';
+import { node, string } from 'prop-types';
 
 import Logo from '../Logo/Logo';
 import NavMenu from './NavMenu';
 
 import './nav-bar.scss';
 
-const NavBar = ({ deviceSelect }) => (
+const NavBar = ({ deviceSelect, documentationUrl }) => (
     <div className="core19-nav-bar">
         {deviceSelect && (
             <div className="core19-nav-bar-device-selector">{deviceSelect}</div>
         )}
         <NavMenu />
-        <Logo changeWithDeviceState />
+        <Logo changeWithDeviceState documentationUrl={documentationUrl} />
     </div>
 );
 
 NavBar.propTypes = {
     deviceSelect: node,
+    documentationUrl: string,
 };
 
 export default NavBar;


### PR DESCRIPTION
Allow apps to set a url for documentation.
```javascript
    <App
        documentationUrl="http://some-url.example"
```

The url will be opened when clicking the nordic logo in the app.

![image](https://user-images.githubusercontent.com/1006193/133231030-a9600a3e-ac78-4c3c-bc39-5fc0958eec0b.png)
