### PR TITLE
Handle prettier separate by renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,10 @@
 {
-    "extends": ["config:base", "group:allNonMajor"]
+    "extends": ["config:base", "group:allNonMajor"],
+    "packageRules": [
+        {
+            "groupName": "Prettier",
+            "matchPackageNames": ["prettier"],
+            "matchUpdateTypes": ["minor", "patch"]
+        }
+    ]
 }


### PR DESCRIPTION
Because prettier updates are more likely to break the build, do not group them together with other minor and patch updates.