### PR TITLE
Enable filtering devices in deviceSelector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.4.0 - 2021-10-07
+### Added
+- Property `deviceFilter` on `DeviceSelector` to filter which devices are
+  shown.
+
 ## 5.3.2 - 2021-10-06
 ### Fixed
 - Removed the outdated externals `pc-nrfjprog-js`, `usb`, and

--- a/index.d.ts
+++ b/index.d.ts
@@ -327,6 +327,13 @@ declare module 'pc-nrfconnect-shared' {
          * failed.
          */
         onDeviceDeselected?: () => void;
+        /**
+         * When providing this function, it is called for every device and
+         * only when the function returns true, the corresponding device
+         * is also displayed in the list of devices. When no function is
+         * provided, all devices are shown.
+         */
+        deviceFilter?: (device: Device) => boolean;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.3.2",
+    "version": "5.4.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/DeviceSelector/DeviceList/DeviceList.jsx
+++ b/src/Device/DeviceSelector/DeviceList/DeviceList.jsx
@@ -29,7 +29,13 @@ const NoDevicesConnected = () => (
     </div>
 );
 
-const DeviceList = ({ isVisible, doSelectDevice }) => {
+const showAllDevices = () => true;
+
+const DeviceList = ({
+    isVisible,
+    doSelectDevice,
+    deviceFilter = showAllDevices,
+}) => {
     const devices = useSelector(sortedDevices);
 
     return (
@@ -38,7 +44,7 @@ const DeviceList = ({ isVisible, doSelectDevice }) => {
                 <NoDevicesConnected />
             ) : (
                 <AnimatedList devices={devices}>
-                    {devices.map(device => (
+                    {devices.filter(deviceFilter).map(device => (
                         <AnimatedItem
                             key={device.serialNumber}
                             itemKey={device.serialNumber}
@@ -58,6 +64,7 @@ const DeviceList = ({ isVisible, doSelectDevice }) => {
 DeviceList.propTypes = {
     doSelectDevice: func.isRequired,
     isVisible: bool.isRequired,
+    deviceFilter: func, // (device) => boolean
 };
 
 export default DeviceList;

--- a/src/Device/DeviceSelector/DeviceSelector.jsx
+++ b/src/Device/DeviceSelector/DeviceSelector.jsx
@@ -26,6 +26,7 @@ const DeviceSelector = ({
     onDeviceSelected = noop,
     onDeviceDeselected = noop,
     onDeviceIsReady = noop,
+    deviceFilter,
 }) => {
     const dispatch = useDispatch();
     const [deviceListVisible, setDeviceListVisible] = useState(false);
@@ -86,6 +87,7 @@ const DeviceSelector = ({
             <DeviceList
                 isVisible={deviceListVisible}
                 doSelectDevice={doSelectDevice}
+                deviceFilter={deviceFilter}
             />
 
             <DeviceSetup />
@@ -112,6 +114,7 @@ DeviceSelector.propTypes = {
     onDeviceSelected: func, // (device) => {}
     onDeviceDeselected: func, // () => {}
     onDeviceIsReady: func, // (device) => {}
+    deviceFilter: func, // (device) => boolean
 };
 
 export default DeviceSelector;


### PR DESCRIPTION
Added a property `deviceFilter` on `DeviceSelector` to filter which devices are shown.

When providing a `deviceFilter` function, it is called for every device and only when the function returns true, the corresponding device is also displayed in the list of devices. When no function is provided, all devices are shown.