### PR TITLE
Fix problems with running scripts under Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.3 - 2022-05-02
+
+### Fixed
+
+-   Problems with new scripts under Windows.
+
 ## 6.0.2 - 2022-04-28
 
 ### Changed
@@ -48,8 +54,8 @@ and this project adheres to
 ### Steps to upgrade when using this package
 
 -   The device-lib in launcher 3.11 crashes with shared@6, so you must bump the
-    `engines` field in `package.json` to require at least version `3.12` of the
-    launcher.
+    `engines` field in `package.json` to require at least version `3.11.1` of
+    the launcher.
 
 -   Because this version removed `nrfconnect-scripts`, all invocations of it
     have to be replaced with direct invocations of the corresponding tools. So
@@ -63,7 +69,7 @@ and this project adheres to
         "webpack": "webpack build --mode development",
         "build": "webpack build",
         "test": "jest",
-        "check": "run-p --silent --continue-on-error --print-label 'check:*'",
+        "check": "run-p --silent --continue-on-error --print-label check:*",
         "check:lint": "eslint --color .",
         "check:types": "check-for-typescript tsc --noEmit --pretty",
         "check:license": "nrfconnect-license check",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",
@@ -9,17 +9,17 @@
     "author": "Nordic Semiconductor ASA",
     "license": "ISC",
     "bin": {
-        "nrfconnect-license": "./scripts/nrfconnect-license.ts",
-        "check-for-typescript": "./scripts/check-for-typescript.ts",
-        "nordic-publish": "./scripts/nordic-publish.ts"
+        "nrfconnect-license": "./scripts/nrfconnect-license.sh",
+        "check-for-typescript": "./scripts/check-for-typescript.sh",
+        "nordic-publish": "./scripts/nordic-publish.sh"
     },
     "main": "src",
     "scripts": {
         "test": "jest",
-        "check": "run-p --silent --continue-on-error --print-label 'check:*'",
+        "check": "run-p --silent --continue-on-error --print-label check:*",
         "check:lint": "eslint --color .",
-        "check:types": "scripts/check-for-typescript.ts tsc --noEmit --pretty",
-        "check:license": "./scripts/nrfconnect-license.ts check"
+        "check:types": "ts-node --swc scripts/check-for-typescript.ts tsc --noEmit --pretty",
+        "check:license": "ts-node --swc scripts/nrfconnect-license.ts check"
     },
     "dependencies": {
         "@babel/core": "7.17.5",

--- a/scripts/check-for-typescript.sh
+++ b/scripts/check-for-typescript.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ts-node --swc "$(dirname $0)/check-for-typescript.ts" "$@"

--- a/scripts/nordic-publish.sh
+++ b/scripts/nordic-publish.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ts-node --swc "$(dirname $0)/nordic-publish.ts" "$@"

--- a/scripts/nrfconnect-license.sh
+++ b/scripts/nrfconnect-license.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ts-node --swc "$(dirname $0)/nrfconnect-license.ts" "$@"


### PR DESCRIPTION
Work around an issue on Windows with running scripts using `env -S` https://github.com/npm/cmd-shim/issues/54