### PR TITLE
Enhance license check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The license check now ignores all files in `.gitignore` and the folder
   `.git`. Before it just ignored `node_modules`, `dist`, and `.git`.
+### Fixed
+- With `npm run lint` the license check failed to run for shared on Windows.
 
 ## 5.0.1 - 2021-09-17
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.1.0 - 2021-09-23
+### Changed
+- The license check now ignores all files in `.gitignore` and the folder
+  `.git`. Before it just ignored `node_modules`, `dist`, and `.git`.
+
 ## 5.0.1 - 2021-09-17
 ### Fixed
 - Format of library version from nrf-device-lib-js.

--- a/bin/nrfconnect-license.mjs
+++ b/bin/nrfconnect-license.mjs
@@ -120,6 +120,14 @@ const checkLicense = () => {
     }
 };
 
+// Replace entries like '/node_modules' with something like 'node_modules/**'
+const replaceRootEntries = entry => entry.replace(/^\/(.*)/, '$1/**');
+
+const entriesInGitignore = readFileSync('.gitignore', { encoding: 'utf8' })
+    .trim()
+    .split(/\r?\n/)
+    .map(replaceRootEntries);
+
 const allSourceFiles = () =>
     glob.sync(
         [
@@ -133,7 +141,7 @@ const allSourceFiles = () =>
             '*.sass',
         ],
         {
-            ignore: ['node_modules', 'dist', '.git'],
+            ignore: [...entriesInGitignore, '.git'],
             baseNameMatch: true,
         }
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -84,17 +84,17 @@ const checkTypeScriptTypes = () => {
     return { promise: undefined, terminator: () => {} };
 };
 
-const runningInShared = existsSync('./bin/nrfconnect-license.mjs');
-const nrfconnectLicense = runningInShared
-    ? './bin/nrfconnect-license.mjs'
-    : 'nrfconnect-license';
-
 const checkLicenses = () => {
     if (packageJson.disableLicenseCheck) {
         return Promise.resolve();
     }
 
-    return spawnInPromise(nrfconnectLicense, ['check']);
+    const runningInShared = existsSync('./bin/nrfconnect-license.mjs');
+    const args = runningInShared
+        ? ['node', ['./bin/nrfconnect-license.mjs', 'check']]
+        : ['nrfconnect-license', ['check']];
+
+    return spawnInPromise(...args);
 };
 
 const checks = [


### PR DESCRIPTION
### Changed
- The license check now ignores all files in `.gitignore` and the folder
  `.git`. Before it just ignored `node_modules`, `dist`, and `.git`.
### Fixed
- With `npm run lint` the license check failed to run for shared on Windows.