### PR TITLE
Fix: macOS freeze

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.3.2 - 2022-06-21
 
 ### Fixed
 
 -   macOS: Froze a few seconds after launch (happened in the launcher and apps
-    that bundle shared).
+    that bundle shared is usage data was enabled).
 
 ## 6.3.1 - 2022-05-23
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   macOS: Froze a few seconds after launch (happened in the launcher and apps
+    that bundle shared).
+
 ## 6.3.1 - 2022-05-23
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -496,16 +496,6 @@
                 "@babel/types": "^7.14.5"
             }
         },
-        "@babel/helpers": {
-            "version": "7.15.3",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-            "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
-            "requires": {
-                "@babel/template": "^7.14.5",
-                "@babel/traverse": "^7.15.0",
-                "@babel/types": "^7.15.0"
-            }
-        },
         "@babel/highlight": {
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -1000,14 +990,6 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
-        "@babel/plugin-syntax-jsx": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-            "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            }
-        },
         "@babel/plugin-syntax-logical-assignment-operators": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -1462,43 +1444,6 @@
                 "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
-        "@babel/plugin-transform-react-display-name": {
-            "version": "7.15.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
-            "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            }
-        },
-        "@babel/plugin-transform-react-jsx": {
-            "version": "7.14.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
-            "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.14.5",
-                "@babel/helper-module-imports": "^7.14.5",
-                "@babel/helper-plugin-utils": "^7.14.5",
-                "@babel/plugin-syntax-jsx": "^7.14.5",
-                "@babel/types": "^7.14.9"
-            }
-        },
-        "@babel/plugin-transform-react-jsx-development": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
-            "integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
-            "requires": {
-                "@babel/plugin-transform-react-jsx": "^7.14.5"
-            }
-        },
-        "@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
-            "integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.14.5",
-                "@babel/helper-plugin-utils": "^7.14.5"
-            }
-        },
         "@babel/plugin-transform-regenerator": {
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
@@ -1866,72 +1811,6 @@
                 "semver": "^6.3.0"
             },
             "dependencies": {
-                "@babel/plugin-proposal-class-properties": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
-                    "integrity": "sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==",
-                    "requires": {
-                        "@babel/helper-create-class-features-plugin": "^7.14.5",
-                        "@babel/helper-plugin-utils": "^7.14.5"
-                    }
-                },
-                "@babel/plugin-proposal-nullish-coalescing-operator": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
-                    "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.14.5",
-                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-                    }
-                },
-                "@babel/plugin-proposal-object-rest-spread": {
-                    "version": "7.14.7",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
-                    "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
-                    "requires": {
-                        "@babel/compat-data": "^7.14.7",
-                        "@babel/helper-compilation-targets": "^7.14.5",
-                        "@babel/helper-plugin-utils": "^7.14.5",
-                        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                        "@babel/plugin-transform-parameters": "^7.14.5"
-                    }
-                },
-                "@babel/plugin-transform-destructuring": {
-                    "version": "7.14.7",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
-                    "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.14.5"
-                    }
-                },
-                "@babel/plugin-transform-modules-commonjs": {
-                    "version": "7.15.0",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz",
-                    "integrity": "sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==",
-                    "requires": {
-                        "@babel/helper-module-transforms": "^7.15.0",
-                        "@babel/helper-plugin-utils": "^7.14.5",
-                        "@babel/helper-simple-access": "^7.14.8",
-                        "babel-plugin-dynamic-import-node": "^2.3.3"
-                    }
-                },
-                "@babel/plugin-transform-parameters": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
-                    "integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.14.5"
-                    }
-                },
-                "@babel/plugin-transform-spread": {
-                    "version": "7.14.6",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
-                    "integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.14.5",
-                        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
-                    }
-                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3472,31 +3351,8 @@
                 "svg-parser": "^2.0.2"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.15.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-                    "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.14.5",
