### PR TITLE
Warn about unused ESLint disable directives and forbid `@ts-ignore`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,12 +17,20 @@ and this project adheres to
 ### Changed
 
 -   Updated a lot of dependencies.
+-   Forbid use of @ts-ignore.
 
 ### Steps to upgrade when using this package
 
 -   A lot of dependencies were updated, including linting and testing tools. So
     there can be some new warnings or errors when linting, testing, or building.
     Check that after updating to this version.
+-   If your project currently uses @ts-ignore you have to change something. In
+    most cases @ts-ignore is used to correct a glitch from another library. At
+    least in these cases @ts-expect-error should be used instead. If the library
+    is corrected, we will then see that we can remove the directive. If it is
+    one of the rare cases that you _really_ want to use @ts-ignore, you can
+    disable the rule @typescript-eslint/ban-ts-comment in that spot, but please
+    think twice about this.
 
 ## 5.16.1 - 2022-01-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+-   Warn if ESLint disable directives (like `eslint-disable` or
+    `eslint-disable-next-line`) are used, even though they are not necessary
+    (anymore).
+
 ### Changed
 
 -   Updated a lot of dependencies.

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -30,8 +30,7 @@
         "@typescript-eslint/ban-ts-comment": [
             "error",
             {
-                "ts-expect-error": "allow-with-description",
-                "ts-ignore": "allow-with-description"
+                "ts-expect-error": "allow-with-description"
             }
         ],
         "camelcase": "off",

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "reportUnusedDisableDirectives": true,
     "parser": "@typescript-eslint/parser",
     "extends": [
         "eslint:recommended",

--- a/src/Device/DeviceSelector/DeviceList/AnimatedList.tsx
+++ b/src/Device/DeviceSelector/DeviceList/AnimatedList.tsx
@@ -29,7 +29,7 @@ const fadeIn: onAppear = element =>
             opacity: [0, 1],
             scale: [0, 1],
         },
-        // @ts-ignore Library types not correct
+        // @ts-expect-error Library types not correct
         onUpdate: ({ opacity, scale }) => {
             element.style.opacity = opacity;
             element.style.transform = `scaleY(${scale})`;
@@ -42,7 +42,7 @@ const fadeOut: onExit = (element, _, removeElement) =>
             opacity: [1, 0],
             scale: [1, 0],
         },
-        // @ts-ignore Library types not correct
+        // @ts-expect-error Library types not correct
         onUpdate: ({ opacity, scale }) => {
             element.style.opacity = opacity;
             element.style.transform = `scaleY(${scale})`;

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -165,7 +165,7 @@ export const stopWatchingDevices = () => {
     }
 };
 
