### PR TITLE
Fix: Type-checking error when used in apps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.3.1 - 2022-05-23
+
+### Fixed
+
+-   Type-checking error when using 6.3.0 in apps.
+
 ## 6.3.0 - 2022-05-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/utils/packageJson.ts
+++ b/src/utils/packageJson.ts
@@ -7,7 +7,31 @@
 import { readFileSync } from 'fs';
 import { PackageJson } from 'pc-nrfconnect-shared';
 
-// @ts-expect-error This will be available when the app uses it.
+/* Explanation for that cascade of eslint-disable-next-line and @ts-ignore:
+   '../../../../package.json' will resolve correctly when `shared` is used in
+   a real app, so it is fine.
+
+   When checking `shared` '../../../../package.json' will not be there, so we
+   need to disable the errors that occur in that case. That is done by the
+   second and third statement:
+     // @ts-ignore This will be available when the app uses it.
+     // eslint-disable-next-line import/no-unresolved
+
+   Usually we would not use `@ts-ignore` but rather `@ts-expect-error`. But
+   the latter is not possible for a different reason: When we type-check an
+   app that uses shared, that line will now be type-checked too and now
+   '../../../../package.json' actually is there, so `ts-expect-error` would
+   lead to an error, telling us that contrary to our expectation there is no
+   error there.
+
+   Because of that we have to use `@ts-ignore`. But that is usually forbidden
+   by the linting rules, so additionally we have to add that first line
+     eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
+   Phew!
+*/
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore This will be available when the app uses it.
 // eslint-disable-next-line import/no-unresolved
 import packageJsons from '../../../../package.json';
 


### PR DESCRIPTION
When 6.3.0 was used in an app the type checking shows an error that was not possible to fix within the app. The explanation is a bit … complicated and described in `src/utils/packageJson.ts`.