-                        "@babel/generator": "^7.15.0",
-                        "@babel/helper-compilation-targets": "^7.15.0",
-                        "@babel/helper-module-transforms": "^7.15.0",
-                        "@babel/helpers": "^7.14.8",
-                        "@babel/parser": "^7.15.0",
-                        "@babel/template": "^7.14.5",
-                        "@babel/traverse": "^7.15.0",
-                        "@babel/types": "^7.15.0",
-                        "convert-source-map": "^1.7.0",
-                        "debug": "^4.1.0",
-                        "gensync": "^1.0.0-beta.2",
-                        "json5": "^2.1.2",
-                        "semver": "^6.3.0",
-                        "source-map": "^0.5.0"
-                    }
-                },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "version": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
@@ -3526,44 +3382,8 @@
                 "loader-utils": "^2.0.0"
             },
             "dependencies": {
-                "@babel/core": {
-                    "version": "7.15.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-                    "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-                    "requires": {
-                        "@babel/code-frame": "^7.14.5",
-                        "@babel/generator": "^7.15.0",
-                        "@babel/helper-compilation-targets": "^7.15.0",
-                        "@babel/helper-module-transforms": "^7.15.0",
-                        "@babel/helpers": "^7.14.8",
-                        "@babel/parser": "^7.15.0",
-                        "@babel/template": "^7.14.5",
-                        "@babel/traverse": "^7.15.0",
-                        "@babel/types": "^7.15.0",
-                        "convert-source-map": "^1.7.0",
-                        "debug": "^4.1.0",
-                        "gensync": "^1.0.0-beta.2",
-                        "json5": "^2.1.2",
-                        "semver": "^6.3.0",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/preset-react": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
-                    "integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.14.5",
-                        "@babel/helper-validator-option": "^7.14.5",
-                        "@babel/plugin-transform-react-display-name": "^7.14.5",
-                        "@babel/plugin-transform-react-jsx": "^7.14.5",
-                        "@babel/plugin-transform-react-jsx-development": "^7.14.5",
-                        "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
-                    }
-                },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "version": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
@@ -4181,6 +4001,12 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
         },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
+        },
         "@types/warning": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
@@ -4348,12 +4174,6 @@
                         "tapable": "^2.2.0"
                     }
                 },
-                "graceful-fs": {
-                    "version": "4.2.9",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-                    "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-                    "dev": true
-                },
                 "loader-runner": {
                     "version": "4.2.0",
                     "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -4475,6 +4295,14 @@
                         "terser-webpack-plugin": "^5.1.3",
                         "watchpack": "^2.3.1",
                         "webpack-sources": "^3.2.3"
+                    },
+                    "dependencies": {
+                        "graceful-fs": {
+                            "version": "4.2.10",
+                            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+                            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+                            "dev": true
+                        }
                     }
                 },
                 "webpack-sources": {
@@ -8212,17 +8040,11 @@
                     }
                 },
                 "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "version": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "requires": {
                         "minimist": "^1.2.0"
                     }
-                },
-                "minimist": {
-                    "version": "1.2.6",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-                    "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
                 },
                 "resolve": {
                     "version": "1.22.0",
@@ -8232,17 +8054,6 @@
                         "is-core-module": "^2.8.1",
                         "path-parse": "^1.0.7",
                         "supports-preserve-symlinks-flag": "^1.0.0"
-                    }
-                },
-                "tsconfig-paths": {
-                    "version": "3.14.1",
-                    "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-                    "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-                    "requires": {
-                        "@types/json5": "^0.0.29",
-                        "json5": "^1.0.1",
-                        "minimist": "^1.2.6",
-                        "strip-bom": "^3.0.0"
                     }
                 }
             }
@@ -9309,22 +9120,6 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-                },
                 "schema-utils": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -9593,11 +9388,6 @@
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "xregexp": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-                    "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
                 }
             }
         },
