### PR TITLE
Remove option to use `electron-store` 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "react-redux": "7.2.6"
     },
     "peerDependencies": {
-        "electron-store": "^5.1.1 || ^8.0.0",
+        "electron-store": "^8.0.0",
         "react": "^16.13",
         "react-redux": "^7.2"
     },


### PR DESCRIPTION
Oversight in #293: The peer dependency should be to only use electron-store v8 from now on.