### PR TITLE
Fix getting versions from `device-lib`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 5.16.4 - 2022-02-14
+## 5.17.0 - 2022-02-15
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,8 @@ and this project adheres to
 -   Forbid use of @ts-ignore.
 -   Use source map in apps in production.
 -   Lint also JSON files.
+-   Initial `Application data folder` is now logged only at debug level, no
+    longer at info.
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Fixed
 
+-   The system report did not contain the version numbers for the nrfjprog DLL
+    and JLink.
 -   The error reporter UI didn't handle content overflow when the available
     options were expanded
 -   When the app crashed and the error reporter was displayed, users can

--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ and this project adheres to
 
 ### Added
 
+-   Added version numbers for device-lib and device-lib-js to the system report.
 -   Warn if ESLint disable directives (like `eslint-disable` or
     `eslint-disable-next-line`) are used, even though they are not necessary
     (anymore).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.16.4",
+    "version": "5.17.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "5.16.4",
+    "version": "5.17.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/About/SupportCard.tsx
+++ b/src/About/SupportCard.tsx
@@ -7,13 +7,9 @@
 import React, { useEffect } from 'react';
 import Button from 'react-bootstrap/Button';
 import { useDispatch, useSelector } from 'react-redux';
-import { setLogLevel } from '@nordicsemiconductor/nrf-device-lib-js';
 
 import Card from '../Card/Card';
