### PR TITLE
Feat/system report

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 5.10.0 - 2021-12-09
+### Added
+- Print nRFjprog and JLink version in system report.
+- Print all serialports of connected devices in system report.
+
+### Changed
+- nRF Device Lib versions now print at info level
 
 ## 5.9.1 - 2021-12-09
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.9.1",
+    "version": "5.10.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -35,7 +35,7 @@ const describeBuggyVersion = (version: BuggyModuleVersion) => {
     return 'Unknown';
 };
 
-const describe = (version?: ModuleVersion) => {
+export const describe = (version?: ModuleVersion) => {
     if (version == null) {
         return 'Unknown';
     }

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -59,7 +59,7 @@ const logVersion = (
     description: string
 ) => {
     const version = versions.find(v => v.moduleName === moduleName);
-    logger.verbose(`Using ${description} version: ${describe(version)}`);
+    logger.info(`Using ${description} version: ${describe(version)}`);
 };
 
 export default async () => {

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -4,15 +4,18 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import nrfDeviceLib from '@nordicsemiconductor/nrf-device-lib-js';
 import fs from 'fs';
 import { EOL } from 'os';
 import path from 'path';
 import pretty from 'prettysize';
 import si from 'systeminformation';
 
+import { getDeviceLibContext } from '../Device/deviceLister';
 import logger from '../logging';
 import { Device, DeviceInfo } from '../state';
 import { getAppDataDir } from './appDirs';
+import { describe } from './logLibVersions';
 import { openFile } from './open';
 
 /* eslint-disable object-curly-newline */
@@ -42,6 +45,13 @@ const generalInfoReport = async () => {
         si.fsSize(),
     ]);
 
+    const versions = await nrfDeviceLib.getModuleVersions(
+        getDeviceLibContext()
+    );
+
+    const nrfjprog = versions.find(v => v.moduleName === 'nrfjprog_dll');
+    const jlink = versions.find(v => v.moduleName === 'jlink_dll');
+
     return [
         `- System:     ${manufacturer} ${model}`,
         `- BIOS:       ${vendor} ${version}`,
@@ -60,6 +70,8 @@ const generalInfoReport = async () => {
         `    - node: ${node}`,
         `    - python: ${python}`,
         `    - python3: ${python3}`,
+        nrfjprog ? `    - nrfjprog: ${describe(nrfjprog)}` : '',
+        jlink ? `    - jlink: ${describe(jlink)}` : '',
         '',
     ];
 };

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -80,9 +80,9 @@ const allDevicesReport = (allDevices: Device[]) => [
     '- Connected devices:',
     ...allDevices.map(
         d =>
-            `    - ${d.serialport?.comName}: ${d.serialNumber} ${
-                d.boardVersion || ''
-            }`
+            `    - ${d.serialNumber} ${d.boardVersion || ''}: ${d.serialPorts
+                ?.map(s => s.comName)
+                .join(', ')}`
     ),
     '',
 ];


### PR DESCRIPTION
- Adds nrfjprog and jlink versions to system report
- System report includes all serialports of connected devices
- nrfdl versions are printer at info level (verbose previously)