### PR TITLE
Bundle shared with apps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,9 +16,10 @@ and this project adheres to
 
 -   Standardise toggle colours.
 -   Updated toggle design in footer.
--   Center `About` pane vertically
+-   Center `About` pane vertically.
 -   Type of `getPersistentStore` was changed to match more that from
     electron-store.
+-   Bundle shared with the apps.
 
 ### Removed
 

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -7,6 +7,7 @@
 
         "strict": true,
         "isolatedModules": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true
     }
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -26,10 +26,9 @@ function createExternals() {
         'electron',
         '@electron/remote',
         'serialport',
-        'nrf-device-lib-js',
         'pc-ble-driver-js',
-        'pc-nrfconnect-shared',
         '@nordicsemiconductor/nrf-device-lib-js',
+        'osx-temperature-sensor',
     ];
 
     // Libs provided by the app at runtime

--- a/index.d.ts
+++ b/index.d.ts
@@ -677,6 +677,12 @@ declare module '*.module.scss' {
     export = properties;
 }
 
+interface Window {
+    appDir: string;
+    appDataDir: string;
+    appLogDir: string;
+}
+
 // Let typescript compiler in `npm run lint` resolve css modules
 declare module '*.icss.scss';
 declare module '*.gif';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2829,6 +2829,11 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@mdi/font": {
+            "version": "3.7.95",
+            "resolved": "https://registry.npmjs.org/@mdi/font/-/font-3.7.95.tgz",
+            "integrity": "sha512-JFQSv1GwhilTN6mj2SHu+YH+jZAIPn6sir/gGYoMSgyEM94nzlLGc7Ew21mnDEr0+W3LhFaInu8dqZFvNUx1bA=="
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3377,14 +3382,6 @@
             "integrity": "sha1-sGLKRlYgApCb4MY6ZGftFzE2rME=",
             "requires": {
                 "date-fns": "*"
-            }
-        },
-        "@types/electron-store": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@types/electron-store/-/electron-store-3.2.0.tgz",
-            "integrity": "sha512-ocZSu4ZgE38kdAQ0a+QiMB8ZW/BO8HzXFt1YImoHDqN/JgFAOhaO4nL5H++GRuONFPTDJZzR66QmTmZ52E/GEg==",
-            "requires": {
-                "electron-store": "*"
             }
         },
         "@types/eslint": {
@@ -3992,6 +3989,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "dev": true,
             "requires": {
                 "ajv": "^8.0.0"
             },
@@ -4000,6 +3998,7 @@
                     "version": "8.10.0",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
                     "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -4010,7 +4009,8 @@
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
                 }
             }
         },
@@ -4401,7 +4401,8 @@
         "atomically": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
-            "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
+            "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+            "dev": true
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -4808,6 +4809,11 @@
             "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
             "dev": true,
             "optional": true
+        },
+        "bootstrap": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+            "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -5629,6 +5635,7 @@
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/conf/-/conf-10.1.1.tgz",
             "integrity": "sha512-z2civwq/k8TMYtcn3SVP0Peso4otIWnHtcTuHhQ0zDZDdP4NTxqEc8owfkz4zBsdMYdn/LFcE+ZhbCeqkhtq3Q==",
+            "dev": true,
             "requires": {
                 "ajv": "^8.6.3",
                 "ajv-formats": "^2.1.1",
@@ -5646,6 +5653,7 @@
                     "version": "8.10.0",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
                     "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -5656,7 +5664,8 @@
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
                 }
             }
         },
@@ -6044,6 +6053,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
             "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^3.0.0"
             }
@@ -6312,6 +6322,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
             "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+            "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
             }
@@ -6378,6 +6389,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.1.tgz",
             "integrity": "sha512-ZyLvNywiqSpbwC/pp89O/AycVWY/UJIkmtyzF2Bd0Nm/rLmcFc0NTGuLdg6+LE8mS8qsiK5JMoe4PnrecLHH5w==",
+            "dev": true,
             "requires": {
                 "conf": "^10.0.3",
                 "type-fest": "^1.0.2"
@@ -6386,7 +6398,8 @@
                 "type-fest": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+                    "dev": true
                 }
             }
         },
