### PR TITLE
Fix: Support legacy `useHotKey()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   The old API of `useHotKey()` was broken. Now the old and the new API are
+    supported. Using the old API just triggers a warning on the console.
+
 ## 6.4.1 - 2022-07-07
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -533,6 +533,12 @@ declare module 'pc-nrfconnect-shared' {
         deps?: React.DependencyList
     ): void;
 
+    // Legacy API for the same function
+    export function useHotKey(
+        hotKey: string | string[],
+        action: () => void
+    ): void;
+
     // classNames.js
 
     /**

--- a/src/utils/useHotKey.tsx
+++ b/src/utils/useHotKey.tsx
@@ -11,7 +11,7 @@ import Mousetrap from 'mousetrap';
 import { addShortcut, removeShortcut, Shortcut } from '../About/shortcutSlice';
 import { sendUsageData } from './usageData';
 
-export default (shortcut: Shortcut, deps?: DependencyList) => {
+const useNewHotKey = (shortcut: Shortcut, deps: DependencyList = []) => {
     const dispatch = useDispatch();
     useEffect(() => {
         dispatch(addShortcut(shortcut));
@@ -28,4 +28,35 @@ export default (shortcut: Shortcut, deps?: DependencyList) => {
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, deps);
+};
+const useLegacyHotKey = (hotKey: string | string[], action: () => void) => {
+    console.warn(
+        `Defining a hot key for '${hotKey}' using a legacy API. ` +
+            'Please update the app (or tell the app author to update it to ' +
+            'the latest API).'
+    );
+
+    useNewHotKey({
+        hotKey,
+        title: 'Legacy shortcut',
+        isGlobal: false,
+        action,
+    });
+};
+
+const isUsingLegacyHotkey = (
+    args: unknown[]
+): args is Parameters<typeof useLegacyHotKey> =>
+    args.length === 2 && typeof args[1] === 'function';
+
+export default (
+    ...args:
+        | Parameters<typeof useNewHotKey>
+        | Parameters<typeof useLegacyHotKey>
+) => {
+    if (isUsingLegacyHotkey(args)) {
+        useLegacyHotKey(...args);
+    } else {
+        useNewHotKey(...args);
+    }
 };


### PR DESCRIPTION
The old API of `useHotKey()` was broken. Now the old and the new API are supported. Using the old API just triggers a warning on the console.