### PR TITLE
Mock nrf-device-lib-js function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 5.9.1 - 2021-12-09
+### Fixed
+- Mock nrf-device-lib-js function used by testing framework.
+
 ## 5.9.0 - 2021-12-07
 ### Fixed
 - [Object object] error message when device enumeration failed.

--- a/mocks/deviceLibMock.js
+++ b/mocks/deviceLibMock.js
@@ -6,4 +6,5 @@
 
 export default {
     createContext: jest.fn().mockReturnValue(1),
+    setTimeoutConfig: jest.fn(),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.9.0",
+    "version": "5.9.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.9.0",
+    "version": "5.9.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Unit tests that import files that import something from shared currently fail due to a function not beeing mocked out as of now.