### PR TITLE
Fix: Wrongly frozen properties

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Selector `selectedDevice` to retrieve the currently selected device in apps.
 
+## 5.6.2 - 2021-10-29
+### Fixed
+- Properties of the main panes (and their children) were frozen by immer.
+
 ## 5.6.1 - 2021-10-28
 ### Fixed
 - Dropdown styling when label prop is used.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.6.1",
+    "version": "5.6.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/appLayout.ts
+++ b/src/App/appLayout.ts
@@ -4,20 +4,24 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { AppLayout, AppLayoutPane, RootState } from '../state';
+import { AppLayout, RootState } from '../state';
 import { persistCurrentPane } from '../utils/persistentStore';
 
 const initialState: AppLayout = {
     isSidePanelVisible: true,
     isLogVisible: true,
     currentPane: 0,
-    panes: [],
+    paneNames: [],
 };
 
-const isAboutPane = (pane: number, allPanes: AppLayoutPane[]) =>
-    pane === allPanes.length - 1;
+const isAboutPane = (pane: number, paneCount: number) => pane === paneCount - 1;
+
+interface PaneSpec {
+    name: string;
+    Main: unknown;
+}
 
 const slice = createSlice({
     name: 'appLayout',
@@ -30,13 +34,13 @@ const slice = createSlice({
             state.isSidePanelVisible = !state.isSidePanelVisible;
         },
         setCurrentPane: (state, action) => {
-            if (!isAboutPane(action.payload, state.panes)) {
+            if (!isAboutPane(action.payload, state.paneNames.length)) {
                 persistCurrentPane(action.payload);
             }
             state.currentPane = action.payload;
         },
-        setPanes: (state, action) => {
-            state.panes = action.payload;
+        setPanes: (state, action: PayloadAction<PaneSpec[]>) => {
+            state.paneNames = action.payload.map(pane => pane.name);
         },
     },
 });
@@ -54,7 +58,9 @@ export const {
 export const isSidePanelVisible = (state: RootState) =>
     state.appLayout.isSidePanelVisible;
 export const isLogVisible = (state: RootState) => state.appLayout.isLogVisible;
-export const panes = (state: RootState) => state.appLayout.panes;
+export const paneNames = (state: RootState) => state.appLayout.paneNames;
 
 export const currentPane = ({ appLayout }: RootState) =>
-    appLayout.currentPane >= appLayout.panes.length ? 0 : appLayout.currentPane;
+    appLayout.currentPane >= appLayout.paneNames.length
+        ? 0
+        : appLayout.currentPane;

--- a/src/NavBar/NavMenu.jsx
+++ b/src/NavBar/NavMenu.jsx
@@ -9,17 +9,17 @@ import { useSelector } from 'react-redux';
 
 import {
     currentPane as currentPaneSelector,
-    panes as panesSelector,
+    paneNames as paneNamesSelector,
 } from '../App/appLayout';
 import NavMenuItem from './NavMenuItem';
 
 const NavMenu = () => {
     const currentPane = useSelector(currentPaneSelector);
-    const panes = useSelector(panesSelector);
+    const paneNames = useSelector(paneNamesSelector);
 
     return (
         <div data-testid="nav-menu">
-            {panes.map(({ name }, index) => (
+            {paneNames.map((name, index) => (
                 <NavMenuItem
                     key={name}
                     index={index}

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,11 +25,7 @@ export interface AppLayout {
     isSidePanelVisible: boolean;
     isLogVisible: boolean;
     currentPane: number;
-    panes: AppLayoutPane[];
-}
-
-export interface AppLayoutPane {
-    name: string;
+    paneNames: string[];
 }
 
 export interface AppReloadDialog {


### PR DESCRIPTION
Because we added the react components of the main panes to the store,
any properties on them were frozen by Immer. This causes a problem in
the old link monitor.

Since we do not really need the components (only the names of the
panes), this commit removes the components from the store.