### PR TITLE
Prepare upgrading all packages

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ]
+    "extends": ["config:base", "group:all"]
 }


### PR DESCRIPTION
Starting to use renovate seems a bit tedious because of all the outdated
dependencies. So, I try to first let renovate group all upgrades into a
single PR, test (and hopefully merge) that and after that switch back to
individual PRs.