-// @ts-ignore This is how the nrfdl-js api works at the moment.
+// @ts-expect-error This is how the nrfdl-js api works at the moment.
 const DEFAULT_TRAITS: DeviceTraits = {
     serialPort: true,
     // usb: false,

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -15,7 +15,6 @@ import nrfDeviceLib, {
     setLogPattern,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 import camelcaseKeys from 'camelcase-keys';
-// eslint-disable-next-line import/no-unresolved
 import { Device, DeviceListing, Serialport } from 'pc-nrfconnect-shared';
 
 import logger from '../logging';

--- a/src/Device/dfu-cc.ts
+++ b/src/Device/dfu-cc.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-/* eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins */
 import * as $protobuf from 'protobufjs/light';
 
 const $root = (

--- a/src/Device/jprogOperations.ts
+++ b/src/Device/jprogOperations.ts
@@ -13,7 +13,7 @@ import {
     Progress,
     // @ts-ignore -- wrong type declaration in nrf-device-lib-js
     readFwInfo,
-} from '@nordicsemiconductor/nrf-device-lib-js'; // eslint-disable-line import/no-unresolved
+} from '@nordicsemiconductor/nrf-device-lib-js';
 import SerialPort from 'serialport';
 
 import logger from '../logging';

--- a/src/Device/jprogOperations.ts
+++ b/src/Device/jprogOperations.ts
@@ -11,7 +11,6 @@ import {
     FirmwareStreamType,
     FWInfo,
     Progress,
-    // @ts-ignore -- wrong type declaration in nrf-device-lib-js
     readFwInfo,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 import SerialPort from 'serialport';

--- a/src/Device/sdfuOperations.ts
+++ b/src/Device/sdfuOperations.ts
@@ -379,7 +379,7 @@ const prepareInDFUBootloader = async (
         hashType: HashType.SHA256,
         hash: calculateSHA256Hash(firmwareImage),
         appSize: firmwareImage.length,
-        // @ts-ignore This parameter is set.
+        // @ts-expect-error This parameter is set.
         sdReq: params.sdId || [],
     };
 
@@ -426,7 +426,7 @@ const prepareInDFUBootloader = async (
         )
     );
 
-    // @ts-ignore This is how the nrfdl-js api works at the moment.
+    // @ts-expect-error This is how the nrfdl-js api works at the moment.
     return waitForDevice(device.serialNumber, DEFAULT_DEVICE_WAIT_TIME, {
         serialPort: true,
         nordicUsb: true,

--- a/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.tsx
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import React, { ReactNode } from 'react';
 import { Button } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -45,7 +47,7 @@ const sendGAEvent = (error: string) => {
 
 interface Props {
     children: ReactNode;
-    selectedSerialNumber?: string;
+    selectedSerialNumber?: string | null;
     devices?: DeviceShapeProps;
     appName?: string;
     restoreDefaults?: () => void;
@@ -189,7 +191,7 @@ class ErrorBoundary extends React.Component<
     }
 }
 
-// @ts-ignore abc
+// @ts-ignore Don't know what to do with these yet
 ErrorBoundary.propTypes = {
     children: PropTypes.node.isRequired,
     selectedSerialNumber: PropTypes.string,
@@ -204,5 +206,5 @@ const mapStateToProps = (state: RootState) => ({
     selectedSerialNumber: state.device?.selectedSerialNumber,
 });
 
-// @ts-ignore abc
+// @ts-ignore Don't know what to do with these yet
 export default connect(mapStateToProps)(ErrorBoundary);

--- a/src/Slider/Handle.tsx
+++ b/src/Slider/Handle.tsx
@@ -61,8 +61,8 @@ const Handle: FC<Props> = ({
         onMouseDragStart.current = { mousePosition, percentage };
         setCurrentlyDragged(true);
 
-        window.addEventListener('mousemove', dragHandle); // eslint-disable-line no-use-before-define
-        window.addEventListener('mouseup', releaseHandle); // eslint-disable-line no-use-before-define
+        window.addEventListener('mousemove', dragHandle);
+        window.addEventListener('mouseup', releaseHandle);
     };
 
     const dragHandle = (event: MouseEvent) => {

--- a/src/utils/packageJson.ts
+++ b/src/utils/packageJson.ts
@@ -5,7 +5,7 @@
  */
 
 import { readFileSync } from 'fs';
-import { PackageJson } from 'pc-nrfconnect-shared'; // eslint-disable-line import/no-unresolved -- This is only importing a type and TypeScript can handle this
+import { PackageJson } from 'pc-nrfconnect-shared';
 
 let packageJson: PackageJson | undefined;
 

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -22,7 +22,6 @@ import { getAppDataDir } from './appDirs';
 import { describe } from './logLibVersions';
 import { openFile } from './open';
 
-/* eslint-disable object-curly-newline */
 const generalInfoReport = async () => {
     const [
         { manufacturer, model },

--- a/src/utils/usageData.ts
+++ b/src/utils/usageData.ts
@@ -5,7 +5,7 @@
  */
 
 import reactGA from 'react-ga';
-import { PackageJson } from 'pc-nrfconnect-shared'; // eslint-disable-line import/no-unresolved -- This is only importing a type and TypeScript can handle this
+import { PackageJson } from 'pc-nrfconnect-shared';
 import shasum from 'shasum';
 import si from 'systeminformation';
 


### PR DESCRIPTION
Warn if ESLint disable directives (like `eslint-disable` or `eslint-disable-next-line`) are used, even though they are not necessary (anymore). Only a warning is shown when running ESLint, it does not fail with an error. Seems like a failure can only be configured through command line args, not through the config. 

Forbid use of `@ts-ignore`. In most cases `@ts-expect-error` is the better choice.