### PR TITLE
Enforce use of unknown in catch blocks

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -10,6 +10,8 @@
         "strict": true,
         "isolatedModules": true,
         "forceConsistentCasingInFileNames": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+
+        "useUnknownInCatchVariables": true
     }
 }


### PR DESCRIPTION
The setting will automatically give the variable type unknown, similar to `catch (error: unknown) {}`.

The main reason to do this is in order to not accidentally throw something that is not an Error, because that would not provide a stack trace, and will therefore make it more difficult to debug.

In order to check if the variable is an error:
    if (error instanceof Error) throw err
    else throw new Error(`${error}`)