### PR TITLE
Feature: Update meta types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 -   Property `apps` in type `SourceJson` became mandatory.
+-   Renamed type `AppJson` to `AppInfo`.
 
 ## 6.13.2 - 2022-12-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.14.0 - 2023-01-02
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to
 -   Property `apps` in type `SourceJson` became mandatory.
 -   Renamed type `AppJson` to `AppInfo`.
 -   Renamed property `latest` to `latestVersion` in type `AppInfo`.
+-   Exported type `AppVersions` and renamed property `tarball` to `tarballUrl`.
 -   Bumped target for TypeScript to `ES2020`.
 
 ## 6.13.2 - 2022-12-19

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to
 -   Property `apps` in type `SourceJson` became mandatory.
 -   Renamed type `AppJson` to `AppInfo`.
 -   Renamed property `latest` to `latestVersion` in type `AppInfo`.
+-   Bumped target for TypeScript to `ES2020`.
 
 ## 6.13.2 - 2022-12-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 -   Property `apps` in type `SourceJson` became mandatory.
 -   Renamed type `AppJson` to `AppInfo`.
+-   Renamed property `latest` to `latestVersion` in type `AppInfo`.
 
 ## 6.13.2 - 2022-12-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+-   Property `apps` in type `SourceJson` became mandatory.
+
 ## 6.13.2 - 2022-12-19
 
 ## Changed

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -2,7 +2,7 @@
     "ts-node": { "swc": true },
 
     "compilerOptions": {
-        "target": "ES2019",
+        "target": "ES2020",
         "moduleResolution": "node",
         "esModuleInterop": true,
         "jsx": "react",

--- a/index.d.ts
+++ b/index.d.ts
@@ -455,6 +455,7 @@ declare module 'pc-nrfconnect-shared' {
 
     export type SourceJson = import('./src/utils/AppTypes').SourceJson;
     export type AppInfo = import('./src/utils/AppTypes').AppInfo;
+    export type AppVersions = import('./src/utils/AppTypes').AppVersions;
     export type PackageJson = import('./src/utils/AppTypes').PackageJson;
 
     // useHotKey.js

--- a/index.d.ts
+++ b/index.d.ts
@@ -454,7 +454,7 @@ declare module 'pc-nrfconnect-shared' {
     // AppTypes.ts
 
     export type SourceJson = import('./src/utils/AppTypes').SourceJson;
-    export type AppJson = import('./src/utils/AppTypes').AppJson;
+    export type AppInfo = import('./src/utils/AppTypes').AppInfo;
     export type PackageJson = import('./src/utils/AppTypes').PackageJson;
 
     // useHotKey.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.13.2",
+    "version": "6.14.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -341,7 +341,7 @@ const getUpdatedAppInfo = async (app: App): Promise<AppInfo> => {
         homepage,
         iconUrl: `${app.sourceUrl}/${app.iconFilename}`,
         releaseNotesUrl: `${app.sourceUrl}/${app.releaseNotesFilename}`,
-        latest: version,
+        latestVersion: version,
         versions: {
             ...versions,
             [version]: {

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -345,7 +345,7 @@ const getUpdatedAppInfo = async (app: App): Promise<AppInfo> => {
         versions: {
             ...versions,
             [version]: {
-                tarball: `${app.sourceUrl}/${app.filename}`,
+                tarballUrl: `${app.sourceUrl}/${app.filename}`,
                 shasum: app.shasum,
             },
         },

--- a/src/utils/AppTypes.ts
+++ b/src/utils/AppTypes.ts
@@ -9,6 +9,13 @@ export interface SourceJson {
     apps: string[];
 }
 
+export type AppVersions = {
+    [version: string]: {
+        shasum: string;
+        tarballUrl: string;
+    };
+};
+
 export interface AppInfo {
     name: string;
     displayName: string;
@@ -17,12 +24,7 @@ export interface AppInfo {
     iconUrl: string;
     releaseNotesUrl: string;
     latestVersion: string;
-    versions: {
-        [version: string]: {
-            shasum: string;
-            tarball: string;
-        };
-    };
+    versions: AppVersions;
     installed?: {
         path: string;
         shasum: string;

--- a/src/utils/AppTypes.ts
+++ b/src/utils/AppTypes.ts
@@ -9,7 +9,7 @@ export interface SourceJson {
     apps: string[];
 }
 
-export interface AppJson {
+export interface AppInfo {
     name: string;
     displayName: string;
     description: string;

--- a/src/utils/AppTypes.ts
+++ b/src/utils/AppTypes.ts
@@ -6,7 +6,7 @@
 
 export interface SourceJson {
     name: string;
-    apps?: string[];
+    apps: string[];
 }
 
 export interface AppJson {

--- a/src/utils/AppTypes.ts
+++ b/src/utils/AppTypes.ts
@@ -16,7 +16,7 @@ export interface AppInfo {
     homepage?: string;
     iconUrl: string;
     releaseNotesUrl: string;
-    latest: string;
+    latestVersion: string;
     versions: {
         [version: string]: {
             shasum: string;


### PR DESCRIPTION
-   Property `apps` in type `SourceJson` became mandatory.
-   Renamed type `AppJson` to `AppInfo`.
-   Renamed property `latest` to `latestVersion` in type `AppInfo`.
-   Exported type `AppVersions` and renamed property `tarball` to `tarballUrl`.
-   Bumped target for TypeScript to `ES2020`.