### PR TITLE
Renovate: Group all non major updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,3 @@
 {
-    "extends": ["config:base"]
+    "extends": ["config:base", "group:allNonMajor"]
 }


### PR DESCRIPTION
Non-major updates usually do not cause any problems. So we can group them, hoping to spare us a lot of small PRs.