### PR TITLE
Collect the callback parameters

### DIFF
--- a/src/SerialPort/SerialPort.ts
+++ b/src/SerialPort/SerialPort.ts
@@ -32,13 +32,19 @@ export const SERIALPORT_CHANNEL = {
 export const SerialPort = async (
     options: SerialPortOpenOptions<AutoDetectTypes>,
     overwrite: boolean,
-    onData: (data: Uint8Array) => void = () => {},
-    onClosed: () => void = () => {},
-    onUpdate: (newOptions: UpdateOptions) => void = () => {},
-    onSet: (newOptions: SetOptions) => void = () => {},
-    onChange: (
-        newOptions: SerialPortOpenOptions<AutoDetectTypes>
-    ) => void = () => {}
+    {
+        onData = () => {},
+        onClosed = () => {},
+        onUpdate = () => {},
+        onSet = () => {},
+        onChange = () => {},
+    }: {
+        onData?: (data: Uint8Array) => void;
+        onClosed?: () => void;
+        onUpdate?: (newOptions: UpdateOptions) => void;
+        onSet?: (newOptions: SetOptions) => void;
+        onChange?: (newOptions: SerialPortOpenOptions<AutoDetectTypes>) => void;
+    } = {}
 ) => {
     const { path } = options;
 


### PR DESCRIPTION
This should:

1. Make it easier to understand what callback does what (instead of looking up “Ah, the third (or fourth?) callback is `onUpdate`”).
2. Make it easier to leave out callbacks you don't want to use.

So, e.g. when calling this function it would turn

```ts
const serialPort = await SerialPort(
    options as SerialPortOpenOptions<AutoDetectTypes>,
    overwrite,
    data => eventEmitter.emit('response', [data]),
    () => {},
    newOptions => dispatch(setSerialOptions(newOptions)),
    newOptions => dispatch(setSerialOptions(newOptions)),
    newOptions => {
        dispatch(setSerialOptions(newOptions));
        console.log(
            `Received new settings from serial port: ${JSON.stringify(
                newOptions
            )}`
        );
    }
);
```

into

```ts
const serialPort = await SerialPort(
    options as SerialPortOpenOptions<AutoDetectTypes>,
    overwrite,
    {
        onData: data => eventEmitter.emit('response', [data]),
        onUpdate: newOptions => dispatch(setSerialOptions(newOptions)),
        onSet: newOptions => dispatch(setSerialOptions(newOptions)),
        onChange: newOptions => {
            dispatch(setSerialOptions(newOptions));
            console.log(
                `Received new settings from serial port: ${JSON.stringify(
                    newOptions
                )}`
            );
        },
    }
);
```