### PR TITLE
Use source map in apps in production

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,7 @@ and this project adheres to
 
 -   Updated a lot of dependencies.
 -   Forbid use of @ts-ignore.
+-   Use source map in apps in production.
 
 ### Removed
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -66,7 +66,7 @@ function findEntryPoint() {
 
 module.exports = {
     mode: nodeEnv,
-    devtool: isProd ? 'hidden-source-map' : 'inline-cheap-source-map',
+    devtool: isProd ? 'source-map' : 'inline-cheap-source-map',
     entry: findEntryPoint(),
     output: {
         path: path.join(appDirectory, 'dist'),


### PR DESCRIPTION
We already provided the source maps for apps before but did not link them. With this small change the source maps are also used in production.