### PR TITLE
Fix problems with running scripts under Unix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.4 - 2022-05-02
+
+### Fixed
+
+-   Problems with new scripts under Unix.
+
 ## 6.0.3 - 2022-05-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/check-for-typescript.sh
+++ b/scripts/check-for-typescript.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-ts-node --swc "$(dirname $0)/check-for-typescript.ts" "$@"
+SCRIPT_FOLDER="$(dirname $(readlink $0))"
+
+ts-node --swc "$SCRIPT_FOLDER/check-for-typescript.ts" "$@"

--- a/scripts/nordic-publish.sh
+++ b/scripts/nordic-publish.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-ts-node --swc "$(dirname $0)/nordic-publish.ts" "$@"
+SCRIPT_FOLDER="$(dirname $(readlink $0))"
+
+ts-node --swc "$SCRIPT_FOLDER/nordic-publish.ts" "$@"

--- a/scripts/nrfconnect-license.sh
+++ b/scripts/nrfconnect-license.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-ts-node --swc "$(dirname $0)/nrfconnect-license.ts" "$@"
+SCRIPT_FOLDER="$(dirname $(readlink $0))"
+
+ts-node --swc "$SCRIPT_FOLDER/nrfconnect-license.ts" "$@"


### PR DESCRIPTION
Because on Unix systems the scripts are soft linked, we need to resolve that link.