### PR TITLE
feat: add documentation card in about pane

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.3.0 - 2021-09-04
+### Added
+- Documentation card in About pane
+
 ## 5.2.1 - 2021-01-01
 ### Added
 - Alert component

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,12 @@ declare module 'pc-nrfconnect-shared' {
         SidePanel?: React.FC;
     }
 
+    interface DocumentationSection extends React.FC {
+        title: string;
+        linkLabel: string;
+        link: string;
+    }
+
     /**
      * Props for the `App` component.
      */
@@ -136,6 +142,12 @@ declare module 'pc-nrfconnect-shared' {
          * opted in. Defaults to `false`.
          */
         reportUsageData?: boolean;
+        /**
+         * Describes the sections of the Documentaion card displayed in the About pane.
+         *
+         * Each section will have a heading, content and a button which links to the relevant website.
+         */
+        documentation?: DocumentationSection[];
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,9 @@ declare module 'pc-nrfconnect-shared' {
             autoScroll: boolean;
             logEntries: readonly string[];
         };
+        documentation: {
+            sections: DocumentationSection[];
+        };
     }
 
     // Actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -2204,6 +2204,29 @@
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
+        "@reduxjs/toolkit": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
+            "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+            "dev": true,
+            "requires": {
+                "immer": "^9.0.1",
+                "redux": "^4.1.0",
+                "redux-thunk": "^2.3.0",
+                "reselect": "^4.0.0"
+            },
+            "dependencies": {
+                "redux": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+                    "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.9.2"
+                    }
+                }
+            }
+        },
         "@restart/context": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
@@ -7951,6 +7974,12 @@
             "requires": {
                 "minimatch": "^3.0.4"
             }
