### PR TITLE
Enhance specifying ranges

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,12 @@ this:
 -   A `Slider` with ticks but without a defined step displayed the ticks
     wrongly.
 
+### Steps to upgrade when using this package
+
+-   If you are using a `NumberInlineInput` or `Slider` with a range with the
+    `explicitRange` property, then you have to replace the whole range with the
+    array of the `explicitRange` property, as shown above.
+
 ## 6.12.1 - 2022-11-29
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+-   Specifying a range with explicit values for a `NumberInlineInput` was
+    changed. When you before wrote an `NumberInlineInput` element like this:
+
+```jsx
+<NumberInlineInput
+    values={[4]}
+    range={{ min: 3, max: 7, explicitRange: [3, 4, 6, 7] }}
+    onChange={[() => {}]}
+/>
+```
+
+Instead you now have to replace the whole range object with the array and write
+it like this:
+
+```jsx
+<NumberInlineInput
+    values={[4]}
+    range={[3, 4, 6, 7]}
+    onChange={[() => {}]}
+/>
+```
+
+It is of course still possible to specify a range without explicit values like
+this:
+
+```jsx
+<NumberInlineInput
+    values={[4]}
+    range={{ min: 3, max: 7 }}
+    onChange={[() => {}]}
+/>
+```
+
 ## 6.12.1 - 2022-11-29
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,9 @@ and this project adheres to
 
 ### Changed
 
--   Specifying a range with explicit values for a `NumberInlineInput` was
-    changed. When you before wrote an `NumberInlineInput` element like this:
+-   Specifying a range with explicit values for a `NumberInlineInput` or a
+    `Slider` was changed. When you before wrote an `NumberInlineInput` element
+    (same applies to a `Slider`) like this:
 
 ```jsx
 <NumberInlineInput

--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,11 @@ this:
 />
 ```
 
