### PR TITLE
Allow non null assertion parameter `!` in tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.14.0 - 2022-01-06
+
+### Changes
+
+-   Allow TypeScript's non null assertion parameter `!` in tests, because there
+    it is often ok to use it and have it fail the test if something is
+    unexpectedly null.
+
 ## 5.13.0 - 2022-01-04
 
 ### Changed

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -136,6 +136,12 @@
             "rules": {
                 "prettier/prettier": ["error", { "parser": "markdown" }]
             }
+        },
+        {
+            "files": ["*.test.*"],
+            "rules": {
+                "@typescript-eslint/no-non-null-assertion": "off"
+            }
         }
     ],
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.13.0",
+    "version": "5.14.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Because there it is often ok to use it and have it fail the test if something is unexpectedly null.