@@ -9574,7 +9587,8 @@
         "is-obj": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+            "dev": true
         },
         "is-plain-obj": {
             "version": "1.1.0",
@@ -11492,7 +11506,8 @@
         "json-schema-typed": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-            "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+            "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
+            "dev": true
         },
         "json-stable-stringify": {
             "version": "0.0.1",
@@ -12219,7 +12234,8 @@
         "mimic-fn": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+            "dev": true
         },
         "mimic-response": {
             "version": "3.1.0",
@@ -13562,6 +13578,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
             "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+            "dev": true,
             "requires": {
                 "find-up": "^3.0.0"
             }
@@ -15445,6 +15462,11 @@
                     "optional": true
                 }
             }
+        },
+        "roboto-fontface": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/roboto-fontface/-/roboto-fontface-0.10.0.tgz",
+            "integrity": "sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g=="
         },
         "rst-selector-parser": {
             "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "@testing-library/react": "10.4.9",
         "@types/adm-zip": "^0.4.34",
         "@types/date-fns": "^2.6.0",
-        "@types/electron-store": "3.2.0",
         "@types/mousetrap": "1.6.9",
         "@types/react-dom": "17.0.12",
         "@types/react-redux": "7.1.23",
@@ -104,6 +103,9 @@
         "typescript": "4.6.2",
         "url-loader": "4.1.1",
         "webpack": "4.46.0",
+        "@mdi/font": "3.7.95",
+        "bootstrap": "4.6.1",
+        "roboto-fontface": "0.10.0",
         "winston": "3.6.0"
     },
     "devDependencies": {

--- a/src/Dropdown/Dropdown.module.scss
+++ b/src/Dropdown/Dropdown.module.scss
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-@import '~pc-nrfconnect-shared/styles';
+@import '../../styles';
 
 .container {
     position: relative;

--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -11,18 +11,14 @@ import { loadPackageJson } from './packageJson';
 
 const getUserDataDir = () => getGlobal('userDataDir');
 
-let appDir: string;
-let appDataDir: string;
-let appLogDir: string;
-
 function setAppDirs(
     newAppDir: string,
     newAppDataDir: string,
     newAppLogDir: string
 ) {
-    appDir = newAppDir;
-    appDataDir = newAppDataDir;
-    appLogDir = newAppLogDir;
+    window.appDir = newAppDir;
+    window.appDataDir = newAppDataDir;
+    window.appLogDir = newAppLogDir;
 
     loadPackageJson(getAppFile('package.json'));
 }
@@ -33,7 +29,7 @@ function setAppDirs(
  * @returns {string|undefined} Absolute path of current app.
  */
 function getAppDir() {
-    return appDir;
+    return window.appDir;
 }
 
 /**
@@ -52,7 +48,7 @@ function getAppFile(filename: string) {
  * @returns {string|undefined} Absolute path of data directory of the current app.
  */
 function getAppDataDir() {
-    return appDataDir;
+    return window.appDataDir;
 }
 
 /**
@@ -61,7 +57,7 @@ function getAppDataDir() {
  * @returns {string|undefined} Absolute path of data directory of the current app.
  */
 function getAppLogDir() {
-    return appLogDir;
+    return window.appLogDir;
 }
 
 export {

--- a/src/utils/packageJson.ts
+++ b/src/utils/packageJson.ts
@@ -7,7 +7,11 @@
 import { readFileSync } from 'fs';
 import { PackageJson } from 'pc-nrfconnect-shared';
 
-let packageJson: PackageJson | undefined;
+// @ts-expect-error This will be available when the app uses it.
+// eslint-disable-next-line import/no-unresolved
+import packageJsons from '../../../../package.json';
+
+let packageJson: PackageJson = packageJsons;
 
 export const loadPackageJson = (packageJsonPath: string) => {
     try {


### PR DESCRIPTION
When updating an app to this version, it will bundle shared. This requires the launcher used to also use this version of shared (or newer). This will let us update shared without updating the launcher in the future. 

This will increase the bundle size of the apps, as it bundles in shared.