### PR TITLE
Ignore the `/dist` folder while linting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.15.0 - 2022-01-07
+
+### Changes
+
+-   Ignore the `/dist` folder while linting.
+
+### Steps to upgrade when using this package
+
+-   Since the `dist` folder is now ignored during linting, it should be fine to
+    tell ESLint to lint _all_ files, by changing the `lint` script in
+    `package.json` to `nrfconnect-scripts lint .`. If there is also a `lintfix`
+    script or alike, those of course also need to be changed. If there are more
+    (e.g. generated) files that need to be ignored during linting, you can
+    create
+    [a `.eslintignore` file](https://eslint.org/docs/user-guide/configuring/ignoring-code#the-eslintignore-file)
+    and add the files to be ignore there in your project.
+
 ## 5.14.0 - 2022-01-06
 
 ### Changes

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -8,6 +8,7 @@
         "prettier/react",
         "prettier/@typescript-eslint"
     ],
+    "ignorePatterns": ["/dist/"],
     "rules": {
         "no-shadow": "off",
         "@typescript-eslint/no-shadow": ["error"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.14.0",
+    "version": "5.15.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
With this it should be fine to tell ESLint to lint _all_ files, by changing the `lint` script in    `package.json` to `nrfconnect-scripts lint .`. 

If there are more    (e.g. generated) files that need to be ignored during linting, one can    create    [a `.eslintignore` file](https://eslint.org/docs/user-guide/configuring/ignoring-code#the-eslintignore-file)    and add the files to be ignore there in your project.