### PR TITLE
Fix warning when creating a system report on macOS Monterey

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Object object] error message when device enumeration failed.
 - Allow selecting device without flashing it if firmware doesn't match.
+- macOS Monterey: There was a warning when creating a system report for the
+  first time.
 ### Added
 - Function `logError` to ease logging error.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15338,9 +15338,9 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "systeminformation": {
-            "version": "5.7.4",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.7.4.tgz",
-            "integrity": "sha512-m6oziAu2zP8IMnNZpVWptzpcaXG6x59c2sQB8BI7DTcfBOTLXj5jGgjWxCVP65c5k7Fwhn35yVTCIZEypc1n9A=="
+            "version": "5.9.15",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.9.15.tgz",
+            "integrity": "sha512-0tUYPXffFEsme8n/iTAMk09jpGgqtaGf46QOx7oFmiON9zDUQCahfSymQaCRr4tsq9BkKolaOzp8nqMVNrKIqQ=="
         },
         "table": {
             "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "semver": "7.3.2",
         "shasum": "1.0.2",
         "style-loader": "2.0.0",
-        "systeminformation": "5.7.4",
+        "systeminformation": "5.9.15",
         "typescript": "^3.9.7",
         "url-loader": "4.1.1",
         "webpack": "4.46.0",


### PR DESCRIPTION
This warning was previously shown, when creating the very first system report using an app in nRF Connect for Desktop on macOS Monterey (the warning was not shown for later system reports): ![MicrosoftTeams-image](https://user-images.githubusercontent.com/260705/142599354-ac3baace-8951-494c-bc89-1068db212e83.png)

[The according issue in `systemreport` was fixed](https://github.com/sebhildebrandt/systeminformation/issues/627) and this PR uses the new version of `systemreport`.