### PR TITLE
Store device in deviceinfo

### DIFF
--- a/src/Device/deviceSetup.ts
+++ b/src/Device/deviceSetup.ts
@@ -164,6 +164,7 @@ export const prepareDevice = async (
                 fw,
                 deviceSetupConfig
             );
+
             if (programmedDevice === undefined) throw new Error();
 
             return programmedDevice;
@@ -175,13 +176,13 @@ export const prepareDevice = async (
 
 const onSuccessfulDeviceSetup = (
     dispatch: TDispatch,
-    info: DeviceInfo,
+    device: Device,
     doStartWatchingDevices: () => void,
-    onDeviceIsReady: (device: DeviceInfo) => void
+    onDeviceIsReady: (device: Device) => void
 ) => {
     doStartWatchingDevices();
-    dispatch(deviceSetupComplete(info));
-    onDeviceIsReady(info);
+    dispatch(deviceSetupComplete(device));
+    onDeviceIsReady(device);
 };
 
 /**
@@ -202,7 +203,7 @@ export const setupDevice =
         device: Device,
         deviceSetup: DeviceSetup,
         releaseCurrentDevice: () => void,
-        onDeviceIsReady: (device: DeviceInfo) => void,
+        onDeviceIsReady: (device: Device) => void,
         doStartWatchingDevices: () => void,
         doDeselectDevice: () => void
     ) =>
@@ -233,7 +234,7 @@ export const setupDevice =
 
             onSuccessfulDeviceSetup(
                 dispatch,
-                deviceInfo(preparedDevice),
+                preparedDevice,
                 doStartWatchingDevices,
                 onDeviceIsReady
             );
@@ -258,7 +259,7 @@ export const setupDevice =
 
                 onSuccessfulDeviceSetup(
                     dispatch,
-                    deviceInfo(device),
+                    device,
                     doStartWatchingDevices,
                     onDeviceIsReady
                 );

--- a/src/Device/deviceSlice.ts
+++ b/src/Device/deviceSlice.ts
@@ -6,7 +6,7 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { Device, DeviceInfo, Devices, DeviceState, RootState } from '../state';
+import { Device, Devices, DeviceState, RootState } from '../state';
 import {
     getPersistedIsFavorite,
     getPersistedNickname,
@@ -84,7 +84,7 @@ const slice = createSlice({
          *
          * @param {Object} device Device object as given by nrf-device-lib.
          */
-        deviceSetupComplete: (state, action: PayloadAction<DeviceInfo>) => {
+        deviceSetupComplete: (state, action: PayloadAction<Device>) => {
             return { ...state, ...noDialogShown, deviceInfo: action.payload };
         },
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -51,7 +51,7 @@ export interface Log {
 export type Devices = { [key: string]: Device | undefined };
 export interface DeviceState {
     devices: Devices;
-    deviceInfo: DeviceInfo | null;
+    deviceInfo: Device | null;
     isSetupDialogVisible: boolean;
     isSetupWaitingForUserInput: boolean | string;
     selectedSerialNumber: string | null;


### PR DESCRIPTION
It seems that apps expect the shared device state to have a device in the deviceInfo property.