### PR TITLE
Let `dispatchTo` dispatch an initialisation action

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+-   The testutil `dispatchTo` always initially dispatches an initialisation
+    action. This resembles more closely what happens in a normal system and
+    makes it a tad easier to test the initial state.
+
 ## 6.6.3 - 2022-09-26
 
 ### Steps to upgrade when using this package

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,10 @@ and this project adheres to
 
 ## 6.6.3 - 2022-09-26
 
+### Changed
+
+-   Speed up releasing apps a _lot_.
+
 ### Steps to upgrade when using this package
 
 -   Change the entry `"nordic-publish"` in the `scripts` section of

--- a/src/ErrorDialog/errorDialogSlice.test.ts
+++ b/src/ErrorDialog/errorDialogSlice.test.ts
@@ -12,7 +12,7 @@ const anotherErrorMessage = 'Another error occurred';
 
 describe('errorDialogReducer', () => {
     it('should be hidden by default', () => {
-        const initialState = dispatchTo(reducer, [{ type: '@INIT' }]);
+        const initialState = dispatchTo(reducer);
 
         expect(initialState.isVisible).toEqual(false);
     });

--- a/test/dispatchTo.ts
+++ b/test/dispatchTo.ts
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2015 Nordic Semiconductor ASA
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
 import { Action, Reducer } from 'redux';
 
-export default <State>(
-    aReducer: Reducer<State>,
-    actions: [Action, ...Action[]]
-) => {
-    const state = actions.reduce(aReducer, undefined);
+const initAction = {
+    type: '@@INIT',
+};
+
+export default <State>(aReducer: Reducer<State>, actions: Action[] = []) => {
+    const state = [initAction, ...actions].reduce(aReducer, undefined);
 
     if (state === undefined) {
         throw new Error(


### PR DESCRIPTION
The testutil `dispatchTo` always initially dispatches an initialisation    action. This resembles more closely what happens in a normal system and    makes it a tad easier to test the initial state.