### PR TITLE
fix: log was never created

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.5.5 - 2022-08-19
+
+### Fixed
+
+-   Log file was never created.
+
 ## 6.5.4 - 2022-08-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.5.4",
+    "version": "6.5.5",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
`getAppLogDir`was not set at the time of importing logging/index.tsx
which caused the log file to never be created.