### PR TITLE
Return device even when not programming it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - [Object object] error message when device enumeration failed.
+- Allow selecting device without flashing it if firmware doesn't match.
 ### Added
 - Function `logError` to ease logging error.
 

--- a/src/Device/deviceSetup.ts
+++ b/src/Device/deviceSetup.ts
@@ -108,7 +108,7 @@ export interface DeviceSetupConfig extends DeviceSetup {
 export const prepareDevice = async (
     device: Device,
     deviceSetupConfig: DeviceSetupConfig
-): Promise<Device | undefined> => {
+): Promise<Device> => {
     const { jprog, dfu, needSerialport } = deviceSetupConfig;
 
     if (dfu && Object.keys(dfu).length > 0) {
@@ -159,19 +159,13 @@ export const prepareDevice = async (
         if (valid) return device;
 
         try {
-            const programmedDevice = await programFirmware(
-                device,
-                fw,
-                deviceSetupConfig
-            );
-
-            if (programmedDevice === undefined) throw new Error();
-
-            return programmedDevice;
+            return await programFirmware(device, fw, deviceSetupConfig);
         } catch (error) {
             throw new Error('Failed to program firmware');
         }
     }
+
+    return device;
 };
 
 const onSuccessfulDeviceSetup = (
@@ -228,9 +222,6 @@ export const setupDevice =
                 device,
                 deviceSetupConfig
             );
-
-            if (preparedDevice === undefined)
-                throw new Error('Unable to prepare device');
 
             onSuccessfulDeviceSetup(
                 dispatch,

--- a/src/Device/jprogOperations.ts
+++ b/src/Device/jprogOperations.ts
@@ -183,7 +183,7 @@ export async function programFirmware(
 ) {
     try {
         const confirmed = await confirmHelper(deviceSetupConfig.promiseConfirm);
-        if (!confirmed) return undefined;
+        if (!confirmed) return device;
 
         logger.debug(`Programming ${device.serialNumber} with ${fw}`);
         await program(device.id, fw);


### PR DESCRIPTION
It seems that apps expect the shared device state to have a device in the deviceInfo property.