### PR TITLE
Make interoperability with device-lib more robust

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug log would always claim that engine was not supported.
 ### Changed
 - Requires now `nrf-device-lib-js` 0.3.18.
+- Increase enumeration timeout to 3 minutes, because according to reports the
+  current enumeration timeout can be too short.
 
 ## 5.6.4 - 2021-11-02
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 5.7.0 - 2021-11-08
 ### Fixed
 - Debug log would always claim that engine was not supported.
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires now `nrf-device-lib-js` 0.3.18.
 - Increase enumeration timeout to 3 minutes, because according to reports the
   current enumeration timeout can be too short.
+- More detailed logging when enumerating the devices failes.
 
 ## 5.6.4 - 2021-11-02
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,16 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- Debug log would always claim that engine was not supported
+- Debug log would always claim that engine was not supported.
+### Changed
+- Requires now `nrf-device-lib-js` 0.3.18.
 
 ## 5.6.4 - 2021-11-02
 ### Changed
-- Make alerts dismissable
+- Make alerts dismissible.
 
 ## 5.6.3 - 2021-11-02
 ### Added
 - Selector `selectedDevice` to retrieve the currently selected device in apps.
-
 ### Fixed
 - Correctly selected device when returning to application mode from bootloader mode.
 

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -53,8 +53,7 @@
                     "nrfconnect/.*",
                     "pc-ble-driver-js",
                     "serialport",
-                    "electron",
-                    "@nordicsemiconductor/nrf-device-lib-js"
+                    "electron"
                 ]
             }
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.5.8",
+    "version": "5.6.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2164,9 +2164,9 @@
             }
         },
         "@nordicsemiconductor/nrf-device-lib-js": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.3.14.tgz",
-            "integrity": "sha512-enQd5AwXrTnocv9YqI1SwR6uW3fAhBO/VlSiExUlPTOU9TiuC2Sm3NhkTLBi2IW/YnYO852AKjm29VPxdPRL2Q==",
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.3.18.tgz",
+            "integrity": "sha512-BVkJmf5294Ypdq0m+75cwmQQeiM+X01CL7cCtuqQOhy1A59R/PqEyR0eTPnk1Z+qDuFlDQAAux3PnRL7oLTgaQ==",
             "dev": true,
             "requires": {
                 "axios": "0.21.1",
@@ -3464,9 +3464,9 @@
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
         "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
@@ -3889,9 +3889,9 @@
             }
         },
         "big-integer": {
-            "version": "1.6.49",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.49.tgz",
-            "integrity": "sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==",
+            "version": "1.6.50",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
+            "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
             "dev": true
         },
         "big.js": {
@@ -6902,9 +6902,9 @@
             }
         },
         "ext": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
-            "integrity": "sha512-+ONcYoWj/SoQwUofMr94aGu05Ou4FepKi7N7b+O8T4jVfyIsZQV1/xeS8jpaBzF0csAk0KLXoHCxU7cKYZjo1Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+            "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
             "dev": true,
             "requires": {
                 "type": "^2.5.0"
@@ -7320,9 +7320,9 @@
             "integrity": "sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw=="
         },
         "follow-redirects": {
-            "version": "1.14.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
             "dev": true
         },
         "for-in": {
@@ -16676,45 +16676,12 @@
             "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
         },
         "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.2 || 2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
+                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "window-size": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.6.4",
+    "version": "5.7.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "winston": "3.2.1"
     },
     "devDependencies": {
-        "@nordicsemiconductor/nrf-device-lib-js": "^0.3.14",
+        "@nordicsemiconductor/nrf-device-lib-js": "0.3.18",
         "@types/react": "16.14.4",
         "electron": "^13.5.1",
         "electron-store": "5.1.1",
@@ -109,7 +109,7 @@
         "react-redux": "7.2.0"
     },
     "peerDependencies": {
-        "@nordicsemiconductor/nrf-device-lib-js": "^0.3.12",
+        "@nordicsemiconductor/nrf-device-lib-js": "^0.3.18",
         "electron-store": "^5.1.1",
         "react": "^16.13",
         "react-redux": "^7.2"

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -6,7 +6,6 @@
 
 /* eslint-disable @typescript-eslint/ban-types */
 
-// eslint-disable-next-line import/no-unresolved
 import nrfDeviceLib, {
     Device as NrfdlDevice,
     DeviceTraits,

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -112,7 +112,10 @@ export const startWatchingDevices =
                 updateDeviceList
             );
         } catch (error) {
-            logger.error(`Error while probing devices: ${error.message}`);
+            logger.error(
+                `Error while probing devices, more details in the debug log: ${error.message}`
+            );
+            logger.debug(JSON.stringify(error.origin, undefined, 2));
         }
     };
 

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -24,6 +24,10 @@ import { devicesDetected } from './deviceSlice';
 const DEFAULT_DEVICE_WAIT_TIME = 3000;
 
 const deviceLibContext = nrfDeviceLib.createContext();
