### PR TITLE
Remove dependency on immutable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,10 @@ and this project adheres to
 -   Updated a lot of dependencies.
 -   Forbid use of @ts-ignore.
 
+### Removed
+
+-   Dependency on `immutable`.
+
 ### Steps to upgrade when using this package
 
 -   A lot of dependencies were updated, including linting and testing tools. So
@@ -31,6 +35,8 @@ and this project adheres to
     one of the rare cases that you _really_ want to use @ts-ignore, you can
     disable the rule @typescript-eslint/ban-ts-comment in that spot, but please
     think twice about this.
+-   If you still use `immutable` in your project and do not want to change that
+    now, then you need to add it to the direct dependencies of your project.
 
 ## 5.16.1 - 2022-01-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9370,11 +9370,6 @@
             "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
             "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
         },
-        "immutable": {
-            "version": "4.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
-            "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
-        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "focus-visible": "5.2.0",
         "ftp": "0.3.10",
         "husky": "4.3.7",
-        "immutable": "4.0.0-rc.12",
         "jest": "26.0.1",
         "jest-bamboo-formatter": "1.0.1",
         "klaw": "3.0.0",


### PR DESCRIPTION
Because we do not need it in `shared` any longer and also not in most of our other projects. If a project still needs it, it can add it as a direct dependency.