### PR TITLE
Feature: Check app properties

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 -   SerialPort wrapper to be used by renderers in order to open and interact
     with port in the main process.
+-   Script `check-app-properties` to check that certain static properties of the
+    app are given, which we expect from it (e.g. certain fields in
+    `package.json` are filled out).
 
 ### Steps to upgrade when using this package
 
@@ -27,6 +30,16 @@ and this project adheres to
     `package.json` to be `"nordic-publish": "node ./dist/nordic-publish.js"`.
 -   Optional housekeeping, because it is not needed anymore: Update the release
     tasks in azure and remove the line `chmod +x ./dist/nordic-publish.js`.
+-   For an app, add an entry `"check:app"` to the `scripts` section of
+    `package.json`:
+
+```json
+{
+    "scripts": {
+        "check:app": "check-app-properties"
+    }
+}
+```
 
 ## 6.8.0 - 2022-11-04
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "author": "Nordic Semiconductor ASA",
     "license": "ISC",
     "bin": {
-        "nrfconnect-license": "./scripts/nrfconnect-license.ts",
         "check-for-typescript": "./scripts/check-for-typescript.ts",
-        "nordic-publish": "./scripts/nordic-publish.ts"
+        "check-app-properties": "./scripts/check-app-properties.ts",
+        "nordic-publish": "./scripts/nordic-publish.ts",
+        "nrfconnect-license": "./scripts/nrfconnect-license.ts"
     },
     "main": "src",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "check:types": "ts-node scripts/check-for-typescript.ts tsc --noEmit --pretty",
         "check:license": "ts-node scripts/nrfconnect-license.ts check",
         "prepare": "husky install",
