### PR TITLE
Fix support for the `serialPorts` trait

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.2.2 - 2022-05-10
+
+### Fixed
+
+-   When the trait `serialPorts` is specified it was wrongly overwritten by the
+    `serialPort` (or `serialport`) trait.
+
 ## 6.2.1 - 2022-05-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/DeviceSelector/DeviceSelector.tsx
+++ b/src/Device/DeviceSelector/DeviceSelector.tsx
@@ -59,8 +59,8 @@ const DeviceSelector: FC<Props> = ({
 
     const doStartWatchingDevices = useCallback(() => {
         const patchedDeviceListing = {
-            ...deviceListing,
             serialPorts: deviceListing.serialPort || deviceListing.serialport,
+            ...deviceListing,
         };
         dispatch(startWatchingDevices(patchedDeviceListing, doDeselectDevice));
     }, [deviceListing, dispatch, doDeselectDevice]);


### PR DESCRIPTION
If it was specified it was wrongly overwritten by the `serialPort` (or `serialport`) trait.