### PR TITLE
Fix: `scripts/nordic-publish.ts` failed when ran in the release pipeline

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,21 +12,23 @@ and this project adheres to
 
 -   `scripts/nordic-publish.ts` failed when ran in the release pipeline.
 
-## 6.11.0
+## 6.11.0 - 2022-11-25
 
 ### Added
 
 -   `NumberInlineInput` can opt to have step defined allowing only values that
-    are a factor of this step size
--   `NumberInlineInput` can opt to have explict ranges allowing for split ranges
+    are a factor of this step size.
+-   `NumberInlineInput` can opt to have explict ranges allowing for split
+    ranges.
 -   `InlineInput` can opt to have support for up/down keyboard events to control
-    the value
--   `NumberInlineInput` support for up/down keyboard events to control the value
--   `Slider` can opt to have steps defined allowing allowing to inciment the
-    value with the step size
+    the value.
+-   `NumberInlineInput` support for up/down keyboard events to control the
+    value.
+-   `Slider` can opt to have steps defined allowing allowing to increment the
+    value with the step size.
 -   `Slider` can opt to have explict ranges allowing for split ranges. Ticks are
-    not yest supported on this mode
--   Warn in console if Min and Max are not factors of the optional step size
+    not yet supported on this mode.
+-   Warn in console if Min and Max are not factors of the optional step size.
 
 ### Fixed
 
@@ -120,14 +122,14 @@ and this project adheres to
 -   Opt-in scroll functionality to the dropdown component if there are more then
     X items in the list.
 -   In Dropdown component currently selected `DropdownItem` can now be passed
-    using the `selectedItem` property
+    using the `selectedItem` property.
 -   In StateSelector component can now be passed using the `selectedItem`
-    property
+    property.
 
 ### Fixed
 
 -   Z-Index issue with dropdown select list when it is vertically above a toggle
-    component and list is opened
+    component and list is opened.
 
 ## 6.7.2 - 2022-11-01
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   `scripts/nordic-publish.ts` failed when ran in the release pipeline.
+
 ## 6.11.0
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.11.1 - 2022-11-28
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Fixed
 
 -   `scripts/nordic-publish.ts` failed when ran in the release pipeline.
+-   Weakened type of `values` property of `Slider` from `number[]` to
+    `readonly number[]`.
 
 ## 6.11.0 - 2022-11-25
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.11.0",
+    "version": "6.11.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -94,7 +94,7 @@ const checkOptionalProperties = (packageJson: PackageJson) => {
 
     if (propertyIsMissing(packageJson)('repository.url')) {
         warn('Please provide a property `repository.url` in package.json.');
-    } else {
+    } else if (existsSync('./.git')) {
         const realGitUrl = execSync('git remote get-url origin', {
             encoding: 'utf-8',
         }).trimEnd();

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -21,7 +21,7 @@ export interface Props {
     id?: string;
     title?: string;
     disabled?: boolean;
-    values: number[];
+    values: readonly number[];
     range: RangeProp;
     ticks?: boolean;
     onChange: ((v: number) => void)[];


### PR DESCRIPTION
Also some other fixes:

- The type of `values` in `Slider` was too strict. (broken in #424)
- The changelog has some smaller issues.