### PR TITLE
Recommend macOS users to use JLink Universal Installer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## 6.6.0 - 2022-08-24
 
+### Added
+
+-   macOS: Warning for M1 users who does not have JLink Universal version.
+
 ### Fixed
 
 -   Windows: Some development scripts were broken if no bash was installed.

--- a/src/Device/deviceLibWrapper.ts
+++ b/src/Device/deviceLibWrapper.ts
@@ -100,14 +100,17 @@ type KnownModule = 'nrfdl' | 'nrfdl-js' | 'jprog' | 'JlinkARM';
 const findTopLevel = (module: KnownModule, versions: ModuleVersion[]) =>
     versions.find(version => version.name === module);
 
-const findInDependencies = (module: KnownModule, versions: ModuleVersion[]) =>
-    getModuleVersion(
-        module,
-        versions.flatMap(version => [
-            ...(version.dependencies ?? []),
-            ...((version.plugins as ModuleVersion[]) ?? []),
-        ])
-    );
+const findInDependencies = (module: KnownModule, versions: ModuleVersion[]) => {
+    if (versions.length > 0) {
+        return getModuleVersion(
+            module,
+            versions.flatMap(version => [
+                ...(version.dependencies ?? []),
+                ...((version.plugins as ModuleVersion[]) ?? []),
+            ])
+        );
+    }
+};
 
 export const getModuleVersion = (
     module: KnownModule,

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -9,6 +9,7 @@ import {
     ModuleVersion,
 } from '@nordicsemiconductor/nrf-device-lib-js';
 import { spawn } from 'child_process';
+import os from 'os';
 
 import {
     getDeviceLibContext,
@@ -74,6 +75,7 @@ export default async () => {
         const versions = await getModuleVersions(getDeviceLibContext());
         const JLinkArch =
             process.platform === 'darwin' &&
+            os.cpus()[0].model.includes('Apple') &&
             (await checkJLinkArchitectureOnDarwin());
 
         log('nrf-device-lib-js', getModuleVersion('nrfdl-js', versions));

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -73,26 +73,29 @@ const checkJLinkArchitectureOnDarwin = async () => {
 export default async () => {
     try {
         const versions = await getModuleVersions(getDeviceLibContext());
-        const JLinkArch =
-            process.platform === 'darwin' &&
-            os.cpus()[0].model.includes('Apple') &&
-            (await checkJLinkArchitectureOnDarwin());
 
         log('nrf-device-lib-js', getModuleVersion('nrfdl-js', versions));
         log('nrf-device-lib', getModuleVersion('nrfdl', versions));
         log('nrfjprog DLL', getModuleVersion('jprog', versions));
         log('JLink', getModuleVersion('JlinkARM', versions));
-        if (JLinkArch && JLinkArch !== 'universal') {
-            const JLinkInstallerVersion =
-                JLinkArch === 'arm'
-                    ? '64-bit Apple M1 Installer'
-                    : '64-bit Installer';
-            logger.warn(
-                `It looks like you have installed JLink using ${JLinkInstallerVersion}, but currently we only support their Universal Installer for your system.`
-            );
-            logger.warn(
-                `Please install JLink: https://www.segger.com/downloads/jlink/JLink_MacOSX_V766a_universal.pkg`
-            );
+        if (
+            process.platform === 'darwin' &&
+            os.cpus()[0].model.includes('Apple')
+        ) {
+            const JLinkArchOnDarwin = await checkJLinkArchitectureOnDarwin();
+
+            if (JLinkArchOnDarwin && JLinkArchOnDarwin !== 'universal') {
+                const JLinkInstallerVersion =
+                    JLinkArchOnDarwin === 'arm'
+                        ? '64-bit Apple M1 Installer'
+                        : '64-bit Intel Installer';
+                logger.warn(
+                    `It looks like you have installed JLink using ${JLinkInstallerVersion}, but currently we only support their Universal Installer for your system.`
+                );
+                logger.warn(
+                    `Please install JLink: https://www.segger.com/downloads/jlink/JLink_MacOSX_V766a_universal.pkg`
+                );
+            }
         }
     } catch (error) {
         logger.logError('Failed to get the library versions', error);

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -8,6 +8,7 @@ import {
     getModuleVersions,
     ModuleVersion,
 } from '@nordicsemiconductor/nrf-device-lib-js';
+import { spawn } from 'child_process';
 
 import {
     getDeviceLibContext,
@@ -26,14 +27,71 @@ const log = (description: string, moduleVersion?: ModuleVersion) => {
     }
 };
 
+const pathEnvVariable = () => {
+    if (process.platform !== 'darwin') return process.env;
+
+    return {
+        ...process.env,
+        PATH: `/usr/local/bin:${process.env.PATH}`,
+    };
+};
+
+const spawnAsync = (cmd: string, params?: string[]) =>
+    new Promise<string>((resolve, reject) => {
+        const codeProcess = spawn(cmd, params, {
+            shell: true,
+            env: pathEnvVariable(),
+        });
+        let stdout = '';
+        let stderr = '';
+        codeProcess.stdout.on('data', data => {
+            stdout += data;
+        });
+        codeProcess.stderr.on('data', data => {
+            stderr += data;
+        });
+
+        codeProcess.on('close', (code, signal) => {
+            if (stderr) console.log(stderr);
+            if (code === 0 && signal === null) {
+                return resolve(stdout);
+            }
+            return reject();
+        });
+    });
+
+const checkJLinkArchitectureOnDarwin = async () => {
+    const stdout = await spawnAsync('file $(which JLinkExe)');
+    const universalMatch = 'Mach-O universal binary with 2 architectures';
+    const intelMatch = 'Mach-O 64-bit executable x86_64';
+    if (stdout.includes(universalMatch)) return 'universal';
+    if (stdout.includes(intelMatch)) return 'x86_64';
+    return 'arm';
+};
+
 export default async () => {
     try {
         const versions = await getModuleVersions(getDeviceLibContext());
+        const JLinkArch =
+            process.platform === 'darwin' &&
+            (await checkJLinkArchitectureOnDarwin());
 
         log('nrf-device-lib-js', getModuleVersion('nrfdl-js', versions));
         log('nrf-device-lib', getModuleVersion('nrfdl', versions));
         log('nrfjprog DLL', getModuleVersion('jprog', versions));
         log('JLink', getModuleVersion('JlinkARM', versions));
+        if (JLinkArch && JLinkArch !== 'universal') {
+            const JLinkInstallerVersion =
+                JLinkArch === 'arm'
+                    ? '64-bit Apple M1 Installer'
+                    : '64-bit Installer';
+
+            logger.warn(`
+                We detected that you have installed JLink using Segger's ${JLinkInstallerVersion},
+                but recommend you install JLink using their Universal Installer:
+                https://www.segger.com/downloads/jlink/JLink_MacOSX_V766a_universal.pkg
+                `);
+        }
     } catch (error) {
         logger.logError('Failed to get the library versions', error);
     }

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -33,7 +33,7 @@ const pathEnvVariable = () => {
 
     return {
         ...process.env,
-        PATH: `/usr/local/bin:${process.env.PATH}`,
+        PATH: `/bin:/usr/bin:/usr/local/bin:${process.env.PATH}`,
     };
 };
 
@@ -87,12 +87,12 @@ export default async () => {
                 JLinkArch === 'arm'
                     ? '64-bit Apple M1 Installer'
                     : '64-bit Installer';
-
-            logger.warn(`
-                We detected that you have installed JLink using Segger's ${JLinkInstallerVersion},
-                but recommend you install JLink using their Universal Installer:
-                https://www.segger.com/downloads/jlink/JLink_MacOSX_V766a_universal.pkg
-                `);
+            logger.warn(
+                `It looks like you have installed JLink using ${JLinkInstallerVersion}, but currently we only support their Universal Installer for your system.`
+            );
+            logger.warn(
+                `Please install JLink: https://www.segger.com/downloads/jlink/JLink_MacOSX_V766a_universal.pkg`
+            );
         }
     } catch (error) {
         logger.logError('Failed to get the library versions', error);


### PR DESCRIPTION
We do not fully support M1 yet, and it is therefore advised to install JLink using Universal Installer for nrfdl to properly work.

E.g. when JLink has been installed using the `64-bit Apple M1 Installer`, then you'll see these warnings in the log:

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/34618612/187397327-5bb5b566-e798-4c7a-92a9-0ea1beef4642.png)

No warnings should appear if JLink has been installed using Universal Installer.

### Summarized:
#### Warnings should not appear on MacOS
- [ ] When M1 has installed JLink using Universal Installer
- [ ] When Intel macOS has installed JLink using Universal Installer

#### Warnings should appear on MacOS
- [ ] When M1 or Intel macOS does not have JLinkExe
- [ ] When M1 or Intel macOS installed JLink using `64-bit Installer`
- [ ] When M1 or Intel macOS installed JLink using `64-bit Apple M1 Installer`