### PR TITLE
Enhance error logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - [Object object] error message when device enumeration failed.
+### Added
+- Function `logError` to ease logging error.
 
 ## 5.8.0 - 2021-11-08
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@
 declare module 'pc-nrfconnect-shared' {
     import { Reducer, AnyAction } from 'redux';
     import React from 'react';
-    import winston from 'winston';
+    import { Logger, LogEntry } from 'winston';
     import Store from 'electron-store';
 
     type RootState = import('./src/state').RootState;
@@ -49,7 +49,14 @@ declare module 'pc-nrfconnect-shared' {
 
     // Logging
 
-    export const logger: winston.Logger;
+    interface SharedLogger extends Logger {
+        addFileTransport: (appLogDir: string) => void;
+        getAndClearEntries: () => LogEntry[];
+        openLogFile: () => void;
+        logError: (message: string, error: unknown) => void;
+    }
+
+    export const logger: SharedLogger;
 
     // App.jsx
     export interface PaneProps {

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -110,14 +110,10 @@ export const startWatchingDevices =
                 updateDeviceList
             );
         } catch (error) {
-            const message = error instanceof Error ? error.message : error;
-            logger.error(
-                `Error while probing devices, more details in the debug log: ${JSON.stringify(
-                    message
-                )}`
+            logger.logError(
+                'Error while probing devices, more details in the debug log',
+                error
             );
-            // @ts-ignore It's ok if the next line is undefined.
-            logger.debug(JSON.stringify(error.origin, undefined, 2));
         }
     };
 
@@ -132,8 +128,7 @@ export const stopWatchingDevices = () => {
         try {
             nrfDeviceLib.stopHotplugEvents(hotplugTaskId);
         } catch (error) {
-            const message = error instanceof Error ? error.message : error;
-            logger.error(`Error while stop watching devices: ${message}`);
+            logger.logError('Error while stopping to watch devices', error);
         }
     }
 };

--- a/src/Device/deviceSetup.ts
+++ b/src/Device/deviceSetup.ts
@@ -263,9 +263,9 @@ export const setupDevice =
                     onDeviceIsReady
                 );
             } else {
-                const message = error instanceof Error ? error.message : error;
-                logger.error(
-                    `Error while setting up device ${device.serialNumber}: ${message}`
+                logger.logError(
+                    `Error while setting up device ${device.serialNumber}`,
+                    error
                 );
                 doDeselectDevice();
             }

--- a/src/logging/createErrorMessage.test.ts
+++ b/src/logging/createErrorMessage.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import createErrorMessage from './createErrorMessage';
+
+const check = (input: [string, unknown], expectedMessage: string) => {
+    expect(createErrorMessage(...input)).toEqual(expectedMessage);
+};
+
+describe('creating log messages for an error 2', () => {
+    it('just returns the message if the error is null or undefined', () => {
+        check(['network failure', null], 'network failure');
+        check(['network failure', undefined], 'network failure');
+    });
+
+    it('appends the error if it is an instance of Error', () => {
+        check(
+            ['specific error', URIError('Malformed')],
+            'specific error: URIError: Malformed'
+        );
+    });
+
+    it('appends the error message if one exists', () => {
+        check(
+            ['something with', { message: 'a message' }],
+            'something with: a message'
+        );
+    });
+
+    it('appends the stringified error if it is anything else', () => {
+        check(['error', { an: 'object' }], 'error: {"an":"object"}');
+        check(['error', 'a string message'], 'error: "a string message"');
+        check(['error', ['some', 'array']], 'error: ["some","array"]');
+        check(['error', 42], 'error: 42');
+    });
+
+    it('appends the error origin', () => {
+        check(
+            [
+                'something with',
+                { message: 'a message', origin: SyntaxError('something') },
+            ],
+            'something with: a message (Origin: SyntaxError: something)'
+        );
+    });
+});

--- a/src/logging/createErrorMessage.ts
+++ b/src/logging/createErrorMessage.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+interface MaybeWithMessageAndOrigin {
+    message?: string;
+    origin?: MaybeWithMessageAndOrigin;
+}
+
+function hasMaybeMessageAndOrigin(
+    error: unknown
+): error is MaybeWithMessageAndOrigin {
+    return error != null;
+}
+
+const describe = (error: MaybeWithMessageAndOrigin) => {
+    if (error instanceof Error) {
+        return String(error);
+    }
+
+    if (error.message != null) {
+        return error.message;
+    }
+
+    return JSON.stringify(error);
+};
+
+const describeOrigin = (origin?: MaybeWithMessageAndOrigin) => {
+    if (origin == null) {
+        return '';
+    }
+
+    return ` (Origin: ${describe(origin)})`;
+};
+
+export default (message: string, error: unknown) => {
+    if (error == null) {
+        return message;
+    }
+
+    /* Because we asserted that error is neither null nor undefined above, we
+       can access properties like `message` and `origin` from here on, without
+       fearing a "Cannot read property 'message' of null/undefined". But
+       TypeScript is not convinced of this. So here comes a statement with a
+       Error that should really never be thrown, just to convince TypeScript
+       of the fact that we can afterwards read the properties `message` and
+       `origin`.
+    */
+    if (!hasMaybeMessageAndOrigin(error)) {
+        throw Error('Will never be thrown');
+    }
+
+    return `${message}: ${describe(error)}${describeOrigin(error.origin)}`;
+};

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -92,10 +92,7 @@ logger.openLogFile = () => {
     try {
         openFile(logFilePath);
     } catch (error) {
-        const message = error instanceof Error ? error.message : error;
-        if (error instanceof Error) {
-            logger.error(`Unable to open log file: ${message}`);
-        }
+        logger.logError('Unable to open log file', error);
     }
 };
 

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -7,12 +7,13 @@
 import { TransformableInfo } from 'logform';
 import path from 'path';
 import { SPLAT } from 'triple-beam';
-import winston, { createLogger, format, LogEntry, transports } from 'winston';
+import { createLogger, format, LogEntry, Logger, transports } from 'winston';
 import Transport from 'winston-transport';
 
 import { openFile } from '../utils/open';
 import AppTransport from './appTransport';
 import ConsoleTransport from './consoleTransport';
+import createErrorMessage from './createErrorMessage';
 import createLogBuffer from './logBuffer';
 
 const filePrefix = new Date().toISOString().replace(/:/gi, '_');
@@ -45,10 +46,11 @@ if (isDevelopment && isConsoleAvailable) {
     );
 }
 
