### PR TITLE
Turn `@types/react` into a prod dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.1 - 2022-04-11
+
+### Changed
+
+-   `@types/react@17` became a prod dependency.
+
 ## 6.0.0 - 2022-04-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.0.0-pre1",
+    "version": "6.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4048,9 +4048,9 @@
             "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
         },
         "@types/react": {
-            "version": "17.0.39",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-            "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+            "version": "17.0.44",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
+            "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -45,6 +45,7 @@
         "@types/adm-zip": "^0.4.34",
         "@types/date-fns": "^2.6.0",
         "@types/mousetrap": "1.6.9",
+        "@types/react": "17.0.44",
         "@types/react-dom": "17.0.13",
         "@types/react-redux": "7.1.23",
         "@types/serialport": "^8.0.2",
@@ -119,7 +120,6 @@
         "@types/ftp": "0.3.33",
         "@types/klaw": "3.0.3",
         "@types/lodash.range": "3.2.6",
-        "@types/react": "17.0.39",
         "@types/semver": "7.3.9",
         "@types/webpack": "5.28.0",
         "electron": "13.6.9",


### PR DESCRIPTION
(and also bump `@types/react` to the latest version of 17).

Having `@types/react` as a dev dependency, as before, means that apps would usually pull in the latest version of `@types/react`. But v18 there changed the types, esp. removed the children property. https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions

By making `@types/react` a prod dependency, all apps using this version of shared will now also pull in `@types/react@17`, not `@18`.