+### Fixed
+
+-   A `Slider` with ticks but without a defined step displayed the ticks
+    wrongly.
+
 ## 6.12.1 - 2022-11-29
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -322,13 +322,8 @@ declare module 'pc-nrfconnect-shared' {
 
     // NumberInlineInput.jsx
 
-    interface NumberInlineInputProps {
-        disabled?: boolean;
-        value: number;
-        range: RangeProp;
-        onChange: (value: number) => void;
-        onChangeComplete?: (value: number) => void;
-    }
+    export type NumberInlineInputProps =
+        import('./src/InlineInput/NumberInlineInput').Props;
 
     export class NumberInlineInput extends React.Component<NumberInlineInputProps> {}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -280,7 +280,7 @@ declare module 'pc-nrfconnect-shared' {
 
     // Slider.jsx
 
-    export type RangeProp = import('./src/Slider/rangeShape').RangeProp;
+    export type Range = import('./src/Slider/range').Range;
     export type SliderProps = import('./src/Slider/Slider').Props;
 
     export class Slider extends React.Component<SliderProps> {}

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -7,7 +7,13 @@
 import React, { FC } from 'react';
 
 import { isFactor } from '../Slider/factor';
-import { isValues, Range, RangeOrValues, Values } from '../Slider/range';
+import {
+    isValues,
+    Range,
+    RangeOrValues,
+    useValidatedRangeOrValues,
+    Values,
+} from '../Slider/range';
 import InlineInput from './InlineInput';
 
 import './number-inline-input.scss';
@@ -79,21 +85,25 @@ const NumberInlineInput: FC<Props> = ({
     range,
     onChange,
     onChangeComplete = () => {},
-}) => (
-    <InlineInput
-        className="number-inline-input"
-        disabled={disabled}
-        value={String(value)}
-        isValid={newValue => isValid(Number(newValue), range)}
-        onChange={newValue => onChange(Number(newValue))}
-        onChangeComplete={newValue => onChangeComplete(Number(newValue))}
-        onKeyboardIncrementAction={() =>
-            changeValueStepwise(value, range, 1, onChange)
-        }
-        onKeyboardDecrementAction={() =>
-            changeValueStepwise(value, range, -1, onChange)
-        }
-    />
-);
+}) => {
+    useValidatedRangeOrValues(range);
+
+    return (
+        <InlineInput
+            className="number-inline-input"
+            disabled={disabled}
+            value={String(value)}
+            isValid={newValue => isValid(Number(newValue), range)}
+            onChange={newValue => onChange(Number(newValue))}
+            onChangeComplete={newValue => onChangeComplete(Number(newValue))}
+            onKeyboardIncrementAction={() =>
+                changeValueStepwise(value, range, 1, onChange)
+            }
+            onKeyboardDecrementAction={() =>
+                changeValueStepwise(value, range, -1, onChange)
+            }
+        />
+    );
+};
 
 export default NumberInlineInput;

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -8,6 +8,7 @@ import React, { FC } from 'react';
 
 import { isFactor } from '../Slider/factor';
 import {
+    getStep,
     isValues,
     Range,
     RangeOrValues,
@@ -54,10 +55,9 @@ const nextInValues = (
 };
 
 const nextInRange = (current: number, range: Range, steps: number) => {
-    const decimal = range.decimals ?? 0;
-    const stepValue =
-        range.step && range.step != null ? range.step : 0.1 ** decimal;
-    const newValue = Number((current + steps * stepValue).toFixed(decimal));
+    const newValue = Number(
+        (current + steps * getStep(range)).toFixed(range.decimals)
+    );
 
     if (newValue >= range.min && newValue <= range.max) {
         return newValue;

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -7,55 +7,74 @@
 import React, { FC } from 'react';
 
 import { isFactor } from '../Slider/factor';
-import { RangeProp } from '../Slider/rangeShape';
+import {
+    isValues,
+    NewRange,
+    RangeOrValues,
+    Values,
+} from '../Slider/rangeShape';
 import InlineInput from './InlineInput';
 
 import './number-inline-input.scss';
 
+export interface Props {
+    disabled?: boolean;
+    value: number;
+    range: RangeOrValues;
+    onChange: (value: number) => void;
+    onChangeComplete?: (value: number) => void;
+}
+
+const isInValues = (value: number, values: Values) => values.includes(value);
+
 const isInRange = (
     value: number,
-    { min, max, decimals = 0, step = 0, explicitRange = [] }: RangeProp
+    { min, max, decimals = 0, step = 0 }: NewRange
 ) =>
     value >= min &&
     value <= max &&
     value === Number(value.toFixed(decimals)) &&
-    (step > 0 ? isFactor(value, step) : true) &&
-    (explicitRange.length > 0 ? explicitRange.indexOf(value) !== -1 : true);
+    (step > 0 ? isFactor(value, step) : true);
 
-interface Props {
-    disabled?: boolean;
-    value: number;
-    range: RangeProp;
-    onChange: (number: number) => void;
-    onChangeComplete?: (number: number) => void;
-}
+const isValid = (value: number, rangeOrValues: RangeOrValues) =>
+    isValues(rangeOrValues)
+        ? isInValues(value, rangeOrValues)
+        : isInRange(value, rangeOrValues);
 
-const changeValueStepwise = (
+const nextInValues = (
     current: number,
-    range: RangeProp,
-    steps: number,
-    action: (v: number) => void
-) => {
-    if (steps === 0) return;
+    values: Values,
+    steps: number
+): number | undefined => {
+    const currentIndex = values.indexOf(current);
+    const newIndex = currentIndex + steps;
 
-    if (range.explicitRange != null && range.explicitRange.length > 0) {
-        const currentIndex = range.explicitRange.indexOf(current);
-        const newIndex = currentIndex + steps;
+    return values[newIndex];
+};
 
-        if (newIndex >= 0 && newIndex < range.explicitRange.length) {
-            action(range.explicitRange[newIndex]);
-        }
-
-        return;
-    }
-
+const nextInRange = (current: number, range: NewRange, steps: number) => {
     const decimal = range.decimals ?? 0;
     const stepValue =
         range.step && range.step != null ? range.step : 0.1 ** decimal;
     const newValue = Number((current + steps * stepValue).toFixed(decimal));
 
     if (newValue >= range.min && newValue <= range.max) {
-        action(newValue);
+        return newValue;
+    }
+};
+
+const changeValueStepwise = (
+    current: number,
+    rangeOrValues: RangeOrValues,
+    steps: number,
+    action: (v: number) => void
+) => {
+    const nextValue = isValues(rangeOrValues)
+        ? nextInValues(current, rangeOrValues, steps)
+        : nextInRange(current, rangeOrValues, steps);
+
+    if (nextValue != null) {
+        action(nextValue);
     }
 };
 
@@ -70,7 +89,7 @@ const NumberInlineInput: FC<Props> = ({
         className="number-inline-input"
         disabled={disabled}
         value={String(value)}
-        isValid={newValue => isInRange(Number(newValue), range)}
+        isValid={newValue => isValid(Number(newValue), range)}
         onChange={newValue => onChange(Number(newValue))}
         onChangeComplete={newValue => onChangeComplete(Number(newValue))}
         onKeyboardIncrementAction={() =>

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -7,12 +7,7 @@
 import React, { FC } from 'react';
 
 import { isFactor } from '../Slider/factor';
-import {
-    isValues,
-    NewRange,
-    RangeOrValues,
-    Values,
-} from '../Slider/rangeShape';
+import { isValues, Range, RangeOrValues, Values } from '../Slider/range';
 import InlineInput from './InlineInput';
 
 import './number-inline-input.scss';
@@ -29,7 +24,7 @@ const isInValues = (value: number, values: Values) => values.includes(value);
 
 const isInRange = (
     value: number,
-    { min, max, decimals = 0, step = 0 }: NewRange
+    { min, max, decimals = 0, step = 0 }: Range
 ) =>
     value >= min &&
     value <= max &&
@@ -52,7 +47,7 @@ const nextInValues = (
     return values[newIndex];
 };
 
-const nextInRange = (current: number, range: NewRange, steps: number) => {
+const nextInRange = (current: number, range: Range, steps: number) => {
     const decimal = range.decimals ?? 0;
     const stepValue =
         range.step && range.step != null ? range.step : 0.1 ** decimal;

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -33,7 +33,7 @@ const isInRange = (value: number, { min, max, decimals, step }: Range) =>
     value >= min &&
     value <= max &&
     value === Number(value.toFixed(decimals)) &&
-    (step == null ? true : isFactor(value, step));
+    (step == null ? true : isFactor(value - min, step));
 
 const isValid = (value: number, rangeOrValues: RangeOrValues) =>
     isValues(rangeOrValues)

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -29,14 +29,11 @@ export interface Props {
 
 const isInValues = (value: number, values: Values) => values.includes(value);
 
-const isInRange = (
-    value: number,
-    { min, max, decimals = 0, step = 0 }: Range
-) =>
+const isInRange = (value: number, { min, max, decimals, step }: Range) =>
     value >= min &&
     value <= max &&
     value === Number(value.toFixed(decimals)) &&
-    (step > 0 ? isFactor(value, step) : true);
+    (step == null ? true : isFactor(value, step));
 
 const isValid = (value: number, rangeOrValues: RangeOrValues) =>
     isValues(rangeOrValues)

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -30,7 +30,7 @@ interface Props {
     onChangeComplete?: (number: number) => void;
 }
 
-const incrementValue = (
+const changeValueStepwise = (
     current: number,
     range: RangeProp,
     steps: number,
@@ -38,10 +38,7 @@ const incrementValue = (
 ) => {
     if (steps === 0) return;
 
-    if (
-        typeof range.explicitRange !== 'undefined' &&
-        range.explicitRange.length > 0
-    ) {
+    if (range.explicitRange != null && range.explicitRange.length > 0) {
         const currentIndex = range.explicitRange.indexOf(current);
         const newIndex = currentIndex + steps;
 
@@ -52,14 +49,9 @@ const incrementValue = (
         return;
     }
 
-    const decimal =
-        range.decimals && typeof range.decimals !== 'undefined'
-            ? range.decimals
-            : 0;
+    const decimal = range.decimals ?? 0;
     const stepValue =
-        range.step && typeof range.step !== 'undefined'
-            ? range.step
-            : 0.1 ** decimal;
+        range.step && range.step != null ? range.step : 0.1 ** decimal;
     const newValue = Number((current + steps * stepValue).toFixed(decimal));
 
     if (newValue >= range.min && newValue <= range.max) {
@@ -82,10 +74,10 @@ const NumberInlineInput: FC<Props> = ({
         onChange={newValue => onChange(Number(newValue))}
         onChangeComplete={newValue => onChangeComplete(Number(newValue))}
         onKeyboardIncrementAction={() =>
-            incrementValue(value, range, 1, onChange)
+            changeValueStepwise(value, range, 1, onChange)
         }
         onKeyboardDecrementAction={() =>
-            incrementValue(value, range, -1, onChange)
+            changeValueStepwise(value, range, -1, onChange)
         }
     />
 );

--- a/src/Slider/Handle.tsx
+++ b/src/Slider/Handle.tsx
@@ -12,7 +12,7 @@ import {
     fromPercentage,
     toPercentage,
 } from './percentage';
-import { RangeProp } from './rangeShape';
+import { RangeOrValues } from './rangeShape';
 
 import './handle.scss';
 
@@ -25,7 +25,7 @@ const useAutoupdatingRef = (value: (number: number) => void) => {
 interface Props {
     value: number;
     disabled: boolean;
-    range: RangeProp;
+    range: RangeOrValues;
     onChange: (number: number) => void;
     onChangeComplete?: () => void;
     sliderWidth?: number;

--- a/src/Slider/Handle.tsx
+++ b/src/Slider/Handle.tsx
@@ -12,7 +12,7 @@ import {
     fromPercentage,
     toPercentage,
 } from './percentage';
-import { RangeOrValues } from './rangeShape';
+import { RangeOrValues } from './range';
 
 import './handle.scss';
 

--- a/src/Slider/Slider.test.tsx
+++ b/src/Slider/Slider.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+
+import render from '../../test/testrenderer';
+import Slider from './Slider';
+
+describe('Slider component', () => {
+    it('renders correct with ticks', () => {
+        expect(
+            render(
+                <Slider
+                    ticks
+                    values={[2]}
+                    range={{ min: 0, max: 5 }}
+                    onChange={[() => {}]}
+                />
+            ).baseElement
+        ).toMatchSnapshot();
+    });
+});

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -17,6 +17,42 @@ import Ticks from './Ticks';
 
 import './slider.scss';
 
+const validateArraySizes = (
+    values: readonly number[],
+    onChange: ((v: number) => void)[]
+) => {
+    if (values.length === 0)
+        console.error('"values" must contain at least on element');
+    if (values.length !== onChange.length)
+        console.error(
+            `Props 'values' and 'onChange' must have the same size but were ${values} and ${onChange}`
+        );
+};
+
+const validateRange = (range: RangeProp) => {
+    if (range.min > range.max)
+        console.error(
+            `range.min must not be higher than range.max: ${JSON.stringify(
+                range
+            )}`
+        );
+
+    if (range.step != null) {
+        if (!isFactor(range.min, range.step))
+            console.error(
+                `range.step must be a factor of range.min: ${JSON.stringify(
+                    range
+                )}`
+            );
+        if (!isFactor(range.max, range.step))
+            console.error(
+                `range.step must be a factor of range.max: ${JSON.stringify(
+                    range
+                )}`
+            );
+    }
+};
+
 export interface Props {
     id?: string;
     title?: string;
@@ -44,32 +80,8 @@ const Slider: FC<Props> = ({
         step: range.step ?? 0,
     };
 
-    if (values.length === 0)
-        console.error('"values" must contain at least on element');
-    if (values.length !== onChange.length)
-        console.error(
-            `Props 'values' and 'onChange' must have the same size but were ${values} and ${onChange}`
-        );
-    if (rangeNoOptional.min > rangeNoOptional.max)
-        console.error(
-            `range.min must not be higher than range.max: ${JSON.stringify(
-                range
-            )}`
-        );
-    if (rangeNoOptional.step > 0) {
-        if (!isFactor(range.min, rangeNoOptional.step))
-            console.error(
-                `range.step must be a factor of range.min: ${JSON.stringify(
-                    range
-                )}`
-            );
-        if (!isFactor(range.max, rangeNoOptional.step))
-            console.error(
-                `range.step must be a factor of range.max: ${JSON.stringify(
-                    range
-                )}`
-            );
-    }
+    validateArraySizes(values, onChange);
+    validateRange(range);
 
     const { width, ref } = useResizeDetector();
 

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -89,7 +89,7 @@ const Slider: FC<Props> = ({
                 start={toPercentage(valueRange.min, rangeNoOptional)}
                 end={toPercentage(valueRange.max, rangeNoOptional)}
             />
-            {ticks && <Ticks valueRange={valueRange} range={rangeNoOptional} />}
+            {ticks && <Ticks valueRange={valueRange} range={range} />}
             {values.map((value, index) => (
                 <Handle
                     key={index} // eslint-disable-line react/no-array-index-key

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
 import classNames from '../utils/classNames';
@@ -17,16 +17,18 @@ import Ticks from './Ticks';
 
 import './slider.scss';
 
-const validateArraySizes = (
+const useValidatedArraySizes = (
     values: readonly number[],
     onChange: ((v: number) => void)[]
 ) => {
-    if (values.length === 0)
-        console.error('"values" must contain at least on element');
-    if (values.length !== onChange.length)
-        console.error(
-            `Props 'values' and 'onChange' must have the same size but were ${values} and ${onChange}`
-        );
+    useEffect(() => {
+        if (values.length === 0)
+            console.error('"values" must contain at least on element');
+        if (values.length !== onChange.length)
+            console.error(
+                `Props 'values' and 'onChange' must have the same size but were ${values} and ${onChange}`
+            );
+    }, [onChange, values]);
 };
 
 const validateValues = (values: Values) => {
@@ -65,12 +67,14 @@ const validateRange = (range: Range) => {
     }
 };
 
-const validateRangeOrValues = (rangeOrValues: RangeOrValues) => {
-    if (isValues(rangeOrValues)) {
-        validateValues(rangeOrValues);
-    } else {
-        validateRange(rangeOrValues);
-    }
+const useValidatedRangeOrValues = (rangeOrValues: RangeOrValues) => {
+    useEffect(() => {
+        if (isValues(rangeOrValues)) {
+            validateValues(rangeOrValues);
+        } else {
+            validateRange(rangeOrValues);
+        }
+    }, [rangeOrValues]);
 };
 
 export interface Props {
@@ -94,8 +98,8 @@ const Slider: FC<Props> = ({
     onChange,
     onChangeComplete,
 }) => {
-    validateArraySizes(values, onChange);
-    validateRangeOrValues(rangeOrValues);
+    useValidatedArraySizes(values, onChange);
+    useValidatedRangeOrValues(rangeOrValues);
 
     const { width, ref } = useResizeDetector();
 

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -9,10 +9,9 @@ import { useResizeDetector } from 'react-resize-detector';
 
 import classNames from '../utils/classNames';
 import Bar from './Bar';
-import { isFactor } from './factor';
 import Handle from './Handle';
 import { toPercentage } from './percentage';
-import { getMin, isValues, Range, RangeOrValues, Values } from './range';
+import { getMin, RangeOrValues, useValidatedRangeOrValues } from './range';
 import Ticks from './Ticks';
 
 import './slider.scss';
@@ -29,52 +28,6 @@ const useValidatedArraySizes = (
                 `Props 'values' and 'onChange' must have the same size but were ${values} and ${onChange}`
             );
     }, [onChange, values]);
-};
-
-const validateValues = (values: Values) => {
-    for (let i = 0; i < values.length - 1; i += 1) {
-        if (values[i] > values[i + 1]) {
-            console.error(
-                `The values of the range must be sorted correctly, but ${
-                    values[i]
-                } is larger then ${values[i + 1]} in ${values}`
-            );
-        }
-    }
-};
-
-const validateRange = (range: Range) => {
-    if (range.min > range.max)
-        console.error(
-            `range.min must not be higher than range.max: ${JSON.stringify(
-                range
-            )}`
-        );
-
-    if (range.step != null) {
-        if (!isFactor(range.min, range.step))
-            console.error(
-                `range.step must be a factor of range.min: ${JSON.stringify(
-                    range
-                )}`
-            );
-        if (!isFactor(range.max, range.step))
-            console.error(
-                `range.step must be a factor of range.max: ${JSON.stringify(
-                    range
-                )}`
-            );
-    }
-};
-
-const useValidatedRangeOrValues = (rangeOrValues: RangeOrValues) => {
-    useEffect(() => {
-        if (isValues(rangeOrValues)) {
-            validateValues(rangeOrValues);
-        } else {
-            validateRange(rangeOrValues);
-        }
-    }, [rangeOrValues]);
 };
 
 export interface Props {

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -12,13 +12,7 @@ import Bar from './Bar';
 import { isFactor } from './factor';
 import Handle from './Handle';
 import { toPercentage } from './percentage';
-import {
-    getMin,
-    isValues,
-    NewRange,
-    RangeOrValues,
-    Values,
-} from './rangeShape';
+import { getMin, isValues, Range, RangeOrValues, Values } from './range';
 import Ticks from './Ticks';
 
 import './slider.scss';
@@ -47,7 +41,7 @@ const validateValues = (values: Values) => {
     }
 };
 
-const validateRange = (range: NewRange) => {
+const validateRange = (range: Range) => {
     if (range.min > range.max)
         console.error(
             `range.min must not be higher than range.max: ${JSON.stringify(

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -74,12 +74,6 @@ const Slider: FC<Props> = ({
     onChange,
     onChangeComplete,
 }) => {
-    const rangeNoOptional = {
-        ...range,
-        decimals: range.decimals ?? 0,
-        step: range.step ?? 0,
-    };
-
     validateArraySizes(values, onChange);
     validateRange(range);
 
@@ -98,15 +92,15 @@ const Slider: FC<Props> = ({
             ref={ref as React.MutableRefObject<HTMLDivElement>}
         >
             <Bar
-                start={toPercentage(valueRange.min, rangeNoOptional)}
-                end={toPercentage(valueRange.max, rangeNoOptional)}
+                start={toPercentage(valueRange.min, range)}
+                end={toPercentage(valueRange.max, range)}
             />
             {ticks && <Ticks valueRange={valueRange} range={range} />}
             {values.map((value, index) => (
                 <Handle
                     key={index} // eslint-disable-line react/no-array-index-key
                     value={value}
-                    range={rangeNoOptional}
+                    range={range}
                     disabled={disabled}
                     onChange={onChange[index]}
                     onChangeComplete={onChangeComplete}

--- a/src/Slider/Ticks.tsx
+++ b/src/Slider/Ticks.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import lodashRange from 'lodash.range';
 
 import classNames from '../utils/classNames';
@@ -18,10 +18,15 @@ interface Props {
 }
 
 const Ticks: FC<Props> = ({ valueRange, range: rangeOrValues }) => {
+    useEffect(() => {
+        if (isValues(rangeOrValues)) {
+            console.error(
+                'Ticks are not yet implemented for explicit values. Not showing ticks.'
+            );
+        }
+    }, [rangeOrValues]);
+
     if (isValues(rangeOrValues)) {
-        console.error(
-            'Ticks are not yet implemented for explicit values. Not showing ticks.'
-        );
         return null;
     }
 

--- a/src/Slider/Ticks.tsx
+++ b/src/Slider/Ticks.tsx
@@ -8,29 +8,29 @@ import React, { FC } from 'react';
 import lodashRange from 'lodash.range';
 
 import classNames from '../utils/classNames';
-import { RangeProp } from './rangeShape';
+import { isValues, RangeOrValues } from './rangeShape';
 
 import './ticks.scss';
 
 interface Props {
-    range: RangeProp;
+    range: RangeOrValues;
     valueRange: { min: number; max: number };
 }
 
-const Ticks: FC<Props> = ({
-    valueRange,
-    range: { min, max, decimals = 0, step, explicitRange = [] },
-}) => {
+const Ticks: FC<Props> = ({ valueRange, range: rangeOrValues }) => {
+    if (isValues(rangeOrValues)) {
+        console.error(
+            'Ticks are not yet implemented for explicit values. Not showing ticks.'
+        );
+        return null;
+    }
+
+    const { min, max, decimals = 0, step } = rangeOrValues;
+
     const computedStep = step == null ? 0.1 ** decimals : step;
 
     const isSelected = (value: number) =>
         value >= valueRange.min && value <= valueRange.max;
-
-    if (explicitRange.length > 0) {
-        console.error(
-            'Explicit Range is set but this functionality has not been impliment yet for Ticks. Expect the spacing between Ticks to be incorrect'
-        );
-    }
 
     return (
         <div className="ticks">

--- a/src/Slider/Ticks.tsx
+++ b/src/Slider/Ticks.tsx
@@ -19,9 +19,9 @@ interface Props {
 
 const Ticks: FC<Props> = ({
     valueRange,
-    range: { min, max, decimals = 0, step = null, explicitRange = [] },
+    range: { min, max, decimals = 0, step, explicitRange = [] },
 }) => {
-    const computedStep = step === null ? 0.1 ** (decimals as number) : step;
+    const computedStep = step == null ? 0.1 ** decimals : step;
 
     const isSelected = (value: number) =>
         value >= valueRange.min && value <= valueRange.max;

--- a/src/Slider/Ticks.tsx
+++ b/src/Slider/Ticks.tsx
@@ -8,7 +8,7 @@ import React, { FC, useEffect } from 'react';
 import lodashRange from 'lodash.range';
 
 import classNames from '../utils/classNames';
-import { isValues, RangeOrValues } from './range';
+import { getStep, isValues, RangeOrValues } from './range';
 
 import './ticks.scss';
 
@@ -30,16 +30,15 @@ const Ticks: FC<Props> = ({ valueRange, range: rangeOrValues }) => {
         return null;
     }
 
-    const { min, max, decimals = 0, step } = rangeOrValues;
+    const range = rangeOrValues;
 
-    const computedStep = step == null ? 0.1 ** decimals : step;
-
+    const step = getStep(range);
     const isSelected = (value: number) =>
         value >= valueRange.min && value <= valueRange.max;
 
     return (
         <div className="ticks">
-            {lodashRange(min, max + computedStep, computedStep).map(value => (
+            {lodashRange(range.min, range.max + step, step).map(value => (
                 <div
                     key={String(value)}
                     className={classNames(

--- a/src/Slider/Ticks.tsx
+++ b/src/Slider/Ticks.tsx
@@ -8,7 +8,7 @@ import React, { FC } from 'react';
 import lodashRange from 'lodash.range';
 
 import classNames from '../utils/classNames';
-import { isValues, RangeOrValues } from './rangeShape';
+import { isValues, RangeOrValues } from './range';
 
 import './ticks.scss';
 

--- a/src/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/Slider/__snapshots__/Slider.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slider component renders correct with ticks 1`] = `
+<body>
+  <div>
+    <div
+      class="slider"
+    >
+      <div
+        class="bar background"
+      />
+      <div
+        class="bar foreground"
+        style="left: 0%; width: 40%;"
+      />
+      <div
+        class="ticks"
+      >
+        <div
+          class="tick selected"
+        />
+        <div
+          class="tick selected"
+        />
+        <div
+          class="tick selected"
+        />
+        <div
+          class="tick"
+        />
+        <div
+          class="tick"
+        />
+        <div
+          class="tick"
+        />
+      </div>
+      <div
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="2"
+        class="handle"
+        role="slider"
+        style="left: 40%;"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</body>
+`;

--- a/src/Slider/percentage.ts
+++ b/src/Slider/percentage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { RangeProp } from './rangeShape';
+import { getMax, getMin, isValues, RangeOrValues } from './rangeShape';
 
 export const constrainedToPercentage = (percentage: number) => {
     if (percentage < 0) return 0;
@@ -12,22 +12,28 @@ export const constrainedToPercentage = (percentage: number) => {
     return percentage;
 };
 
-export const toPercentage = (value: number, { min, max }: RangeProp) =>
-    ((value - min) * 100) / (max - min);
+export const toPercentage = (value: number, rangeOrValues: RangeOrValues) => {
+    const min = getMin(rangeOrValues);
+    const max = getMax(rangeOrValues);
+
+    return ((value - min) * 100) / (max - min);
+};
 
 export const fromPercentage = (
     lastValue: number,
     value: number,
-    { min, max, decimals = 0, step = 0, explicitRange = [] }: RangeProp,
+    rangeOrValues: RangeOrValues,
     directionForward: boolean
 ) => {
-    if (explicitRange.length > 0) {
-        const noOfIndexes = explicitRange.length - 1;
-        const computedValue = Number(
-            ((value * (max - min)) / 100 + min).toFixed(decimals)
-        );
+    const min = getMin(rangeOrValues);
+    const max = getMax(rangeOrValues);
 
-        const lastValueIndex = explicitRange.indexOf(lastValue);
+    if (isValues(rangeOrValues)) {
+        const values = rangeOrValues;
+        const noOfIndexes = values.length - 1;
+        const computedValue = (value * (max - min)) / 100 + min;
+
+        const lastValueIndex = values.indexOf(lastValue);
         const closestPrevIndex = lastValueIndex === 0 ? 0 : lastValueIndex - 1;
         const closestNextIndex =
             lastValueIndex === noOfIndexes ? noOfIndexes : lastValueIndex + 1;
@@ -36,25 +42,26 @@ export const fromPercentage = (
 
         if (directionForward) {
             closestIndex =
-                explicitRange[closestNextIndex] > computedValue
+                values[closestNextIndex] > computedValue
                     ? lastValueIndex
                     : closestNextIndex;
         } else {
             closestIndex =
-                explicitRange[closestPrevIndex] < computedValue
+                values[closestPrevIndex] < computedValue
                     ? lastValueIndex
                     : closestPrevIndex;
         }
 
-        return Number(explicitRange[closestIndex].toFixed(decimals));
+        return values[closestIndex];
     }
 
-    if (step > 0) {
-        const noOfSteps = (max - min) / step;
+    const range = rangeOrValues;
+    if (range.step != null) {
+        const noOfSteps = (max - min) / range.step;
         const closestStep = Math.round((value / 100) * noOfSteps);
 
-        return Number((min + closestStep * step).toFixed(decimals));
+        return Number((min + closestStep * range.step).toFixed(range.decimals));
     }
 
-    return Number(((value * (max - min)) / 100 + min).toFixed(decimals));
+    return Number(((value * (max - min)) / 100 + min).toFixed(range.decimals));
 };

--- a/src/Slider/percentage.ts
+++ b/src/Slider/percentage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { getMax, getMin, isValues, RangeOrValues } from './rangeShape';
+import { getMax, getMin, isValues, RangeOrValues } from './range';
 
 export const constrainedToPercentage = (percentage: number) => {
     if (percentage < 0) return 0;

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -5,14 +5,14 @@
  */
 
 export type Values = readonly number[];
-export type NewRange = {
+export type Range = {
     min: number;
     max: number;
     decimals?: number;
     step?: number; // positive number
 };
 
-export type RangeOrValues = NewRange | Values;
+export type RangeOrValues = Range | Values;
 
 export const isValues = (
     rangeOrValues: RangeOrValues

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -56,7 +56,17 @@ const validateRange = (range: Range) => {
         `range.min must not be higher than range.max: ${JSON.stringify(range)}`
     );
 
+    if (range.decimals != null)
+        assert(
+            range.decimals >= 0 && Number.isInteger(range.decimals),
+            `range.decimals must be non-negative integer but is ${range.decimals}`
+        );
+
     if (range.step != null) {
+        assert(
+            range.step > 0,
+            `range.step must be larger than zero but is ${range.step}`
+        );
         assert(
             isFactor(range.min, range.step),
             `range.step must be a factor of range.min: ${JSON.stringify(range)}`

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { useEffect } from 'react';
+
+import { isFactor } from './factor';
+
 export type Values = readonly number[];
 export type Range = {
     min: number;
@@ -25,3 +29,49 @@ export const getMax = (rangeOrValues: RangeOrValues) =>
     isValues(rangeOrValues)
         ? rangeOrValues[rangeOrValues.length - 1]
         : rangeOrValues.max;
+
+const validateValues = (values: Values) => {
+    for (let i = 0; i < values.length - 1; i += 1) {
+        if (values[i] > values[i + 1]) {
+            console.error(
+                `The values of the range must be sorted correctly, but ${
+                    values[i]
+                } is larger then ${values[i + 1]} in ${values}`
+            );
+        }
+    }
+};
+
+const validateRange = (range: Range) => {
+    if (range.min > range.max)
+        console.error(
+            `range.min must not be higher than range.max: ${JSON.stringify(
+                range
+            )}`
+        );
+
+    if (range.step != null) {
+        if (!isFactor(range.min, range.step))
+            console.error(
+                `range.step must be a factor of range.min: ${JSON.stringify(
+                    range
+                )}`
+            );
+        if (!isFactor(range.max, range.step))
+            console.error(
+                `range.step must be a factor of range.max: ${JSON.stringify(
+                    range
+                )}`
+            );
+    }
+};
+
+export const useValidatedRangeOrValues = (rangeOrValues: RangeOrValues) => {
+    useEffect(() => {
+        if (isValues(rangeOrValues)) {
+            validateValues(rangeOrValues);
+        } else {
+            validateRange(rangeOrValues);
+        }
+    }, [rangeOrValues]);
+};

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -30,6 +30,9 @@ export const getMax = (rangeOrValues: RangeOrValues) =>
         ? rangeOrValues[rangeOrValues.length - 1]
         : rangeOrValues.max;
 
+export const getStep = (range: Range) =>
+    range.step != null ? range.step : 0.1 ** (range.decimals ?? 0);
+
 const validateValues = (values: Values) => {
     for (let i = 0; i < values.length - 1; i += 1) {
         if (values[i] > values[i + 1]) {

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -52,6 +52,11 @@ const validateValues = (values: Values) => {
 
 const validateRange = (range: Range) => {
     assert(
+        !(`explicitRange` in range),
+        'Using `explicitRange` is not supported anymore, use only an array instead of a range object.'
+    );
+
+    assert(
         range.min < range.max,
         `range.min must not be higher than range.max: ${JSON.stringify(range)}`
     );

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -33,39 +33,38 @@ export const getMax = (rangeOrValues: RangeOrValues) =>
 export const getStep = (range: Range) =>
     range.step != null ? range.step : 0.1 ** (range.decimals ?? 0);
 
+const assert = (expectedToBeTrue: boolean, warning: string) => {
+    if (!expectedToBeTrue) {
+        console.error(warning);
+    }
+};
+
 const validateValues = (values: Values) => {
     for (let i = 0; i < values.length - 1; i += 1) {
-        if (values[i] > values[i + 1]) {
-            console.error(
-                `The values of the range must be sorted correctly, but ${
-                    values[i]
-                } is larger then ${values[i + 1]} in ${values}`
-            );
-        }
+        assert(
+            values[i] < values[i + 1],
+            `The values of the range must be sorted correctly, but ${
+                values[i]
+            } is larger then ${values[i + 1]} in ${values}`
+        );
     }
 };
 
 const validateRange = (range: Range) => {
-    if (range.min > range.max)
-        console.error(
-            `range.min must not be higher than range.max: ${JSON.stringify(
-                range
-            )}`
-        );
+    assert(
+        range.min < range.max,
+        `range.min must not be higher than range.max: ${JSON.stringify(range)}`
+    );
 
     if (range.step != null) {
-        if (!isFactor(range.min, range.step))
-            console.error(
-                `range.step must be a factor of range.min: ${JSON.stringify(
-                    range
-                )}`
-            );
-        if (!isFactor(range.max, range.step))
-            console.error(
-                `range.step must be a factor of range.max: ${JSON.stringify(
-                    range
-                )}`
-            );
+        assert(
+            isFactor(range.min, range.step),
+            `range.step must be a factor of range.min: ${JSON.stringify(range)}`
+        );
+        assert(
+            isFactor(range.max, range.step),
+            `range.step must be a factor of range.max: ${JSON.stringify(range)}`
+        );
     }
 };
 

--- a/src/Slider/range.ts
+++ b/src/Slider/range.ts
@@ -68,12 +68,10 @@ const validateRange = (range: Range) => {
             `range.step must be larger than zero but is ${range.step}`
         );
         assert(
-            isFactor(range.min, range.step),
-            `range.step must be a factor of range.min: ${JSON.stringify(range)}`
-        );
-        assert(
-            isFactor(range.max, range.step),
-            `range.step must be a factor of range.max: ${JSON.stringify(range)}`
+            isFactor(range.max - range.min, range.step),
+            `range.step must be a factor of range.max - range.min: ${JSON.stringify(
+                range
+            )}`
         );
     }
 };

--- a/src/Slider/rangeShape.ts
+++ b/src/Slider/rangeShape.ts
@@ -3,19 +3,25 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
-export interface RangeProp {
+
+export type Values = readonly number[];
+export type NewRange = {
     min: number;
     max: number;
     decimals?: number;
     step?: number; // positive number
-    explicitRange?: number[];
-}
-
-export type Values = readonly number[];
-export type NewRange = Omit<RangeProp, 'explicitRange'>;
+};
 
 export type RangeOrValues = NewRange | Values;
 
 export const isValues = (
     rangeOrValues: RangeOrValues
 ): rangeOrValues is Values => Array.isArray(rangeOrValues);
+
+export const getMin = (rangeOrValues: RangeOrValues) =>
+    isValues(rangeOrValues) ? rangeOrValues[0] : rangeOrValues.min;
+
+export const getMax = (rangeOrValues: RangeOrValues) =>
+    isValues(rangeOrValues)
+        ? rangeOrValues[rangeOrValues.length - 1]
+        : rangeOrValues.max;

--- a/src/Slider/rangeShape.ts
+++ b/src/Slider/rangeShape.ts
@@ -10,3 +10,12 @@ export interface RangeProp {
     step?: number; // positive number
     explicitRange?: number[];
 }
+
+export type Values = readonly number[];
+export type NewRange = Omit<RangeProp, 'explicitRange'>;
+
+export type RangeOrValues = NewRange | Values;
+
+export const isValues = (
+    rangeOrValues: RangeOrValues
+): rangeOrValues is Values => Array.isArray(rangeOrValues);

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -19,3 +19,9 @@ enzyme.configure({ adapter: new Adapter() });
 if (process.env.TESTING_ASYNC_TIMEOUT != null) {
     configure({ asyncUtilTimeout: Number(process.env.TESTING_ASYNC_TIMEOUT) });
 }
+
+window.ResizeObserver = class {
+    observe() {} // eslint-disable-line class-methods-use-this -- because we just stub things here
+    disconnect() {} // eslint-disable-line class-methods-use-this
+    unobserve() {} // eslint-disable-line class-methods-use-this
+};


### PR DESCRIPTION
I was unhappy about the introduction of so called `explicitRange`s. 

A range like this is easily possible but obviously an error:
```ts
{
  min: 3,
  max: 6,
  explicitRange: [4, 6, 7, 8]
}
```

Initially not clear to me was that also a range like this leads to buggy behaviour:
```ts
{
  min: 3,
  max: 6,
  explicitRange: [3, 3.1, 6]
}
```

That second example is missing appropriate values for the optional properties `step` and `decimals`. 

But, even more important, when specifying explicit values, the other range properties should not really be necessary, because they can be deduced. 

So this PR changes that a range can be _either_ specified by enumerating the values _or_ by specifying the properties `min`, `max`, and optionally `step` and `decimals`. 

This is valid for both components where this applies: `Slider` and `NumberInlineInput`. So a `NumberInlineInput` element can now be created in one of these two ways:

```jsx
<>
  <NumberInlineInput
    values={[4]}
    range={[3, 4, 6, 7]}
    onChange={[() => {}]}
  />

  <NumberInlineInput
    values={[4]}
    range={{ min: 3, max: 7 }}
    onChange={[() => {}]}
  />
</>
```

Because TypeScript in many cases ignores excessive properties, it sometimes does not raise a type error when still using the `explicitRange` property. But that property is not supported anymore, so there is also a runtime check for it and an error is printed if it is still used.

### Other changes

- Like before it is not implemented to show ticks in a `Slider` when using explicit values. But before we showed the ticks in wrong locations and a warning. Now the ticks are not shown at all in this case and a slightly different warning is shown. (implemented as part of e78309529)
- 8bc8f35: Fixed: Sliders with ticks without a `step` were rendered incorrectly, e.g. 
    ```jsx
  <Slider
       ticks
       values={[2]}
       range={{ min: 0, max: 5 }}
       onChange={[() => {}]}
   />
    ```
- 4bf1185: The properties of a range were previously checked for consistency on every render. Now they are only checked in the beginning and when they are changed.
- b78b336: The properties of a range were previously checked for consistency for a `Slider`, now they are also checked for a `NumberInlineInput`. 
- 547cf34: Check some more properties for consistency: That `decimals` (when specified) must be a non-negative integer and that `step` (when specified) must be larger than zero.
- e4dd35f: Before `min` and `max` needed to be multitudes of `step`. But it is actually sufficient if only the difference between `max` and `min` is a multitude of `step`.

### Remaining aspects

- With a range like `{min: 1, max: 7, step: 0.5}` no warning is printed, but `Slider` (or `NumberInlineInput`) act buggy, unless also `decimals: 1` is specified. But maybe we should not try to catch and warn about all possible errors with properties.