### PR TITLE
feat: add export for verbose log state selector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+-   Export verbose log state selector,
+
 ## 6.3.4 - 2022-06-29
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -580,7 +580,7 @@ declare module 'pc-nrfconnect-shared' {
 
     // logSlice.js
 
-    export function verboseLoggingEnabled<AppState>(
+    export function isLoggingVerbose<AppState>(
         state: NrfConnectState<AppState>
     ): boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -578,6 +578,12 @@ declare module 'pc-nrfconnect-shared' {
         state: NrfConnectState<AppState>
     ): number;
 
+    // logSlice.js
+
+    export function verboseLoggingEnabled<AppState>(
+        state: NrfConnectState<AppState>
+    ): boolean;
+
     // persistentStore.ts
 
     /**

--- a/src/About/SupportCard.tsx
+++ b/src/About/SupportCard.tsx
@@ -16,9 +16,9 @@ import {
     selectedSerialNumber,
     sortedDevices,
 } from '../Device/deviceSlice';
-import { toggleVerboseLogging, verboseLoggingEnabled } from '../Log/logSlice';
+import { isLoggingVerbose, toggleIsLoggingVerbose } from '../Log/logSlice';
 import { Toggle } from '../Toggle/Toggle';
-import { persistVerboseLoggingEnabled } from '../utils/persistentStore';
+import { persistIsLoggingVerbose } from '../utils/persistentStore';
 import systemReport from '../utils/systemReport';
 import AboutButton from './AboutButton';
 import Section from './Section';
@@ -27,11 +27,11 @@ export default () => {
     const dispatch = useDispatch();
     const devices = useSelector(sortedDevices);
     const currentSerialNumber = useSelector(selectedSerialNumber);
-    const verboseLogging = useSelector(verboseLoggingEnabled);
+    const verboseLogging = useSelector(isLoggingVerbose);
     const currentDevice = useSelector(deviceInfo);
 
     useEffect(() => {
-        persistVerboseLoggingEnabled(false);
+        persistIsLoggingVerbose(false);
     }, []);
 
     useEffect(() => {
@@ -76,14 +76,14 @@ export default () => {
                 <Toggle
                     id="enableVerboseLoggin"
                     label="VERBOSE LOGGING"
-                    onToggle={() => dispatch(toggleVerboseLogging())}
+                    onToggle={() => dispatch(toggleIsLoggingVerbose())}
                     isToggled={verboseLogging}
                     variant="primary"
                 />
                 <Section>
                     <Button
                         onClick={() => {
-                            persistVerboseLoggingEnabled(true);
+                            persistIsLoggingVerbose(true);
                             getCurrentWindow().reload();
                         }}
                         title="Restart application with verbose logging turned on to get log messages from initial enumeration"

--- a/src/About/SupportCard.tsx
+++ b/src/About/SupportCard.tsx
@@ -16,10 +16,7 @@ import {
     selectedSerialNumber,
     sortedDevices,
 } from '../Device/deviceSlice';
-import {
-    nrfdlVerboseLoggingEnabled,
-    toggleNrflVerboseLogging,
-} from '../Log/logSlice';
+import { toggleVerboseLogging, verboseLoggingEnabled } from '../Log/logSlice';
 import { Toggle } from '../Toggle/Toggle';
 import { persistVerboseLoggingEnabled } from '../utils/persistentStore';
 import systemReport from '../utils/systemReport';
@@ -30,7 +27,7 @@ export default () => {
     const dispatch = useDispatch();
     const devices = useSelector(sortedDevices);
     const currentSerialNumber = useSelector(selectedSerialNumber);
-    const verboseLogging = useSelector(nrfdlVerboseLoggingEnabled);
+    const verboseLogging = useSelector(verboseLoggingEnabled);
     const currentDevice = useSelector(deviceInfo);
 
     useEffect(() => {
@@ -79,7 +76,7 @@ export default () => {
                 <Toggle
                     id="enableVerboseLoggin"
                     label="VERBOSE LOGGING"
-                    onToggle={() => dispatch(toggleNrflVerboseLogging())}
+                    onToggle={() => dispatch(toggleVerboseLogging())}
                     isToggled={verboseLogging}
                     variant="primary"
                 />

--- a/src/Device/deviceLibWrapper.ts
+++ b/src/Device/deviceLibWrapper.ts
@@ -16,10 +16,10 @@ import {
     stopLogEvents,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 
-import { verboseLoggingEnabled } from '../Log/logSlice';
+import { isLoggingVerbose } from '../Log/logSlice';
 import logger from '../logging';
 import { RootState, TDispatch } from '../state';
-import { getVerboseLoggingEnabled } from '../utils/persistentStore';
+import { getIsLoggingVerbose } from '../utils/persistentStore';
 
 const deviceLibContext = createContext();
 export const getDeviceLibContext = () => deviceLibContext;
@@ -28,7 +28,7 @@ export const logNrfdlLogs =
     (evt: LogEvent) => (_: unknown, getState: () => RootState) => {
         if (
             process.env.NODE_ENV === 'production' &&
-            !verboseLoggingEnabled(getState())
+            !isLoggingVerbose(getState())
         )
             return;
         switch (evt.level) {
@@ -94,7 +94,7 @@ export const getModuleVersion = (
     findTopLevel(module, versions) ?? findInDependencies(module, versions);
 
 setLogPattern(getDeviceLibContext(), '[%n][%l](%T.%e) %v');
-setVerboseDeviceLibLogging(getVerboseLoggingEnabled());
+setVerboseDeviceLibLogging(getIsLoggingVerbose());
 setTimeoutConfig(deviceLibContext, {
     enumerateMs: 3 * 60 * 1000,
 });

--- a/src/Device/deviceLibWrapper.ts
+++ b/src/Device/deviceLibWrapper.ts
@@ -16,7 +16,7 @@ import {
     stopLogEvents,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 
-import { nrfdlVerboseLoggingEnabled } from '../Log/logSlice';
+import { verboseLoggingEnabled } from '../Log/logSlice';
 import logger from '../logging';
 import { RootState, TDispatch } from '../state';
 import { getVerboseLoggingEnabled } from '../utils/persistentStore';
@@ -28,7 +28,7 @@ export const logNrfdlLogs =
     (evt: LogEvent) => (_: unknown, getState: () => RootState) => {
         if (
             process.env.NODE_ENV === 'production' &&
-            !nrfdlVerboseLoggingEnabled(getState())
+            !verboseLoggingEnabled(getState())
         )
             return;
         switch (evt.level) {

--- a/src/Log/logSlice.ts
+++ b/src/Log/logSlice.ts
@@ -8,14 +8,14 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { LogEntry } from 'winston';
 
 import { Log, RootState } from '../state';
-import { getVerboseLoggingEnabled } from '../utils/persistentStore';
+import { getIsLoggingVerbose } from '../utils/persistentStore';
 
 const MAX_ENTRIES = 1000;
 
 const initialState: Log = {
     autoScroll: true,
     logEntries: [],
-    verboseLoggingEnabled: getVerboseLoggingEnabled(),
+    isLoggingVerbose: getIsLoggingVerbose(),
 };
 
 const infoEntry = () => ({
@@ -33,8 +33,8 @@ const limitedToMaxSize = (entries: LogEntry[]) =>
 
 export const autoScroll = (state: RootState) => state.log.autoScroll;
 export const logEntries = (state: RootState) => state.log.logEntries;
-export const verboseLoggingEnabled = (state: RootState) =>
-    state.log.verboseLoggingEnabled;
+export const isLoggingVerbose = (state: RootState) =>
+    state.log.isLoggingVerbose;
 
 const slice = createSlice({
     name: 'log',
@@ -52,13 +52,13 @@ const slice = createSlice({
         toggleAutoScroll: state => {
             state.autoScroll = !state.autoScroll;
         },
-        toggleVerboseLogging: state => {
-            state.verboseLoggingEnabled = !state.verboseLoggingEnabled;
+        toggleIsLoggingVerbose: state => {
+            state.isLoggingVerbose = !state.isLoggingVerbose;
         },
     },
 });
 
 export const {
     reducer,
-    actions: { addEntries, clear, toggleAutoScroll, toggleVerboseLogging },
+    actions: { addEntries, clear, toggleAutoScroll, toggleIsLoggingVerbose },
 } = slice;

--- a/src/Log/logSlice.ts
+++ b/src/Log/logSlice.ts
@@ -15,7 +15,7 @@ const MAX_ENTRIES = 1000;
 const initialState: Log = {
     autoScroll: true,
     logEntries: [],
-    nrfdlVerboseLogging: getVerboseLoggingEnabled(),
+    verboseLoggingEnabled: getVerboseLoggingEnabled(),
 };
 
 const infoEntry = () => ({
@@ -33,8 +33,8 @@ const limitedToMaxSize = (entries: LogEntry[]) =>
 
 export const autoScroll = (state: RootState) => state.log.autoScroll;
 export const logEntries = (state: RootState) => state.log.logEntries;
-export const nrfdlVerboseLoggingEnabled = (state: RootState) =>
-    state.log.nrfdlVerboseLogging;
+export const verboseLoggingEnabled = (state: RootState) =>
+    state.log.verboseLoggingEnabled;
 
 const slice = createSlice({
     name: 'log',
@@ -52,13 +52,13 @@ const slice = createSlice({
         toggleAutoScroll: state => {
             state.autoScroll = !state.autoScroll;
         },
-        toggleNrflVerboseLogging: state => {
-            state.nrfdlVerboseLogging = !state.nrfdlVerboseLogging;
+        toggleVerboseLogging: state => {
+            state.verboseLoggingEnabled = !state.verboseLoggingEnabled;
         },
     },
 });
 
 export const {
     reducer,
-    actions: { addEntries, clear, toggleAutoScroll, toggleNrflVerboseLogging },
+    actions: { addEntries, clear, toggleAutoScroll, toggleVerboseLogging },
 } = slice;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export { isDevelopment } from './utils/environment';
 
 export { currentPane, setCurrentPane } from './App/appLayout';
 
-export { verboseLoggingEnabled } from './Log/logSlice';
+export { isLoggingVerbose } from './Log/logSlice';
 
 export { getAppSpecificStore as getPersistentStore } from './utils/persistentStore';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ export { isDevelopment } from './utils/environment';
 
 export { currentPane, setCurrentPane } from './App/appLayout';
 
+export { verboseLoggingEnabled } from './Log/logSlice';
+
 export { getAppSpecificStore as getPersistentStore } from './utils/persistentStore';
 
 export { selectedDevice } from './Device/deviceSlice';

--- a/src/state.ts
+++ b/src/state.ts
@@ -46,7 +46,7 @@ export interface ErrorResolutions {
 export interface Log {
     autoScroll: boolean;
     logEntries: LogEntry[];
-    verboseLoggingEnabled: boolean;
+    isLoggingVerbose: boolean;
 }
 
 export type Devices = { [key: string]: Device | undefined };

--- a/src/state.ts
+++ b/src/state.ts
@@ -46,7 +46,7 @@ export interface ErrorResolutions {
 export interface Log {
     autoScroll: boolean;
     logEntries: LogEntry[];
-    nrfdlVerboseLogging: boolean;
+    verboseLoggingEnabled: boolean;
 }
 
 export type Devices = { [key: string]: Device | undefined };

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -44,10 +44,10 @@ const newUsageDataClientId = () => {
 export const getUsageDataClientId = () =>
     existingUsageDataClientId() ?? newUsageDataClientId();
 
-export const persistVerboseLoggingEnabled = (value: boolean) =>
-    sharedStore.set('verboseLogging', value);
-export const getVerboseLoggingEnabled = () =>
-    sharedStore.get('verboseLogging', false);
+export const persistIsLoggingVerbose = (value: boolean) =>
+    sharedStore.set('isLoggingVerbose', value);
+export const getIsLoggingVerbose = () =>
+    sharedStore.get('isLoggingVerbose', false);
 
 // This one must be initialised lazily, because the package.json is not read yet when this module is initialised.
 // This can probably be changed when we bundle shared with the apps.


### PR DESCRIPTION
Exposes a state selector for the verbose log setting

Also removes `nrfdl` from the verbose code when it is not specific for nRF Device Lib