### PR TITLE
Refactor/macos path device lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.6.1",
+    "version": "6.6.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3303,9 +3303,9 @@
             }
         },
         "@nordicsemiconductor/nrf-device-lib-js": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.4.13.tgz",
-            "integrity": "sha512-coCNZ9c2vYSqm0PRc5Ya1euUrV72mM/boZnuqB3oMXbpbNumqSutPnyNHpzkT0bnS9BHEO0raANMaCkTUOhqPQ==",
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.4.15.tgz",
+            "integrity": "sha512-x9fK/dJOpFDy+BPb2uYVnfh7TvfXenbeo2nCia68wa0wiLeHc8WoXdIiUzoVcXWnxsEsJ468hf6dkngosnpUdw==",
             "requires": {
                 "cmake-js": "^6.1.0",
                 "fs": "0.0.1-security",
@@ -9043,11 +9043,11 @@
             }
         },
         "ext": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-            "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+            "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
             "requires": {
-                "type": "^2.5.0"
+                "type": "^2.7.2"
             },
             "dependencies": {
                 "type": {
@@ -9443,9 +9443,9 @@
             "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
         },
         "for-in": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@babel/preset-typescript": "7.18.6",
         "@electron/remote": "^2.0.4",
         "@mdi/font": "6.9.96",
-        "@nordicsemiconductor/nrf-device-lib-js": "^0.4.13",
+        "@nordicsemiconductor/nrf-device-lib-js": "^0.4.15",
         "@reduxjs/toolkit": "1.8.3",
         "@svgr/webpack": "5.5.0",
         "@swc/core": "1.2.218",

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -33,7 +33,7 @@ const pathEnvVariable = () => {
 
     return {
         ...process.env,
-        PATH: `/bin:/usr/bin:/usr/local/bin:${process.env.PATH}`,
+        PATH: `/usr/local/bin:${process.env.PATH}`,
     };
 };
 


### PR DESCRIPTION
This should only be merged once the launcher upgrade with nrf-device-lib-js version 0.4.15 has been released on all platforms