-import {
-    getDeviceLibContext,
-    setDefaultNrfdlLogLevel,
-} from '../Device/deviceLister';
+import { setDeviceLibLogLevel } from '../Device/deviceLibWrapper';
 import {
     deviceInfo,
     selectedSerialNumber,
@@ -45,9 +41,7 @@ export default () => {
     }, []);
 
     useEffect(() => {
-        if (verboseLogging)
-            setLogLevel(getDeviceLibContext(), 'NRFDL_LOG_TRACE');
-        else setDefaultNrfdlLogLevel();
+        setDeviceLibLogLevel(verboseLogging);
     }, [verboseLogging]);
 
     return (

--- a/src/Device/deviceLibWrapper.test.ts
+++ b/src/Device/deviceLibWrapper.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { getModuleVersion } from './deviceLibWrapper';
+
+const exampleModuleVersions = [
+    {
+        dependencies: [
+            {
+                dependencies: [
+                    {
+                        expectedVersion: {
+                            version: 'JLink_V7.58b',
+                            versionFormat: 'string' as const,
+                        },
+                        moduleName: 'jlink',
+                        version: 'JLink_V7.56a',
+                        versionFormat: 'string' as const,
+                    },
+                ],
+                moduleName: 'jprog',
+                version: {
+                    major: 10,
+                    metadata: '0',
+                    minor: 15,
+                    patch: 1,
+                    pre: '0',
+                },
+                versionFormat: 'semantic' as const,
+            },
+        ],
+        moduleName: 'nrfdl',
+        version: {
+            major: 0,
+            metadata: '0',
+            minor: 10,
+            patch: 3,
+            pre: '0',
+        },
+        versionFormat: 'semantic' as const,
+    },
+    {
+        moduleName: 'nrfdl-js',
+        version: {
+            major: 0,
+            minor: 4,
+            patch: 3,
+            metadata: '0',
+            pre: '0',
+        },
+        versionFormat: 'semantic' as const,
+    },
+];
+
+describe('finding module versions', () => {
+    test('in the top level modules', () => {
+        // @ts-expect-error -- The type ModuleVersion is wrong, this is fixed in https://github.com/NordicPlayground/nrf-device-lib-js/pull/100, which just needs to trickle down here
+        expect(getModuleVersion('nrfdl-js', exampleModuleVersions)).toEqual({
+            moduleName: 'nrfdl-js',
+            version: {
+                major: 0,
+                minor: 4,
+                patch: 3,
+                metadata: '0',
+                pre: '0',
+            },
+            versionFormat: 'semantic' as const,
+        });
+    });
+
+    test('in nested dependencies', () => {
+        // @ts-expect-error -- The type ModuleVersion is wrong, this is fixed in https://github.com/NordicPlayground/nrf-device-lib-js/pull/100, which just needs to trickle down here
+        expect(getModuleVersion('jlink', exampleModuleVersions)).toEqual({
+            expectedVersion: {
+                version: 'JLink_V7.58b',
+                versionFormat: 'string' as const,
+            },
+            moduleName: 'jlink',
+            version: 'JLink_V7.56a',
+            versionFormat: 'string' as const,
+        });
+    });
+});

--- a/src/Device/deviceLibWrapper.ts
+++ b/src/Device/deviceLibWrapper.ts
@@ -5,12 +5,14 @@
  */
 
 import { app } from '@electron/remote';
-import nrfDeviceLib, {
+import {
+    createContext,
     Error,
     LogEvent,
     ModuleVersion,
     setLogLevel,
     setLogPattern,
+    setTimeoutConfig,
     startLogEvents,
     stopLogEvents,
 } from '@nordicsemiconductor/nrf-device-lib-js';
@@ -20,7 +22,7 @@ import logger from '../logging';
 import { RootState, TDispatch } from '../state';
 import { getVerboseLoggingEnabled } from '../utils/persistentStore';
 
-const deviceLibContext = nrfDeviceLib.createContext();
+const deviceLibContext = createContext();
 export const getDeviceLibContext = () => deviceLibContext;
 
 export const logNrfdlLogs =
@@ -90,6 +92,6 @@ export const getModuleVersion = (
 
 setLogPattern(getDeviceLibContext(), '[%n][%l](%T.%e) %v');
 setDeviceLibLogLevel(getVerboseLoggingEnabled());
-nrfDeviceLib.setTimeoutConfig(deviceLibContext, {
+setTimeoutConfig(deviceLibContext, {
     enumerateMs: 3 * 60 * 1000,
 });

--- a/src/Device/deviceLibWrapper.ts
+++ b/src/Device/deviceLibWrapper.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { app } from '@electron/remote';
+import nrfDeviceLib, {
+    Error,
+    LogEvent,
+    setLogLevel,
+    setLogPattern,
+    startLogEvents,
+    stopLogEvents,
+} from '@nordicsemiconductor/nrf-device-lib-js';
+
+import { nrfdlVerboseLoggingEnabled } from '../Log/logSlice';
+import logger from '../logging';
+import { RootState, TDispatch } from '../state';
+import { getVerboseLoggingEnabled } from '../utils/persistentStore';
+
+const deviceLibContext = nrfDeviceLib.createContext();
+export const getDeviceLibContext = () => deviceLibContext;
+
+export const logNrfdlLogs =
+    (evt: LogEvent) => (_: unknown, getState: () => RootState) => {
+        if (app.isPackaged && !nrfdlVerboseLoggingEnabled(getState())) return;
+        switch (evt.level) {
+            case 'NRFDL_LOG_TRACE':
+                logger.verbose(evt.message);
+                break;
+            case 'NRFDL_LOG_DEBUG':
+                logger.debug(evt.message);
+                break;
+            case 'NRFDL_LOG_INFO':
+                logger.info(evt.message);
+                break;
+            case 'NRFDL_LOG_WARNING':
+                logger.warn(evt.message);
+                break;
+            case 'NRFDL_LOG_ERROR':
+                logger.error(evt.message);
+                break;
+            case 'NRFDL_LOG_CRITICAL':
+                logger.error(evt.message);
+                break;
+        }
+    };
+
+export const forwardLogEventsFromDeviceLib = (dispatch: TDispatch) => {
+    const taskId = startLogEvents(
+        getDeviceLibContext(),
+        (err?: Error) => {
+            if (err)
+                logger.logError(
+                    'Error while listening to log messages from nrf-device-lib',
+                    err
+                );
+        },
+        (evt: LogEvent) => dispatch(logNrfdlLogs(evt))
+    );
+    return () => {
+        stopLogEvents(taskId);
+    };
+};
+
+export const setDeviceLibLogLevel = (verboseLogging: boolean) =>
+    setLogLevel(
+        getDeviceLibContext(),
+        verboseLogging ? 'NRFDL_LOG_TRACE' : 'NRFDL_LOG_ERROR'
+    );
+
+setLogPattern(getDeviceLibContext(), '[%n][%l](%T.%e) %v');
+setDeviceLibLogLevel(getVerboseLoggingEnabled());
+nrfDeviceLib.setTimeoutConfig(deviceLibContext, {
+    enumerateMs: 3 * 60 * 1000,
+});

--- a/src/Device/deviceLibWrapper.ts
+++ b/src/Device/deviceLibWrapper.ts
@@ -8,6 +8,7 @@ import { app } from '@electron/remote';
 import nrfDeviceLib, {
     Error,
     LogEvent,
+    ModuleVersion,
     setLogLevel,
     setLogPattern,
     startLogEvents,
@@ -69,6 +70,23 @@ export const setDeviceLibLogLevel = (verboseLogging: boolean) =>
         getDeviceLibContext(),
         verboseLogging ? 'NRFDL_LOG_TRACE' : 'NRFDL_LOG_ERROR'
     );
+
+type KnownModule = 'nrfdl' | 'nrfdl-js' | 'jprog' | 'jlink';
+
+const findTopLevel = (module: KnownModule, versions: ModuleVersion[]) =>
+    versions.find(version => version.moduleName === module);
+
+const findInDependencies = (module: KnownModule, versions: ModuleVersion[]) =>
+    getModuleVersion(
+        module,
+        versions.flatMap(version => version.dependencies ?? [])
+    );
+
+export const getModuleVersion = (
+    module: KnownModule,
+    versions: ModuleVersion[] = []
+): ModuleVersion | undefined =>
+    findTopLevel(module, versions) ?? findInDependencies(module, versions);
 
 setLogPattern(getDeviceLibContext(), '[%n][%l](%T.%e) %v');
 setDeviceLibLogLevel(getVerboseLoggingEnabled());

--- a/src/Device/jprogOperations.ts
+++ b/src/Device/jprogOperations.ts
@@ -17,7 +17,7 @@ import SerialPort from 'serialport';
 
 import logger from '../logging';
 import { Device } from '../state';
-import { getDeviceLibContext } from './deviceLister';
+import { getDeviceLibContext } from './deviceLibWrapper';
 import { DeviceSetupConfig } from './deviceSetup';
 
 const deviceLibContext = getDeviceLibContext();

--- a/src/Device/sdfuOperations.ts
+++ b/src/Device/sdfuOperations.ts
@@ -13,7 +13,8 @@ import SerialPort from 'serialport';
 
 import logger from '../logging';
 import { Device } from '../state';
-import { getDeviceLibContext, waitForDevice } from './deviceLister';
+import { getDeviceLibContext } from './deviceLibWrapper';
+import { waitForDevice } from './deviceLister';
 import { DeviceSetupConfig, DfuEntry } from './deviceSetup';
 import {
     createInitPacketBuffer,

--- a/src/Log/logListener.ts
+++ b/src/Log/logListener.ts
@@ -6,8 +6,13 @@
 
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { getModuleVersions } from '@nordicsemiconductor/nrf-device-lib-js';
 import { ipcRenderer } from 'electron';
 
+import {
+    getDeviceLibContext,
+    getModuleVersion,
+} from '../Device/deviceLibWrapper';
 import logger from '../logging';
 import { TDispatch } from '../state';
 import { getAppDataDir } from '../utils/appDirs';
@@ -20,6 +25,7 @@ const sendInitialMessage = () => {
     if (initialMessageSent) return;
 
     initialMessageSent = true;
+    logLibVersions();
     logger.info(`Application data folder: ${getAppDataDir()}`);
 
     ipcRenderer.once('app-details', async (_event, details) => {
@@ -45,12 +51,10 @@ const sendInitialMessage = () => {
         logger.debug(`HomeDir: ${homeDir}`);
         logger.debug(`TmpDir: ${tmpDir}`);
 
-        const versions = await logLibVersions();
-
         if (bundledJlink) {
-            const jlinkVersion = versions?.find(
-                v => v.moduleName === 'jlink_dll'
-            );
+            const versions = await getModuleVersions(getDeviceLibContext());
+            const jlinkVersion = getModuleVersion('jlink', versions);
+
             if (!describeVersion(jlinkVersion).includes(bundledJlink)) {
                 logger.info(
                     `Installed JLink version does not match the provided version (${bundledJlink})`

--- a/src/Log/logListener.ts
+++ b/src/Log/logListener.ts
@@ -26,7 +26,7 @@ const sendInitialMessage = () => {
 
     initialMessageSent = true;
     logLibVersions();
-    logger.info(`Application data folder: ${getAppDataDir()}`);
+    logger.debug(`Application data folder: ${getAppDataDir()}`);
 
     ipcRenderer.once('app-details', async (_event, details) => {
         const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,11 +66,11 @@ export { getAppSpecificStore as getPersistentStore } from './utils/persistentSto
 export { selectedDevice } from './Device/deviceSlice';
 export { deviceInfo } from './Device/deviceInfo/deviceInfo';
 export {
-    getDeviceLibContext,
     stopWatchingDevices,
     startWatchingDevices,
     waitForDevice,
 } from './Device/deviceLister';
+export { getDeviceLibContext } from './Device/deviceLibWrapper';
 export { default as sdfuOperations } from './Device/sdfuOperations';
 export { defaultInitPacket, HashType, FwType } from './Device/initPacket';
 

--- a/src/utils/describeVersion.ts
+++ b/src/utils/describeVersion.ts
@@ -6,37 +6,9 @@
 
 import { ModuleVersion } from '@nordicsemiconductor/nrf-device-lib-js';
 
-// TODO: All these types and the function describeBuggyVersion are just needed
-// because the versions in nrf-device-lib-js v0.3.12 are buggy. As soon as we
-// upgrade to a version where this is fixed, we can remove all of this.
-type Semantic = { major: number; minor: number; patch: number };
-type SemanticInVersion = { version?: Semantic };
-type SemanticInSemantic = { semantic?: Semantic };
-type Incremental = { incremental?: number };
-type PlainString = { string?: string };
-type BuggyModuleVersion = SemanticInVersion &
-    SemanticInSemantic &
-    Incremental &
-    PlainString;
-
-const describeBuggyVersion = (version: BuggyModuleVersion) => {
-    if (version.version)
-        return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
-    if (version.semantic)
-        return `${version.semantic.major}.${version.semantic.minor}.${version.semantic.patch}`;
-    if (version.incremental) return String(version.incremental);
-    if (version.string) return version.string;
-
-    return 'Unknown';
-};
-
 export default (version?: ModuleVersion) => {
     if (version == null) {
         return 'Unknown';
-    }
-
-    if (version.versionFormat == null) {
-        return describeBuggyVersion(version);
     }
 
     switch (version.versionFormat) {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -4,53 +4,36 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import nrfDeviceLib, {
+import {
+    getModuleVersions,
     ModuleVersion,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 
-import { getDeviceLibContext } from '../Device/deviceLibWrapper';
+import {
+    getDeviceLibContext,
+    getModuleVersion,
+} from '../Device/deviceLibWrapper';
 import logger from '../logging';
 import describeVersion from './describeVersion';
 
-const logVersion = (
-    versions: ModuleVersion[],
-    moduleName: string,
-    description: string
-) => {
-    versions.forEach(version => {
-        findDependency(version, description, moduleName);
-    });
-};
-
-const findDependency = (
-    version: ModuleVersion,
-    description: string,
-    name: string
-) => {
-    if (version.moduleName === name) {
+const log = (description: string, moduleVersion?: ModuleVersion) => {
+    if (moduleVersion == null) {
+        logger.warn(`Unable to detect version of ${description}.`);
+    } else {
         logger.info(
-            `Using ${description} version: ${describeVersion(version)}`
+            `Using ${description} version: ${describeVersion(moduleVersion)}`
         );
-        return;
     }
-
-    version.dependencies?.forEach(dep =>
-        findDependency(dep, description, name)
-    );
 };
 
 export default async () => {
     try {
-        const versions = await nrfDeviceLib.getModuleVersions(
-            getDeviceLibContext()
-        );
-        const log = (moduleName: string, description: string) =>
-            logVersion(versions, moduleName, description);
+        const versions = await getModuleVersions(getDeviceLibContext());
 
-        log('nrfdl-js', 'nrf-device-lib-js');
-        log('nrfdl', 'nrf-device-lib');
-        log('jprog', 'nrfjprog DLL');
-        log('jlink', 'JLink');
+        log('nrf-device-lib-js', getModuleVersion('nrfdl-js', versions));
+        log('nrf-device-lib', getModuleVersion('nrfdl', versions));
+        log('nrfjprog DLL', getModuleVersion('jprog', versions));
+        log('JLink', getModuleVersion('jlink', versions));
 
         return versions;
     } catch (error) {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -34,8 +34,6 @@ export default async () => {
         log('nrf-device-lib', getModuleVersion('nrfdl', versions));
         log('nrfjprog DLL', getModuleVersion('jprog', versions));
         log('JLink', getModuleVersion('jlink', versions));
-
-        return versions;
     } catch (error) {
         logger.logError('Failed to get the library versions', error);
     }

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -47,9 +47,9 @@ export default async () => {
         const log = (moduleName: string, description: string) =>
             logVersion(versions, moduleName, description);
 
-        log('nrfdl-js', '@nordicsemiconductor/nrf-device-lib-js');
+        log('nrfdl-js', 'nrf-device-lib-js');
         log('nrfdl', 'nrf-device-lib');
-        log('jprog', 'nrfjprog dll');
+        log('jprog', 'nrfjprog DLL');
         log('jlink', 'JLink');
 
         return versions;

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -8,7 +8,7 @@ import nrfDeviceLib, {
     ModuleVersion,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 
-import { getDeviceLibContext } from '../Device/deviceLister';
+import { getDeviceLibContext } from '../Device/deviceLibWrapper';
 import logger from '../logging';
 import describeVersion from './describeVersion';
 

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -15,7 +15,7 @@ import {
     deviceInfo as getDeviceInfo,
     productPageUrl,
 } from '../Device/deviceInfo/deviceInfo';
-import { getDeviceLibContext } from '../Device/deviceLister';
+import { getDeviceLibContext } from '../Device/deviceLibWrapper';
 import logger from '../logging';
 import { Device } from '../state';
 import { getAppDataDir } from './appDirs';

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -15,7 +15,10 @@ import {
     deviceInfo as getDeviceInfo,
     productPageUrl,
 } from '../Device/deviceInfo/deviceInfo';
-import { getDeviceLibContext } from '../Device/deviceLibWrapper';
+import {
+    getDeviceLibContext,
+    getModuleVersion,
+} from '../Device/deviceLibWrapper';
 import logger from '../logging';
 import { Device } from '../state';
 import { getAppDataDir } from './appDirs';
@@ -52,9 +55,6 @@ const generalInfoReport = async () => {
         getDeviceLibContext()
     );
 
-    const nrfjprog = versions.find(v => v.moduleName === 'nrfjprog_dll');
-    const jlink = versions.find(v => v.moduleName === 'jlink_dll');
-
     return [
         `- System:     ${manufacturer} ${model}`,
         `- BIOS:       ${vendor} ${version}`,
@@ -73,8 +73,10 @@ const generalInfoReport = async () => {
         `    - node: ${node}`,
         `    - python: ${python}`,
         `    - python3: ${python3}`,
-        nrfjprog ? `    - nrfjprog: ${describeVersion(nrfjprog)}` : '',
-        jlink ? `    - jlink: ${describeVersion(jlink)}` : '',
+        `    - nrfjprog DLL: ${describeVersion(
+            getModuleVersion('jprog', versions)
+        )}`,
+        `    - JLink: ${describeVersion(getModuleVersion('jlink', versions))}`,
         '',
     ];
 };

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -73,6 +73,12 @@ const generalInfoReport = async () => {
         `    - node: ${node}`,
         `    - python: ${python}`,
         `    - python3: ${python3}`,
+        `    - nrf-device-lib-js: ${describeVersion(
+            getModuleVersion('nrfdl-js', versions)
+        )}`,
+        `    - nrf-device-lib: ${describeVersion(
+            getModuleVersion('nrfdl', versions)
+        )}`,
         `    - nrfjprog DLL: ${describeVersion(
             getModuleVersion('jprog', versions)
         )}`,


### PR DESCRIPTION
Already before `device-lib` changed what it returns from `getModuleVersions`. This was adapted in `src/utils/logLibVersions.ts` but not in `src/utils/systemReport.ts` and `src/Log/logListener.ts`. This is fixed here.

Some additional changes:
- The whole code to retrieve a single module version is now encapsulated in the function `getModuleVersion` which also got unit tests.
- In the system report, the versions of `device-lib` and `device-lib-js` are also included.
- Remove an outdated hack in `src/utils/describeVersion.ts`
- Lower the log level of the `Application data folder` message.
- Bump version number