### PR TITLE
Mixed bag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,10 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     flow.
   - Components which are displayed not at all, but are rendered just for other
     means, e.g. to dispatch Redux actions when the App is started.
+### Changed
+- Enabled two additional ESLint rules:
+  - [`require-await`](https://eslint.org/docs/rules/require-await), to
+    disallow async functions which have no await expression.
+  - [`react/jsx-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md),
+    to check that a key property is used for lists in JSX.
 ### Fixed
 - The property `allowCustomDevice` was used but missing in the type and props
   definitions for DeviceSetup.
 - Run complete setup for custom devices.
+### Steps to upgrade when using this package
+- The two newly enabled ESLint rules `require-await` and `react/jsx-key` may
+  require you to update some code. Please note that you should not blindly
+  remove an `async` in front of a function if there is no `await` in it: When
+  you have other code which depends on this function returning a Promise (e.g.
+  by calling `.then` on the returned object), then you also need to change that
+  code.
 
 ## 5.1.0 - 2021-09-23
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.2.0 - 2021-09-28
+### Fixed
+- The property `allowCustomDevice` was used but missing in the type and props
+  definitions for DeviceSetup.
+
 ## 5.1.0 - 2021-09-23
 ### Changed
 - The license check now ignores all files in `.gitignore` and the folder

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The property `allowCustomDevice` was used but missing in the type and props
   definitions for DeviceSetup.
+- Run complete setup for custom devices.
 
 ## 5.1.0 - 2021-09-23
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 5.2.0 - 2021-09-28
+### Added
+- Render children of the component `App`. Children of the component `App`
+  usually should not render to something that is directly visible on the
+  screen, as this would break the normal layout of the app. There are mainly
+  two use cases:
+  - Components like dialogs, which are displayed outside of the normal render
+    flow.
+  - Components which are displayed not at all, but are rendered just for other
+    means, e.g. to dispatch Redux actions when the App is started.
 ### Fixed
 - The property `allowCustomDevice` was used but missing in the type and props
   definitions for DeviceSetup.

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -11,6 +11,7 @@
     "rules": {
         "react/jsx-indent": ["error", 4],
         "react/jsx-indent-props": ["error", 4],
+        "react/jsx-key": ["error", { "checkFragmentShorthand": true }],
         "react/jsx-one-expression-per-line": "off",
         "react/jsx-props-no-spreading": "off",
         "react/require-default-props": "off",
@@ -60,6 +61,7 @@
         "import/extensions": ["off"],
         "no-undef": 1,
         "no-unused-vars": "off",
+        "require-await": "error",
         "prettier/prettier": "error",
         "import/order": "off",
         "simple-import-sort/imports": [

--- a/index.d.ts
+++ b/index.d.ts
@@ -216,6 +216,7 @@ declare module 'pc-nrfconnect-shared' {
         jprog?: Record<string, unknown>;
         dfu?: Record<string, unknown>;
         needSerialPort?: boolean;
+        allowCustomDevice?: boolean;
     }
 
     export interface Serialport {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.1.1",
+    "version": "5.2.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -87,6 +87,7 @@ const ConnectedApp = ({
     sidePanel,
     showLogByDefault = true,
     reportUsageData = false,
+    children,
 }) => {
     const allPanes = useMemo(
         () => [...panes, { name: 'About', Main: About }].map(convertLegacy),
@@ -164,6 +165,7 @@ const ConnectedApp = ({
 
             <AppReloadDialog />
             <ErrorDialog />
+            {children}
         </div>
     );
 };
@@ -183,6 +185,7 @@ ConnectedApp.propTypes = {
     sidePanel: node,
     showLogByDefault: bool,
     reportUsageData: bool,
+    children: node,
 };
 
 const noopReducer = (state = null) => state;

--- a/src/Device/DeviceSelector/DeviceSelector.jsx
+++ b/src/Device/DeviceSelector/DeviceSelector.jsx
@@ -106,6 +106,7 @@ DeviceSelector.propTypes = {
         jprog: object,
         dfu: object,
         needSerialport: bool,
+        allowCustomDevice: bool,
     }),
     releaseCurrentDevice: func, // () => {}
     onDeviceSelected: func, // (device) => {}

--- a/src/Device/deviceSetup.js
+++ b/src/Device/deviceSetup.js
@@ -153,6 +153,17 @@ export const prepareDevice = async (device, deviceSetupConfig) => {
     return createReturnValue(device, { wasProgrammed }, detailedOutput);
 };
 
+const onSuccessfulDeviceSetup = (
+    dispatch,
+    device,
+    doStartWatchingDevices,
+    onDeviceIsReady
+) => {
+    doStartWatchingDevices();
+    dispatch(deviceSetupComplete(device));
+    onDeviceIsReady(device);
+};
+
 /**
  * Selects a device and sets it up for use according to the `config.deviceSetup`
  * configuration given by the app.
@@ -196,12 +207,35 @@ export const setupDevice =
                 device,
                 deviceSetupConfig
             );
-            doStartWatchingDevices();
-            dispatch(deviceSetupComplete(preparedDevice));
-            onDeviceIsReady(preparedDevice);
+            onSuccessfulDeviceSetup(
+                dispatch,
+                preparedDevice,
+                doStartWatchingDevices,
+                onDeviceIsReady
+            );
         } catch (error) {
             dispatch(deviceSetupError(device, error));
-            if (!deviceSetupConfig.allowCustomDevice) {
+            if (
+                deviceSetupConfig.allowCustomDevice &&
+                error.message.includes('No firmware defined')
+            ) {
+                logger.info(
+                    `Connected to device with serial number: ${device.serialNumber} ` +
+                        `and family: ${device.deviceInfo.family || 'Unknown'} `
+                );
+                logger.debug(
+                    'Note: no pre-compiled firmware is available for the selected device. ' +
+                        'You may still use the app if you have programmed the device ' +
+                        'with a compatible connectivity firmware.'
+                );
+
+                onSuccessfulDeviceSetup(
+                    dispatch,
+                    device,
+                    doStartWatchingDevices,
+                    onDeviceIsReady
+                );
+            } else {
                 logger.error(
                     `Error while setting up device ${device.serialNumber}: ${error.message}`
                 );

--- a/src/Device/deviceSetup.js
+++ b/src/Device/deviceSetup.js
@@ -223,10 +223,10 @@ export const setupDevice =
                     `Connected to device with serial number: ${device.serialNumber} ` +
                         `and family: ${device.deviceInfo.family || 'Unknown'} `
                 );
-                logger.debug(
+                logger.info(
                     'Note: no pre-compiled firmware is available for the selected device. ' +
                         'You may still use the app if you have programmed the device ' +
-                        'with a compatible connectivity firmware.'
+                        'with a compatible firmware.'
                 );
 
                 onSuccessfulDeviceSetup(

--- a/src/Device/sdfuOperations.js
+++ b/src/Device/sdfuOperations.js
@@ -48,7 +48,7 @@ export const isDeviceInDFUBootloader = device => {
  * @param {Object} device device
  * @returns {Promise<Object>} device object which is already in bootloader.
  */
-export const ensureBootloaderMode = async device => {
+export const ensureBootloaderMode = /* async */ device => {
     if (isDeviceInDFUBootloader(device)) {
         logger.debug('Device is in bootloader mode');
         return device;
@@ -83,7 +83,7 @@ export const ensureBootloaderMode = async device => {
  * @param {function} promiseConfirm funtion that returns Promise<boolean> for confirmation
  * @returns {Promise<Object>} updated device
  */
-const checkConfirmUpdateBootloader = async (device, promiseConfirm) => {
+const checkConfirmUpdateBootloader = /* async */ (device, promiseConfirm) => {
     if (!promiseConfirm) {
         // without explicit consent bootloader will not be updated
         return device;
@@ -125,7 +125,7 @@ const confirmHelper = async promiseConfirm => {
  * @param {function} promiseChoice Promise returning function
  * @returns {Promise} resolves to user selected choice or first element
  */
-const choiceHelper = async (choices, promiseChoice) => {
+const choiceHelper = /* async */ (choices, promiseChoice) => {
     if (choices.length > 1 && promiseChoice) {
         return promiseChoice('Which firmware do you want to program?', choices);
     }

--- a/src/Dialog/ConfirmationDialog.test.jsx
+++ b/src/Dialog/ConfirmationDialog.test.jsx
@@ -135,7 +135,7 @@ describe('ConfirmationDialog', () => {
             });
         });
 
-        it('is disabled when in progess', async () => {
+        it('is disabled when in progess', () => {
             const onCancelMock = jest.fn();
             const { rerender, queryByText, getByText } = render(
                 <ConfirmationDialog {...defaultProps} onCancel={onCancelMock} />

--- a/src/ErrorBoundary/ErrorBoundary.test.jsx
+++ b/src/ErrorBoundary/ErrorBoundary.test.jsx
@@ -52,7 +52,7 @@ describe('ErrorBoundary', () => {
         expect(reactGA.initialize).toHaveBeenCalled();
     });
 
-    it('can take custom reporting functions', async () => {
+    it('can take custom reporting functions', () => {
         const sendUsageData = jest.fn();
         render(
             <ErrorBoundary sendUsageData={sendUsageData}>


### PR DESCRIPTION
A mixed bag of mostly small changes:
- 5fb4159: The DeviceSelector already supported the property `allowCustomDevice` in the `DeviceSetup`, it was just missing in the type and prop types.
- 42a0317: When using custom devices (which can be done in the BLE app), the setup was not ran correctly.
- 5c84ddc: Small change which allows passing children to the component `App`. This is useful for components outside the normal render flow (e.g. dialogs) or invisible components, which are rendered just for other means (e.g. to dispatch Redux actions when the App is started), as explained in `Changelog.md`.
- 5acb2ab: Enables two additional ESLint rules: [`require-await`](https://eslint.org/docs/rules/require-await) and [`react/jsx-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md). 