-interface SharedLogger extends winston.Logger {
+interface SharedLogger extends Logger {
     addFileTransport: (appLogDir: string) => void;
     getAndClearEntries: () => LogEntry[];
     openLogFile: () => void;
+    logError: (message: string, error: unknown) => void;
 }
 
 /* This function is only needed, because our version of TypeScript still seems
@@ -95,6 +97,10 @@ logger.openLogFile = () => {
             logger.error(`Unable to open log file: ${message}`);
         }
     }
+};
+
+logger.logError = (message: string, error: unknown) => {
+    logger.error(createErrorMessage(message, error));
 };
 
 export default logger;

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -77,9 +77,6 @@ export default async () => {
         logVersion(versions, 'nrfjprog_dll', 'nrfjprog dll');
         logVersion(versions, 'jlink_dll', 'JLink');
     } catch (error) {
-        const message = error instanceof Error ? error.message : error;
-        if (error instanceof Error) {
-            logger.error(`Failed to get the library versions: ${message}`);
-        }
+        logger.logError('Failed to get the library versions', error);
     }
 };

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -129,7 +129,6 @@ export default async (
         logger.info(`System report: ${filePath}`);
         openFile(filePath);
     } catch (error) {
-        const details = error instanceof Error ? error.message : error;
-        logger.error(`Failed to generate system report: ${details}`);
+        logger.logError('Failed to generate system report', error);
     }
 };


### PR DESCRIPTION
In #218 in lots of error logging places the code `error.message` was replaced by `error instanceof Error ? error.message : error`. This altered the behaviour because e.g. device-lib returns error objects which do have a `message` property but are not instances of `Error`.

#233 enhanced the situation by calling `JSON.stringify` in one place but it also means that the whole error object is now dumped as JSON into the log, which may not be so readable.

This PR now wants to mostly restore the initial behaviour and enhance it slightly:
1. A function `logError` on the logger is introduced, so that everywhere where we want to log an error (usually in a `catch` block) we can use the same function.
2. That function handles different kind of situations: 
    1. If the error is an instance of `Error`, then the error itself is printed, because JavaScript Error objects usually provide a good `toString` implementation.
    2. If the error has a `message` property, then that is printed.
    3. If the above do not apply, then use `JSON.stringify` on the error object.
    4. If the error contains a property `origin` (like some errors from device-lib) then print that also.
3. There is [a unit test for `logError`](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/blob/f89323d9b18bfa7d313268dcaec6d9a99a317b16/src/logging/createErrorMessage.test.ts) to illustrate and test the different behaviours.
4. In shared the function `logError` is now used in all places where it seems reasonable.