### PR TITLE
Fix: Logging with bundled apps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,11 @@ and this project adheres to
 -   Collect telemetry on cpu architecture to help determine usefulness of 32-bit
     builds.
 
+### Removed
+
+-   `addFileTransport` from the exported interface of the logger, because it
+    should not be called by the launcher any longer.
+
 ## 6.2.3 - 2022-05-11
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.3.0 - 2022-05-23
+
+### Fixed
+
+-   Log file was always empty and could not be opened through “Open log file”
+    for apps bundling shared.
 
 ### Added
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,10 @@
  */
 
 declare module 'pc-nrfconnect-shared' {
-    import { Reducer, Action, AnyAction } from 'redux';
+    import { Reducer, AnyAction } from 'redux';
     import React from 'react';
     import { Logger, LogEntry } from 'winston';
     import Store from 'electron-store';
-    import { RenderResult } from '@testing-library/react';
     import { DeviceTraits } from '@nordicsemiconductor/nrf-device-lib-js';
 
     type RootState = import('./src/state').RootState;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,6 @@ declare module 'pc-nrfconnect-shared' {
     // Logging
 
     interface SharedLogger extends Logger {
-        addFileTransport: (appLogDir: string) => void;
         getAndClearEntries: () => LogEntry[];
         openLogFile: () => void;
         logError: (message: string, error: unknown) => void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.2.3",
+    "version": "6.3.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -9,6 +9,11 @@ import React from 'react';
 import render from '../../test/testrenderer';
 import App, { Pane } from './App';
 
+jest.mock('../Log/LogViewer', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
 const renderApp = (panes: Pane[]) => {
     const dummyReducer = (s = null) => s;
     const dummyNode = <div />;

--- a/src/Log/logListener.ts
+++ b/src/Log/logListener.ts
@@ -15,7 +15,7 @@ import {
 } from '../Device/deviceLibWrapper';
 import logger from '../logging';
 import { TDispatch } from '../state';
-import { getAppDataDir } from '../utils/appDirs';
+import { getAppDataDir, getAppLogDir } from '../utils/appDirs';
 import describeVersion from '../utils/describeVersion';
 import logLibVersions from '../utils/logLibVersions';
 import { addEntries } from './logSlice';
@@ -81,6 +81,8 @@ const addLogEntriesToStore = (dispatch: TDispatch) => () => {
  * @returns {function(*)} Function that stops the listener.
  */
 const startListening = (dispatch: TDispatch) => {
+    logger.addFileTransport(getAppLogDir());
+
     sendInitialMessage();
 
     const LOG_UPDATE_INTERVAL = 400;


### PR DESCRIPTION
The bug: When bundling shared with an app, clicking on “open log file” did not open the log but showed an error in the log viewer: “Unable to open log file: Error: Could not find file at path: undefined”. Also, the log file created on disk was always empty.

The cause: If the app bundles shared, then the module `logging/index.ts` exists twice: The one bundled with the launcher and the one bundled with the app. The launcher calls `logger.addFileTransport` on the module bundled with the launcher, so the module scoped variable `logFilePath` is set in that module. When the app then calls the `logger` to log something, this is done on the module bundled with the app, so the module scoped variable `logFilePath` is not set in that module.

The fix: Instead of calling `logger.addFileTransport` from the launcher call it during initialisation from within the app. 