@@ -10880,6 +10670,11 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
             "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         },
         "isarray": {
             "version": "1.0.0",
@@ -16892,6 +16687,13 @@
                 "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+                }
             }
         },
         "require-directory": {
@@ -18040,22 +17842,6 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-                },
                 "schema-utils": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -18160,17 +17946,6 @@
                 "string-width": "^3.0.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -18185,11 +17960,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
                 },
                 "string-width": {
                     "version": "3.1.0",
@@ -18343,17 +18113,6 @@
                 "worker-farm": "^1.7.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "find-cache-dir": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -18363,16 +18122,6 @@
                         "make-dir": "^2.0.0",
                         "pkg-dir": "^3.0.0"
                     }
-                },
-                "is-wsl": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-                    "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
                 },
                 "make-dir": {
                     "version": "2.1.0",
@@ -19073,22 +18822,6 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-                },
                 "schema-utils": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -19157,9 +18890,9 @@
             }
         },
         "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",
@@ -19428,17 +19161,6 @@
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
                     "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
                 },
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "eslint-scope": {
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -19447,11 +19169,6 @@
                         "esrecurse": "^4.1.0",
                         "estraverse": "^4.1.1"
                     }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
                 },
                 "json5": {
                     "version": "1.0.1",
@@ -19770,6 +19487,11 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+        },
+        "xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
         "ts-node": "10.8.1",
         "typescript": "4.7.3",
         "url-loader": "4.1.1",
+        "uuid": "8.3.2",
         "webpack": "4.46.0",
         "webpack-cli": "4.10.0",
         "winston": "3.7.2"
@@ -121,6 +122,7 @@
         "@types/klaw": "3.0.3",
         "@types/lodash.range": "3.2.7",
         "@types/semver": "7.3.9",
+        "@types/uuid": "8.3.4",
         "@types/webpack": "5.28.0",
         "electron": "13.6.9",
         "electron-store": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -25,9 +25,6 @@ jest.mock('../utils/usageData', () => ({
     sendErrorReport: jest.fn(),
     isEnabled: () => true,
 }));
-jest.mock('systeminformation', () => ({
-    networkInterfaces: () => [],
-}));
 
 const SYSTEM_REPORT = 'system report';
 const OKBUTTONTEXT = 'Restore';

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -5,12 +5,14 @@
  */
 
 import Store from 'electron-store';
+import { v4 as uuid } from 'uuid';
 
 import packageJson from './packageJson';
 
 const sharedStore = new Store<{
     verboseLogging: boolean;
     isSendingUsageData: boolean | undefined;
+    clientId?: string;
 }>({
     name: 'pc-nrfconnect-shared',
 });
@@ -31,6 +33,16 @@ export const getIsSendingUsageData = () =>
     sharedStore.get('isSendingUsageData', undefined) as boolean | undefined;
 export const deleteIsSendingUsageData = () =>
     sharedStore.delete('isSendingUsageData');
+
+const existingUsageDataClientId = () => sharedStore.get('clientId');
+const newUsageDataClientId = () => {
+    const clientId = uuid();
+    sharedStore.set('clientId', clientId);
+
+    return clientId;
+};
+export const getUsageDataClientId = () =>
+    existingUsageDataClientId() ?? newUsageDataClientId();
 
 export const persistVerboseLoggingEnabled = (value: boolean) =>
     sharedStore.set('verboseLogging', value);

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import { EOL } from 'os';
 import path from 'path';
 import pretty from 'prettysize';