+// @ts-expect-error: The type TimeoutConfig currently wrongly has all properies
+// required while they should be optional, it is correct to just specify
+// enumerateMs
+nrfDeviceLib.setTimeoutConfig(deviceLibContext, { enumerateMs: 3 * 60 * 1000 });
 export const getDeviceLibContext = () => deviceLibContext;
 
 let hotplugTaskId: number;

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -11,7 +11,6 @@ import nrfDeviceLib, {
     Device as NrfdlDevice,
     DeviceTraits,
     HotplugEvent,
-    stopHotplugEvents,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 import camelcaseKeys from 'camelcase-keys';
 // eslint-disable-next-line import/no-unresolved
@@ -185,7 +184,7 @@ export const waitForDevice = (
                     isTraitIncluded()
                 ) {
                     clearTimeout(timeoutId);
-                    stopHotplugEvents(hotplugEventsId);
+                    nrfDeviceLib.stopHotplugEvents(hotplugEventsId);
                     resolve(device);
                 }
             }

--- a/src/Device/deviceSlice.ts
+++ b/src/Device/deviceSlice.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
-/* eslint-disable valid-jsdoc */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
@@ -61,7 +60,7 @@ const slice = createSlice({
     name: 'device',
     initialState,
     reducers: {
-        /**
+        /*
          * Indicates that a device has been selected.
          *
          * @param {Device} device Device object as given by nrf-device-lib.
@@ -70,7 +69,7 @@ const slice = createSlice({
             state.selectedSerialNumber = action.payload.serialNumber;
         },
 
-        /**
+        /*
          * Indicates that the currently selected device has been deselected.
          */
         deselectDevice: state => {
@@ -78,7 +77,7 @@ const slice = createSlice({
             state.deviceInfo = null;
         },
 
-        /**
+        /*
          * Indicates that device setup is complete. This means that the device is
          * ready for use according to the `config.deviceSetup` configuration provided
          * by the app.

--- a/src/Device/initPacket.ts
+++ b/src/Device/initPacket.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-// eslint-disable-next-line import/no-unresolved
 import protobuf from 'protobufjs';
 
 import dfuCcProto from './dfu-cc';

--- a/src/Device/jprogOperations.js
+++ b/src/Device/jprogOperations.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import nrfDeviceLib from '@nordicsemiconductor/nrf-device-lib-js'; // eslint-disable-line import/no-unresolved
+import nrfDeviceLib from '@nordicsemiconductor/nrf-device-lib-js';
 import SerialPort from 'serialport';
 
 import logger from '../logging';

--- a/src/Device/sdfuOperations.js
+++ b/src/Device/sdfuOperations.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import nrfDeviceLib from '@nordicsemiconductor/nrf-device-lib-js'; // eslint-disable-line import/no-unresolved
+import nrfDeviceLib from '@nordicsemiconductor/nrf-device-lib-js';
 import AdmZip from 'adm-zip';
 import { createHash } from 'crypto';
 import fs from 'fs';

--- a/src/state.ts
+++ b/src/state.ts
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import {
-    Device as NrfdlDevice,
-    ModuleVersion,
-} from '@nordicsemiconductor/nrf-device-lib-js';
+import { Device as NrfdlDevice } from '@nordicsemiconductor/nrf-device-lib-js';
 import { LogEntry } from 'winston';
 
 export interface RootState {
@@ -108,5 +105,4 @@ export interface Device extends Omit<NrfdlDevice, 'usb' | 'jlink'> {
     nickname?: string;
     serialport?: Serialport;
     favorite?: boolean;
-    dfuTriggerVersion?: ModuleVersion;
 }

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import nrfdl, { ModuleVersion } from '@nordicsemiconductor/nrf-device-lib-js';
+import nrfDeviceLib, {
+    ModuleVersion,
+} from '@nordicsemiconductor/nrf-device-lib-js';
 
 import { getDeviceLibContext } from '../Device/deviceLister';
 import logger from '../logging';
@@ -62,7 +64,9 @@ const logVersion = (
 
 export default async () => {
     try {
-        const versions = await nrfdl.getModuleVersions(getDeviceLibContext());
+        const versions = await nrfDeviceLib.getModuleVersions(
+            getDeviceLibContext()
+        );
 
         logVersion(
             versions,


### PR DESCRIPTION
For https://trello.com/c/8yg4tEWq/341-enumerateworker-error:

Main changes are 0c0281945b91715b161600b1836fc69ab6e44c8d to increase the timeout when enumerating and e956671c5c0b0dacdd0e7a28fac0d110acf6b399 to get better logging when enumerating fails. The rest is more cleanup.