### PR TITLE
Update mdi chevron

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.14.1 - 2023-01-04
 
 ## Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+-   Chevron was not visible on a Collapsible Group.
+
 ## 6.14.0 - 2023-01-02
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.14.0",
+    "version": "6.14.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/SidePanel/Group.tsx
+++ b/src/SidePanel/Group.tsx
@@ -48,6 +48,7 @@ const ContextAwareToggle: React.FC<{
             className={classNames('group-toggle', isCurrentEventKey && 'show')}
         >
             <Heading label={heading} title={title} />
+            <span className="mdi mdi-chevron-down" />
         </PseudoButton>
     );
 };

--- a/src/SidePanel/group.scss
+++ b/src/SidePanel/group.scss
@@ -4,41 +4,39 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
- @import "../variables";
+@import '../variables';
 
- .sidepanel-group {
-     .body {
-         > * {
-             margin-bottom: 8px;
-         }
- 
-         > *:last-child {
-             margin-bottom: 0px;
-         }
-     }
- 
-     .heading {
-         margin-bottom: 16px;
- 
-         font-size: 10px;
-         font-weight: normal;
-         letter-spacing: 0.5ex;
- 
-         text-transform: uppercase;
-     }
- 
-     .group-toggle {
-         display: flex;
-         justify-content: space-between;
- 
-         .heading {
-             margin-top: 4px;
-         }
- 
-         &.show .mdi-chevron-down::before {
-             transform: rotate(180deg);
-         }
- 
-     }
- }
- 
+.sidepanel-group {
+    .body {
+        > * {
+            margin-bottom: 8px;
+        }
+
+        > *:last-child {
+            margin-bottom: 0px;
+        }
+    }
+
+    .heading {
+        margin-bottom: 16px;
+
+        font-size: 10px;
+        font-weight: normal;
+        letter-spacing: 0.5ex;
+
+        text-transform: uppercase;
+    }
+
+    .group-toggle {
+        display: flex;
+        justify-content: space-between;
+
+        .heading {
+            margin-top: 4px;
+        }
+
+        &.show .mdi-chevron-down::before {
+            transform: rotate(180deg);
+        }
+    }
+}

--- a/src/SidePanel/group.scss
+++ b/src/SidePanel/group.scss
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-@import '../variables';
-
 .sidepanel-group {
     .body {
         > * {
@@ -31,8 +29,10 @@
         display: flex;
         justify-content: space-between;
 
-        .heading {
-            margin-top: 4px;
+        .mdi-chevron-down::before {
+            font-size: 20px;
+            position: relative;
+            top: -9px;
         }
 
         &.show .mdi-chevron-down::before {

--- a/src/SidePanel/group.scss
+++ b/src/SidePanel/group.scss
@@ -4,56 +4,41 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-@import "../variables";
+ @import "../variables";
 
-.sidepanel-group {
-    .body {
-        > * {
-            margin-bottom: 8px;
-        }
-
-        > *:last-child {
-            margin-bottom: 0px;
-        }
-    }
-
-    .heading {
-        margin-bottom: 16px;
-
-        font-size: 10px;
-        font-weight: normal;
-        letter-spacing: 0.5ex;
-
-        text-transform: uppercase;
-    }
-
-    .group-toggle {
-        .heading {
-            transition: margin-bottom 0.2s ease-in-out;
-            margin-bottom: 0;
-
-            line-height: 13px;
-            position: relative;
-
-            &::after {
-                content: "\f140";
-                font-family: "Material Design Icons";
-                font-size: 15px;
-                display: inline-block;
-                vertical-align: middle;
-                transition: transform 0.2s ease-in-out;
-                position: absolute;
-                right: 0;
-                transform-origin: 8px 6px;
-                margin-right: -5px;
-            }
-        }
-
-        &.show .heading {
-            margin-bottom: 16px;
-            &::after {
-                transform: rotate(-180deg);
-            }
-        }
-    }
-}
+ .sidepanel-group {
+     .body {
+         > * {
+             margin-bottom: 8px;
+         }
+ 
+         > *:last-child {
+             margin-bottom: 0px;
+         }
+     }
+ 
+     .heading {
+         margin-bottom: 16px;
+ 
+         font-size: 10px;
+         font-weight: normal;
+         letter-spacing: 0.5ex;
+ 
+         text-transform: uppercase;
+     }
+ 
+     .group-toggle {
+         display: flex;
+         justify-content: space-between;
+ 
+         .heading {
+             margin-top: 4px;
+         }
+ 
+         &.show .mdi-chevron-down::before {
+             transform: rotate(180deg);
+         }
+ 
+     }
+ }
+ 


### PR DESCRIPTION
Old method of importing mdi chevron no longer worked. Updated import and relevant styling.

![image](https://user-images.githubusercontent.com/34618612/210337775-33419737-1bc8-4956-97c4-c9ad5ac1b162.png)

![image](https://user-images.githubusercontent.com/34618612/210337848-8c8e6d00-cc6d-4f60-bda6-32d47d358970.png)
