### PR TITLE
Fix problems with scripts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.5 - 2022-05-02
+
+### Fixed
+
+-   Problems with new scripts everywhere.
+
 ## 6.0.4 - 2022-05-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/check-for-typescript.sh
+++ b/scripts/check-for-typescript.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-SCRIPT_FOLDER="$(dirname $(readlink $0))"
+set -o errexit -o pipefail
 
-ts-node --swc "$SCRIPT_FOLDER/check-for-typescript.ts" "$@"
+ts-node --swc ./node_modules/pc-nrfconnect-shared/scripts/check-for-typescript.ts "$@"

--- a/scripts/nordic-publish.sh
+++ b/scripts/nordic-publish.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-SCRIPT_FOLDER="$(dirname $(readlink $0))"
+set -o errexit -o pipefail
 
-ts-node --swc "$SCRIPT_FOLDER/nordic-publish.ts" "$@"
+ts-node --swc ./node_modules/pc-nrfconnect-shared/scripts/nordic-publish.ts "$@"

--- a/scripts/nrfconnect-license.sh
+++ b/scripts/nrfconnect-license.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-SCRIPT_FOLDER="$(dirname $(readlink $0))"
+set -o errexit -o pipefail
 
-ts-node --swc "$SCRIPT_FOLDER/nrfconnect-license.ts" "$@"
+ts-node --swc ./node_modules/pc-nrfconnect-shared/scripts/nrfconnect-license.ts "$@"


### PR DESCRIPTION
Trying to determine the script folder portable is just not worth the effort (e.g. while on some platforms we must supply `readlink` with the `-f` argument, it is not allowed on macOS). Hardcoding the path `./node_modules/pc-nrfconnect-shared/scripts` seems the easiest solution.