+        },
+        "immer": {
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+            "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+            "dev": true
         },
         "immutable": {
             "version": "4.0.0-rc.12",
@@ -13848,6 +13877,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "reselect": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+            "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+            "dev": true
         },
         "resize-observer-polyfill": {
             "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,7 +2208,6 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
             "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
-            "dev": true,
             "requires": {
                 "immer": "^9.0.1",
                 "redux": "^4.1.0",
@@ -2220,7 +2219,6 @@
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
                     "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
-                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.9.2"
                     }
@@ -7978,8 +7976,7 @@
         "immer": {
             "version": "9.0.6",
             "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
-            "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-            "dev": true
+            "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
         },
         "immutable": {
             "version": "4.0.0-rc.12",
@@ -13881,8 +13878,7 @@
         "reselect": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-            "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
-            "dev": true
+            "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
         },
         "resize-observer-polyfill": {
             "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.2.1",
+    "version": "5.3.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     },
     "devDependencies": {
         "@nordicsemiconductor/nrf-device-lib-js": "^0.3.14",
+        "@reduxjs/toolkit": "^1.6.1",
         "@types/react": "16.14.4",
         "electron-store": "5.1.1",
         "react": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@babel/plugin-transform-spread": "7.10.0",
         "@babel/preset-react": "7.10.0",
         "@babel/preset-typescript": "^7.10.4",
+        "@reduxjs/toolkit": "^1.6.1",
         "@svgr/webpack": "5.5.0",
         "@testing-library/jest-dom": "5.8.0",
         "@testing-library/react": "10.0.4",
@@ -99,7 +100,6 @@
     },
     "devDependencies": {
         "@nordicsemiconductor/nrf-device-lib-js": "^0.3.14",
-        "@reduxjs/toolkit": "^1.6.1",
         "@types/react": "16.14.4",
         "electron-store": "5.1.1",
         "react": "16.13.1",

--- a/src/About/About.jsx
+++ b/src/About/About.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import ApplicationCard from './ApplicationCard';
 import DeviceCard from './DeviceCard';
+import DocumentationCard from './DocumentationCard';
 import SupportCard from './SupportCard';
 
 import './about.scss';
@@ -16,6 +17,7 @@ export default () => (
     <div className="about">
         <ApplicationCard />
         <DeviceCard />
+        <DocumentationCard />
         <SupportCard />
     </div>
 );

--- a/src/About/DocumentationCard.jsx
+++ b/src/About/DocumentationCard.jsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import Card from '../Card/Card';
+import AboutButton from './AboutButton';
+import { documentationSections } from './documentationSlice';
+import Section from './Section';
+
+export default () => {
+    const sections = useSelector(documentationSections);
+    if (sections.length === 0) return null;
+
+    return (
+        <Card title="Documentation">
+            {sections.map(section => (
+                <Section key={section.props.title} title={section.props.title}>
+                    <p>{section.props.children}</p>
+                    {section.props.link && (
+                        <AboutButton
+                            url={section.props.link}
+                            label={section.props.linkLabel}
+                        />
+                    )}
+                </Section>
+            ))}
+        </Card>
+    );
+};

--- a/src/About/documentationSlice.js
+++ b/src/About/documentationSlice.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+    sections: [],
+};
+
+const slice = createSlice({
+    name: 'documentation',
+    initialState,
+    reducers: {
+        setDocumentationSections: (state, action) => {
+            state.sections = action.payload;
+        },
+    },
+});
+
+export const {
+    reducer,
+    actions: { setDocumentationSections },
+} = slice;
+
+export const documentationSections = ({ documentation }) =>
+    documentation.sections;

--- a/src/About/documentationSlice.ts
+++ b/src/About/documentationSlice.ts
@@ -16,7 +16,7 @@ interface DocumentationState {
     sections: DocumentationSection[];
 }
 
-const initialState = {
+const initialState: DocumentationState = {
     sections: [],
 };
 

--- a/src/About/documentationSlice.ts
+++ b/src/About/documentationSlice.ts
@@ -6,6 +6,16 @@
 
 import { createSlice } from '@reduxjs/toolkit';
 
+interface DocumentationSection extends React.FC {
+    title: string;
+    linkLabel: string;
+    link: string;
+}
+
+interface DocumentationState {
+    sections: DocumentationSection[];
+}
+
 const initialState = {
     sections: [],
 };
@@ -25,5 +35,6 @@ export const {
     actions: { setDocumentationSections },
 } = slice;
 
-export const documentationSections = ({ documentation }) =>
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export const documentationSections = ({ documentation }: any) =>
     documentation.sections;

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -23,6 +23,7 @@ import {
 } from 'prop-types';
 
 import About from '../About/About';
+import { setDocumentationSections } from '../About/documentationSlice';
 import AppReloadDialog from '../AppReload/AppReloadDialog';
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary';
 import ErrorDialog from '../ErrorDialog/ErrorDialog';
@@ -87,6 +88,7 @@ const ConnectedApp = ({
     sidePanel,
     showLogByDefault = true,
     reportUsageData = false,
+    documentation,
     children,
 }) => {
     const allPanes = useMemo(
@@ -108,6 +110,10 @@ const ConnectedApp = ({
     useEffect(() => {
         dispatch(setPanes(allPanes));
     }, [dispatch, allPanes]);
+
+    useEffect(() => {
+        if (documentation) dispatch(setDocumentationSections(documentation));
+    }, [dispatch, documentation]);
 
     const SidePanelComponent = allPanes[currentPane].SidePanel;
     const currentSidePanel =
@@ -178,6 +184,12 @@ const PanePropType = exact({
     SidePanel: elementType,
 });
 
+const DocumentationPropType = exact({
+    title: string,
+    linkLabel: string,
+    link: string,
+});
+
 ConnectedApp.propTypes = {
     deviceSelect: node,
     panes: arrayOf(oneOfType([LegacyPanePropType, PanePropType]).isRequired)
@@ -185,6 +197,7 @@ ConnectedApp.propTypes = {
     sidePanel: node,
     showLogByDefault: bool,
     reportUsageData: bool,
+    documentation: arrayOf(DocumentationPropType),
     children: node,
 };
 

--- a/src/coreReducers.js
+++ b/src/coreReducers.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { reducer as documentation } from './About/documentationSlice';
 import { reducer as appLayout } from './App/appLayout';
 import appReloadDialog from './AppReload/appReloadDialogReducer';
 import device from './Device/deviceReducer';
@@ -16,4 +17,5 @@ export default {
     device,
     errorDialog,
     log,
+    documentation,
 };


### PR DESCRIPTION
Adds a documentation property to the App component which will show "documentation sections" in the about pane.

![Screenshot from 2021-10-01 14-15-52](https://user-images.githubusercontent.com/30871542/135618654-63da4032-5969-4bc9-83f5-e09f20c0c886.png)

An array of objects like these would be passed to the App component:
```
<DocumentationSection
                title="Infocenter"
                link="https://infocenter.nordicsemi.com/index.jsp?topic=%2Fug_nc_programmer%2FUG%2Fnrf_connect_programmer%2Fncp_introduction.html"
                linkLabel="Go to infocenter"
            >
                For more information about this app and its usage, visit the
                infocenter page for it.
</DocumentationSection>
```