### PR TITLE
Broken trait

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.4.0 - 2022-06-30
 
 ### Added
 
--   Export verbose log state selector,
 -   Add shortcut menu and implement shortcuts
+-   `BrokenDeviceDialog` component that shows more info when selecting a device
+    with broken traits.
+-   Devices with broken trait are listed as unsupported in `DeviceLister`.
+-   Export verbose log state selector.
 
 ## 6.3.4 - 2022-06-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.3.4",
+    "version": "6.4.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -16,6 +16,7 @@ import { Reducer } from 'redux';
 import About from '../About/About';
 import { setDocumentationSections } from '../About/documentationSlice';
 import AppReloadDialog from '../AppReload/AppReloadDialog';
+import BrokenDeviceDialog from '../Device/BrokenDeviceDialog/BrokenDeviceDialog';
 import { forwardLogEventsFromDeviceLib } from '../Device/deviceLibWrapper';
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary';
 import ErrorDialog from '../ErrorDialog/ErrorDialog';
@@ -180,6 +181,7 @@ const ConnectedApp: FC<ConnectedAppProps> = ({
 
             <AppReloadDialog />
             <ErrorDialog />
+            <BrokenDeviceDialog />
             {children}
         </div>
     );

--- a/src/Device/BrokenDeviceDialog/BrokenDeviceDialog.tsx
+++ b/src/Device/BrokenDeviceDialog/BrokenDeviceDialog.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    hideDialog,
+    info as infoSelector,
+    isVisible as isVisibleSelector,
+} from './brokenDeviceDialogSlice';
+
+import './broken-device-dialog.scss';
+
+const AppReloadDialog = () => {
+    const dispatch = useDispatch();
+
+    const isVisible = useSelector(isVisibleSelector);
+    const { description, url } = useSelector(infoSelector);
+
+    return (
+        <Modal
+            show={isVisible}
+            onHide={() => dispatch(hideDialog())}
+            centered
+            className="broken-device-dialog"
+        >
+            <Modal.Header closeButton={false}>
+                <p>
+                    <b>Unusable device</b>
+                </p>
+
+                <span className="mdi mdi-alert" />
+            </Modal.Header>
+            <Modal.Body>
+                {' '}
+                <p>{description}</p>
+                <a target="_blank" rel="noreferrer" href={url}>
+                    {url}
+                </a>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    onClick={() => dispatch(hideDialog())}
+                    variant="secondary"
+                >
+                    Close
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default AppReloadDialog;

--- a/src/Device/BrokenDeviceDialog/broken-device-dialog.scss
+++ b/src/Device/BrokenDeviceDialog/broken-device-dialog.scss
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+@import '../../variables';
+
+.broken-device-dialog {
+    .modal-content {
+        border: 0 transparent;
+        box-shadow: 0px 3px 6px #00000029;
+        background: #ffffff 0% 0% no-repeat padding-box;
+    }
+
+    .modal-header {
+        height: 40px;
+        border: 0 transparent;
+        background: $gray-50;
+        padding: 0 16px;
+
+        flex-direction: row;
+        align-items: center;
+
+        p {
+            font-size: 14px;
+            margin: 0;
+        }
+
+        .mdi {
+            font-size: 20px;
+        }
+    }
+
+    .modal-body {
+        padding: 32px 16px 16px 16px;
+        p {
+            font-size: 14px;
+        }
+
+        p + p {
+            margin-bottom: 24px;
+        }
+    }
+
+    .modal-footer {
+        padding: 16px;
+        border: 0 transparent;
+        button {
+            height: 32px;
+            padding: 0 16px;
+            font-size: 12px;
+        }
+    }
+}

--- a/src/Device/BrokenDeviceDialog/brokenDeviceDialogSlice.tsx
+++ b/src/Device/BrokenDeviceDialog/brokenDeviceDialogSlice.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { createSlice } from '@reduxjs/toolkit';
+
+import { BrokenDeviceDialog, RootState } from '../../state';
+
+const initialState: BrokenDeviceDialog = {
+    isVisible: false,
+    description: '',
+    url: '',
+};
+
+const slice = createSlice({
+    name: 'brokenDeviceDialog',
+    initialState,
+    reducers: {
+        showDialog: (state, action) => {
+            state.isVisible = true;
+            state.description = action.payload.description;
+            state.url = action.payload.url;
+        },
+        hideDialog: state => {
+            state.isVisible = false;
+        },
+    },
+});
+
+export const {
+    reducer,
+    actions: { hideDialog, showDialog },
+} = slice;
+
+export const isVisible = (state: RootState) =>
+    state.brokenDeviceDialog.isVisible;
+export const info = (state: RootState) => ({
+    description: state.brokenDeviceDialog.description,
+    url: state.brokenDeviceDialog.url,
+});

--- a/src/Device/DeviceSelector/BasicDeviceInfo.tsx
+++ b/src/Device/DeviceSelector/BasicDeviceInfo.tsx
@@ -51,7 +51,7 @@ const DeviceSerialNumber: FC<{ device: Device }> = ({ device }) => (
 interface BasicDeviceProps {
     device: Device;
     deviceNameInputRef?: React.Ref<HTMLInputElement>;
-    toggles: ReactNode;
+    toggles?: ReactNode;
 }
 
 const BasicDeviceInfo: FC<BasicDeviceProps> = ({

--- a/src/Device/DeviceSelector/DeviceIcon.tsx
+++ b/src/Device/DeviceSelector/DeviceIcon.tsx
@@ -15,7 +15,11 @@ const DeviceIcon: FC<{ device: Device }> = ({ device }) => {
     const Icon = deviceInfo(device).icon;
     return (
         <div className="icon">
-            <Icon />
+            {device.traits.broken ? (
+                <span className="mdi mdi-alert" />
+            ) : (
+                <Icon />
+            )}
         </div>
     );
 };

--- a/src/Device/DeviceSelector/DeviceList/BrokenDevice.tsx
+++ b/src/Device/DeviceSelector/DeviceList/BrokenDevice.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React, { FC } from 'react';
+import { useDispatch } from 'react-redux';
+import { bool, func } from 'prop-types';
+
+import PseudoButton from '../../../PseudoButton/PseudoButton';
+import { Device as DeviceProps } from '../../../state';
+import { showDialog } from '../../BrokenDeviceDialog/brokenDeviceDialogSlice';
+import BasicDeviceInfo from '../BasicDeviceInfo';
+
+import './broken-device.scss';
+
+const ShowMoreInfo: FC<{ isVisible: boolean; toggleVisible: () => void }> = ({
+    isVisible,
+    toggleVisible,
+}) => (
+    <PseudoButton
+        className={`show-more mdi mdi-chevron-${isVisible ? 'up' : 'down'}`}
+        testId="show-more-device-info"
+        onClick={toggleVisible}
+    />
+);
+
+ShowMoreInfo.propTypes = {
+    isVisible: bool.isRequired,
+    toggleVisible: func.isRequired,
+};
+
+interface Props {
+    device: DeviceProps;
+}
+
+const Device: FC<Props> = ({ device }) => {
+    const dispatch = useDispatch();
+
+    return (
+        <PseudoButton
+            className="broken-device"
+            onClick={() => dispatch(showDialog(device.broken))}
+        >
+            <BasicDeviceInfo device={device} />
+            <div className="broken-device-info">
+                <p>Unusable device detected </p>
+                <p>
+                    <u>More information</u>
+                </p>
+            </div>
+        </PseudoButton>
+    );
+};
+
+export default Device;

--- a/src/Device/DeviceSelector/DeviceList/DeviceList.tsx
+++ b/src/Device/DeviceSelector/DeviceList/DeviceList.tsx
@@ -12,6 +12,7 @@ import { Device as DeviceProps } from '../../../state';
 import classNames from '../../../utils/classNames';
 import { sortedDevices } from '../../deviceSlice';
 import { AnimatedItem, AnimatedList } from './AnimatedList';
+import BrokenDevice from './BrokenDevice';
 import Device from './Device';
 
 import './device-list.scss';
@@ -62,11 +63,15 @@ const DeviceList: FC<Props> = ({
                             key={device.serialNumber}
                             itemKey={device.serialNumber}
                         >
-                            <Device
-                                device={device}
-                                doSelectDevice={doSelectDevice}
-                                allowMoreInfoVisible={isVisible}
-                            />
+                            {device.traits.broken ? (
+                                <BrokenDevice device={device} />
+                            ) : (
+                                <Device
+                                    device={device}
+                                    doSelectDevice={doSelectDevice}
+                                    allowMoreInfoVisible={isVisible}
+                                />
+                            )}
                         </AnimatedItem>
                     ))}
                 </AnimatedList>

--- a/src/Device/DeviceSelector/DeviceList/broken-device.scss
+++ b/src/Device/DeviceSelector/DeviceList/broken-device.scss
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+@import '../../../variables';
+
+.core19-device-selector {
+    .broken-device {
+        display: flex;
+        flex-direction: column;
+
+        padding: 12px 0;
+        font-weight: $font-weight-light;
+
+        .icon {
+            transform: translateY(0);
+        }
+
+        .broken-device-info {
+            margin: 8px 0 8px 68px;
+            font-size: 12px;
+            p {
+                margin: 0;
+            }
+            p + p {
+                margin-top: 1em;
+            }
+        }
+    }
+}

--- a/src/Device/DeviceSelector/device-icon.scss
+++ b/src/Device/DeviceSelector/device-icon.scss
@@ -13,6 +13,12 @@
         padding-left: 27px;
 
         fill: $gray-700;
+
+        .mdi {
+            display: flex;
+            flex-direction: column;
+            font-size: 27px;
+        }
     }
 
     .selected-device:hover .icon {

--- a/src/rootReducer.ts
+++ b/src/rootReducer.ts
@@ -9,6 +9,7 @@ import { combineReducers, Reducer } from 'redux';
 import { reducer as documentation } from './About/documentationSlice';
 import { reducer as appLayout } from './App/appLayout';
 import { reducer as appReloadDialog } from './AppReload/appReloadDialogSlice';
+import { reducer as brokenDeviceDialog } from './Device/BrokenDeviceDialog/brokenDeviceDialogSlice';
 import { reducer as device } from './Device/deviceSlice';
 import { reducer as errorDialog } from './ErrorDialog/errorDialogSlice';
 import { reducer as log } from './Log/logSlice';
@@ -17,6 +18,7 @@ const coreReducers = {
     appLayout,
     appReloadDialog,
     device,
+    brokenDeviceDialog,
     errorDialog,
     log,
     documentation,

--- a/src/state.ts
+++ b/src/state.ts
@@ -19,6 +19,7 @@ export interface RootState {
     log: Log;
     device: DeviceState;
     documentation: DocumentationState;
+    brokenDeviceDialog: BrokenDeviceDialog;
 }
 
 export interface AppLayout {
@@ -97,4 +98,10 @@ export interface Device extends NrfdlDevice {
     nickname?: string;
     serialport?: Serialport;
     favorite?: boolean;
+}
+
+export interface BrokenDeviceDialog {
+    isVisible: boolean;
+    description: string;
+    url: string;
 }


### PR DESCRIPTION
Devices with a broken trait will be unselectable and displayed as such:
![Screenshot from 2022-06-30 11-33-17](https://user-images.githubusercontent.com/30871542/176644218-e4eb883d-3e92-4ce0-aa2c-029baf50cc7a.png)

Clicking the device element brings up a dialog with the broken trait information received from nrf-device-lib
![Screenshot from 2022-06-30 11-33-30](https://user-images.githubusercontent.com/30871542/176644236-d1810b1e-74fb-4201-bcaa-15dc61818332.png)

