### PR TITLE
Use new api-method

### DIFF
--- a/src/utils/open.js
+++ b/src/utils/open.js
@@ -29,7 +29,7 @@ function openFile(filePath) {
     if (os.type() === 'Darwin') {
         childProcess.execSync(`open ${escapedPath}`);
     } else {
-        shell.openItem(escapedPath);
+        shell.openPath(escapedPath);
     }
 }
 


### PR DESCRIPTION
The openFile()-method was renamed to openPath() in electron 9 and also made async.

The open log button was affected.
![image](https://user-images.githubusercontent.com/1006193/133761007-0e5deef8-1b11-4d18-af3a-f9cd598cc504.png)
