### PR TITLE
Move testUtils out of main bundle

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -612,24 +612,6 @@ declare module 'pc-nrfconnect-shared' {
 
     // describeError.ts
     export const describeError: (error: unknown) => string;
-
-    export const testUtils: {
-        // dispatchTo.tsx
-        dispatchTo: <State>(
-            aReducer: Reducer<State>,
-            actions: [Action, ...Action[]]
-        ) => State;
-
-        // testrenderer.tsx
-        render: (
-            appReducer?: Reducer
-        ) => (element: React.ReactElement, actions?: Action[]) => RenderResult;
-
-        // rootReducer.ts
-        rootReducer: <AppState>(
-            appReducer?: Reducer<AppState>
-        ) => Reducer<NrfConnectState<AppState>>;
-    };
 }
 
 declare module 'prettysize' {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import dispatchTo from '../test/dispatchTo';
-import { testRendererForApps } from '../test/testrenderer';
 import { hideDialog, showDialog } from './ErrorDialog/errorDialogSlice';
-import rootReducer from './rootReducer';
 
 const ErrorDialogActions = { hideDialog, showDialog };
 
@@ -73,9 +70,3 @@ export { default as sdfuOperations } from './Device/sdfuOperations';
 export { defaultInitPacket, HashType, FwType } from './Device/initPacket';
 
 export { default as describeError } from './logging/describeError';
-
-export const testUtils = {
-    dispatchTo,
-    render: testRendererForApps,
-    rootReducer,
-};

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+export { testUtils } from './testUtil';

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import rootReducer from '../src/rootReducer';
+import dispatchTo from './dispatchTo';
+import { testRendererForApps } from './testrenderer';
+
+export const testUtils = {
+    dispatchTo,
+    render: testRendererForApps,
+    rootReducer,
+};


### PR DESCRIPTION
Importing testUtils from shared now has to use the path:
```
import { testUtils } from 'pc-nrfconnect-shared/test';
```
The problem with having it in the main index ts, was that it was loaded on starting apps at runtime.