### PR TITLE
Extract typings to avoid apps having to resolve css modules for now.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 5.2.1 - 2021-01-01
+## 5.2.2 - 2021-10-05
+### Fixed
+- Add ambient module for resolving css modules
+
+## 5.2.1 - 2021-10-01
 ### Added
 - Alert component
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -657,3 +657,6 @@ declare module 'pc-nrfconnect-shared' {
 
     export const deviceInfo: (device: Device) => DeviceInfo;
 }
+
+// Let typescript compiler in `npm run lint` resolve css modules
+declare module '*.module.scss';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.2.1",
+    "version": "5.2.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This lets shared export typings of components using css modules, with the types from the modules themselves. 