+import type Systeminformation from 'systeminformation';
 
 import {
     deviceInfo as getDeviceInfo,
@@ -26,7 +27,7 @@ import { openFile } from './open';
 
 const generalInfoReport = async () => {
     // eslint-disable-next-line global-require
-    const si = require('systeminformation');
+    const si = require('systeminformation') as typeof Systeminformation;
     const [
         { manufacturer, model },
         { vendor, version },

--- a/src/utils/usageData.ts
+++ b/src/utils/usageData.ts
@@ -6,13 +6,13 @@
 
 import reactGA from 'react-ga';
 import { PackageJson } from 'pc-nrfconnect-shared';
-import shasum from 'shasum';
 
 import logger from '../logging';
 import { isDevelopment } from './environment';
 import {
     deleteIsSendingUsageData,
     getIsSendingUsageData,
+    getUsageDataClientId,
     persistIsSendingUsageData,
 } from './persistentStore';
 
@@ -43,31 +43,7 @@ export const init = (packageJson: PackageJson) => {
     setTimeout(async () => {
         // eslint-disable-next-line global-require
         const si = require('systeminformation');
-        const networkInterfaces: {
-            // Lost the type doing lazy require
-            iface: string;
-            mac: boolean;
-            ip4: string;
-            ip6: string;
-            internal: boolean;
-        }[] = await si.networkInterfaces();
-        const networkInterface =
-            networkInterfaces.find(i => i.iface === 'eth0') ?? // for most Debian
-            networkInterfaces.find(i => i.iface === 'en0') ?? // for most macOS
-            networkInterfaces.find(i => i.iface === 'Ethernet') ?? // for most Windows
-            networkInterfaces.find(i => i.mac && !i.internal); // for good luck
-
-        logger.debug(`iface: ${networkInterface?.iface}`);
-        logger.debug(`IP4: ${networkInterface?.ip4}`);
-        logger.debug(`IP6: ${networkInterface?.ip6}`);
-        logger.debug(`MAC: ${networkInterface?.mac}`);
-
-        const clientId = networkInterface
-            ? shasum(
-                  networkInterface.ip4 ||
-                      networkInterface.ip6 + networkInterface.mac
-              )
-            : 'unknown';
+        const clientId = getUsageDataClientId();
 
         logger.debug(`Client Id: ${clientId}`);
 

--- a/src/utils/usageData.ts
+++ b/src/utils/usageData.ts
@@ -6,6 +6,7 @@
 
 import reactGA from 'react-ga';
 import { PackageJson } from 'pc-nrfconnect-shared';
+import type Systeminformation from 'systeminformation';
 
 import logger from '../logging';
 import { isDevelopment } from './environment';
@@ -41,8 +42,6 @@ export const init = (packageJson: PackageJson) => {
     if (!getIsSendingUsageData()) return;
 
     setTimeout(async () => {
-        // eslint-disable-next-line global-require
-        const si = require('systeminformation');
         const clientId = getUsageDataClientId();
 
         logger.debug(`Client Id: ${clientId}`);
@@ -68,6 +67,8 @@ export const init = (packageJson: PackageJson) => {
 
         reactGA.pageview(appJson.name);
 
+        // eslint-disable-next-line global-require
+        const si = require('systeminformation') as typeof Systeminformation;
         sendUsageData('architecture', (await si.osInfo()).arch);
 
         initialized = true;
@@ -95,7 +96,7 @@ export const isInitialized = () => {
  * @returns {Boolean | undefined} returns whether the setting is on, off or undefined
  */
 export const isEnabled = () => {
-    const isSendingUsageData = getIsSendingUsageData() as boolean | undefined;
+    const isSendingUsageData = getIsSendingUsageData();
     logger.debug(`Usage data is ${isSendingUsageData}`);
     return isSendingUsageData;
 };


### PR DESCRIPTION
Fixes a bug on macOS: The launcher and apps that bundle shared froze a few seconds after launch. 

This was caused by [calling `systeminformation.networkInterfaces()`](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/blob/034b0d73ccb6ad9246c200bedfdbecddc9f6e29d/src/utils/usageData.ts#L53) (because on macOS that [calls `ipconfig getpacket`](https://github.com/sebhildebrandt/systeminformation/blob/69987c5c60ae35ca90e77ff106e1238e26229129/lib/network.js#L624-L637) for every network interface, each call takes about 300 ms, which sums up to 5 s in my case).

The network interfaces are only used to [determine a `clientId` for GA](https://github.com/sebhildebrandt/systeminformation/blob/69987c5c60ae35ca90e77ff106e1238e26229129/lib/network.js#L624-L637). 

This PR instead creates and stores a unique client ID and uses that for all further GA sessions. 

I am creating only a draft PR for this for now, because I first want to hear from Chun next week whether he has any objections.