-        "postinstall": "esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning"
+        "postinstall": "esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning --minify"
     },
     "dependencies": {
         "@babel/core": "7.18.9",

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -160,4 +160,9 @@ const runChecks = () => {
     checkMandatoryResources();
 };
 
-runChecks();
+const isRanAsAScript = require.main === module; // https://nodejs.org/docs/latest/api/modules.html#accessing-the-main-module
+if (isRanAsAScript) {
+    runChecks();
+}
+
+export default runChecks;

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env ts-node
+
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import property from 'lodash/property';
+
+export interface PackageJson {
+    files?: string[];
+    repository?: {
+        type: string;
+        url: string;
+    };
+}
+
+const format = (strings: string[]) =>
+    strings.map(string => `\`${string}\``).join(', ');
+
+const propertyIsMissing = (obj: unknown) => (propertyPath: string) => {
+    const value = property(propertyPath)(obj);
+    return value == null || value === '';
+};
+
+const fail = (message: string) => {
+    console.error(message);
+    process.exit(1);
+};
+
+const warn = (message: string) => {
+    console.warn(message);
+};
+
+const mustBeEmpty = (array: string[], errorMessage: string) => {
+    if (array.length !== 0) {
+        fail(`${errorMessage}: ${format(array)}`);
+    }
+};
+
+const mustContain = (
+    existingEntries: string[],
+    mandatoryEntries: string[],
+    errorMessage: string
+) => {
+    const missingFileEntries = mandatoryEntries.filter(
+        entry => !existingEntries.includes(entry)
+    );
+
+    mustBeEmpty(missingFileEntries, errorMessage);
+};
+
+const mustContainOneOf = (
+    existingEntries: string[],
+    oneOfTheseEntriesIsMandatory: string[],
+    errorMessage: string
+) => {
+    if (
+        !oneOfTheseEntriesIsMandatory.some(entry =>
+            existingEntries.includes(entry)
+        )
+    ) {
+        fail(`${errorMessage}: ${format(oneOfTheseEntriesIsMandatory)}`);
+    }
+};
+
+const checkMandatoryProperties = (packageJson: PackageJson) => {
+    const mandatoryProperties = [
+        `name`,
+        `version`,
+        `description`,
+        `displayName`,
+        `engines.nrfconnect`,
+    ];
+
+    const missingProperties = mandatoryProperties.filter(
+        propertyIsMissing(packageJson)
+    );
+
+    mustBeEmpty(
+        missingProperties,
+        'package.json is missing these mandatory properties'
+    );
+};
+
+const checkOptionalProperties = (packageJson: PackageJson) => {
+    if (propertyIsMissing(packageJson)('homepage')) {
+        warn('Please provide a property `homepage` in package.json.');
+    }
+
+    if (propertyIsMissing(packageJson)('repository.url')) {
+        warn('Please provide a property `repository.url` in package.json.');
+    } else {
+        const realGitUrl = execSync('git remote get-url origin', {
+            encoding: 'utf-8',
+        }).trimEnd();
+        const declaredGitUrl = packageJson.repository?.url;
+
+        const withoutPostfix = (gitUrl?: string) =>
+            gitUrl?.replace(/\.git$/, '');
+
+        if (withoutPostfix(realGitUrl) !== withoutPostfix(declaredGitUrl)) {
+            fail(
+                `package.json says the repository is located at \`${declaredGitUrl}\` but \`git remote get-url origin\` says it is at \`${realGitUrl}\`.`
+            );
+        }
+    }
+};
+
+const checkFileProperty = (packageJson: PackageJson) => {
+    mustContain(
+        packageJson.files ?? [],
+        ['LICENSE', 'dist/'],
+        'These entries are missing in the property `files` in package.json'
+    );
+
+    mustContainOneOf(
+        packageJson.files ?? [],
+        ['resources/*', 'resources/icon.*', 'resources/'],
+        'One of these entries must be in the property `files` in package.json'
+    );
+};
+
+const checkChangelog = () => {
+    if (!existsSync('./Changelog.md')) {
+        fail('The mandatory file `Changelog.md` is missing.');
+    }
+};
+
+const filesIn = (directory: string) => {
+    try {
+        return readdirSync(directory);
+    } catch (error) {
+        fail(`Unable to read directory \`${directory}\`.`);
+        // Unreachable, but not understood by Typescript
+        throw new Error();
+    }
+};
+
+const checkMandatoryResources = () => {
+    mustContain(
+        filesIn('./resources'),
+        ['icon.svg', 'icon.icns', 'icon.ico', 'icon.png'],
+        'In the directory `resources` these files are missing'
+    );
+};
+
+const runChecks = () => {
+    const packageJson = <PackageJson>(
+        JSON.parse(readFileSync('./package.json', 'utf8'))
+    );
+
+    checkMandatoryProperties(packageJson);
+    checkOptionalProperties(packageJson);
+    checkFileProperty(packageJson);
+    checkChangelog();
+    checkMandatoryResources();
+};
+
+runChecks();

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -29,6 +29,7 @@ program
 
 const options = program.opts();
 
+const deployOfficial = options.source === 'official';
 const nonOffcialSource =
     options.source !== 'official' ? options.source : undefined;
 
@@ -42,20 +43,20 @@ const config = {
     password: process.env.REPO_PASS || 'anonymous@',
 };
 
-const repoDirOfficial = '.pc-tools/nrfconnect-apps';
-const repoDirNonOfficial = nonOffcialSource
-    ? `${repoDirOfficial}/${nonOffcialSource}`
-    : undefined;
-const repoDir = `/${
-    process.env.REPO_DIR || repoDirNonOfficial || repoDirOfficial
-}`;
+const repoDirOfficial = '/.pc-tools/nrfconnect-apps';
+const repoDir =
+    process.env.REPO_DIR ||
+    (deployOfficial
+        ? repoDirOfficial
+        : `${repoDirOfficial}/${nonOffcialSource}`);
 
 const repoUrlOfficial =
     'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps';
-const repoUrlNonOfficial = nonOffcialSource
-    ? `${repoUrlOfficial}/${nonOffcialSource}`
-    : undefined;
-const repoUrl = process.env.REPO_URL || repoUrlNonOfficial || repoUrlOfficial;
+const repoUrl =
+    process.env.REPO_URL ||
+    (deployOfficial
+        ? repoUrlOfficial
+        : `${repoUrlOfficial}/${nonOffcialSource}`);
 
 const client = new FtpClient();
 
@@ -189,7 +190,9 @@ let thisPackage: {
 
 Promise.resolve()
     .then(() => {
-        checkAppProperties();
+        checkAppProperties({
+            checkChangelogHasCurrentEntry: deployOfficial,
+        });
     })
     .then(() => {
         let filename;

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -13,6 +13,8 @@ import FtpClient from 'ftp';
 import semver from 'semver';
 import shasum from 'shasum';
 
+import checkAppProperties from './check-app-properties';
+
 program
     .description('Publish to nordic repository')
     .requiredOption(
@@ -186,6 +188,9 @@ let thisPackage: {
 };
 
 Promise.resolve()
+    .then(() => {
+        checkAppProperties();
+    })
     .then(() => {
         let filename;
         if (options.pack) {


### PR DESCRIPTION
Adds a new static checker `scripts/check-app-properties.ts` for some basic app properties:

- `package.json`:
  - These properties must be set: `name`, `version`, `description`, `displayName`, `engines.nrfconnect`
  - `files` must contain: `resources/*`, `LICENSE`, `dist/`
  - `repository.url` should exist (and if it exists, then it must be correct)
  - `homepage` should exist
- A `Changelog.md` must exist
- `resources` must contain these files: `icon.svg`, `icon.icns`, `icon.ico`, and `icon.png` 

In `Changelog.md` there is the recommendation, that this script is added to `package.json` so that it gets called automatically when invoking `npm run check`.

The script is also invoked when publishing an app, so that no apps without these properties are deployed.

When publishing to the official source, there is an additional check for the `Changelog.md`: It must contain an entry for the current release and there must not be an `unreleased` entry.

Implements https://trello.com/c/EzuSRmp1