### PR TITLE
Fix: Broken usage of unknown state

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,8 @@ and this project adheres to
 
 ### Fixed
 
--   The ErrorBoundary component was broken if the Redux state wasn't in a
-    supported state.
+-   The components ErrorBoundary and Logo were broken if the Redux state wasn't
+    in a supported state.
 
 ## 6.17.0 - 2023-01-18
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   The ErrorBoundary component was broken if the Redux state wasn't in a
+    supported state.
+
 ## 6.17.0 - 2023-01-18
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,14 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 6.17.1 - 2023-01-19
 
 ### Fixed
 
--   The components ErrorBoundary and Logo were broken if the Redux state wasn't
-    in a supported state.
+-   The components `ErrorBoundary` and `Logo` were broken if the Redux state
+    wasn't in a supported state.
 
 ## 6.17.0 - 2023-01-18
+
+### Added
+
+-   Component `RootErrorDialog` (which is the `ErrorDialog` wrongly removed in
+    6.15.0).
 
 ### Changed
 
@@ -73,6 +78,7 @@ and this project adheres to
 ### Removed
 
 -   `ConfirmationDialog` component.
+-   Previous `ErrorDialog` component.
 
 ### Steps to upgrade when using this package
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.17.0",
+    "version": "6.17.1",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -16,7 +16,12 @@ import { Reducer } from 'redux';
 import About from '../About/About';
 import { setDocumentationSections } from '../About/documentationSlice';
 import BrokenDeviceDialog from '../Device/BrokenDeviceDialog/BrokenDeviceDialog';
-import { setGlobalAutoReconnect } from '../Device/deviceSlice';
+import {
+    selectedDevice as selectedDeviceSelector,
+    selectedSerialNumber as selectedSerialNumberSelector,
+    setGlobalAutoReconnect,
+    sortedDevices as sortedDevicesSelector,
+} from '../Device/deviceSlice';
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary';
 import ErrorDialog from '../ErrorDialog/ErrorDialog';
 import LogViewer from '../Log/LogViewer';
@@ -193,14 +198,30 @@ const ConnectedApp: FC<ConnectedAppProps> = ({
     );
 };
 
+const ConnectedErrorBoundary: React.FC = ({ children }) => {
+    const sortedDevices = useSelector(sortedDevicesSelector);
+    const selectedDevice = useSelector(selectedDeviceSelector);
+    const selectedSerialNumber = useSelector(selectedSerialNumberSelector);
+
+    return (
+        <ErrorBoundary
+            devices={sortedDevices}
+            selectedDevice={selectedDevice}
+            selectedSerialNumber={selectedSerialNumber ?? undefined}
+        >
+            {children}
+        </ErrorBoundary>
+    );
+};
+
 const App = ({
     appReducer,
     ...props
 }: { appReducer?: Reducer } & ConnectedAppProps) => (
     <ConnectedToStore appReducer={appReducer}>
-        <ErrorBoundary>
+        <ConnectedErrorBoundary>
             <ConnectedApp {...props} />
-        </ErrorBoundary>
+        </ConnectedErrorBoundary>
     </ConnectedToStore>
 );
 

--- a/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.tsx
@@ -6,13 +6,12 @@
 
 import React, { ReactNode } from 'react';
 import { Button } from 'react-bootstrap';
-import { connect } from 'react-redux';
 import { getCurrentWindow } from '@electron/remote';
 
 import Spinner from '../Dialog/Spinner';
 import FactoryResetButton from '../FactoryReset/FactoryResetButton';
 import { CollapsibleGroup } from '../SidePanel/Group';
-import { Device, RootState } from '../state';
+import { Device } from '../state';
 import { openUrl } from '../utils/open';
 import packageJson from '../utils/packageJson';
 import { getAppSpecificStore as store } from '../utils/persistentStore';
@@ -40,7 +39,8 @@ const sendGAEvent = (error: string) => {
 interface Props {
     children: ReactNode;
     selectedSerialNumber?: string;
-    devices: Map<string, Device>;
+    selectedDevice?: Device;
+    devices?: Device[];
     appName?: string;
     restoreDefaults?: () => void;
     sendUsageData?: (message: string) => void;
@@ -72,19 +72,15 @@ class ErrorBoundary extends React.Component<
     }
 
     componentDidCatch(error: Error) {
-        const { devices, selectedSerialNumber, sendUsageData } = this.props;
+        const { devices, selectedDevice, selectedSerialNumber, sendUsageData } =
+            this.props;
         sendUsageData != null
             ? sendUsageData(error.message)
             : sendGAEvent(error.message);
 
-        const selectedDevice =
-            selectedSerialNumber == null
-                ? undefined
-                : devices.get(selectedSerialNumber);
-
         generateSystemReport(
             new Date().toISOString().replace(/:/g, '-'),
-            Object.values(devices) as Device[],
+            devices,
             selectedDevice,
             selectedSerialNumber
         ).then(report => {
@@ -184,9 +180,4 @@ class ErrorBoundary extends React.Component<
     }
 }
 
-const mapStateToProps = (state: RootState) => ({
-    devices: state.device.devices,
-    selectedSerialNumber: state.device?.selectedSerialNumber ?? undefined,
-});
-
-export default connect(mapStateToProps)(ErrorBoundary);
+export default ErrorBoundary;

--- a/src/Logo/Logo.tsx
+++ b/src/Logo/Logo.tsx
@@ -6,7 +6,6 @@
 
 import React, { FC } from 'react';
 import { useSelector } from 'react-redux';
-import { bool } from 'prop-types';
 
 import { deviceIsSelected as deviceIsSelectedSelector } from '../Device/deviceSlice';
 import { openUrl } from '../utils/open';
@@ -19,36 +18,31 @@ import './logo.scss';
 const goToNRFConnectWebsite = () =>
     openUrl('http://www.nordicsemi.com/nRFConnect');
 
-const chooseLogo = (
-    changeWithDeviceState: boolean,
-    deviceIsSelected: boolean
-) => {
-    if (!changeWithDeviceState) {
-        return logoUniform;
-    }
+const LogoImage: FC<{ src: string }> = ({ src }) => (
+    <img
+        className="core19-logo"
+        src={src}
+        alt="Nordic Semiconductor logo"
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+        role="link"
+        onClick={goToNRFConnectWebsite}
+        onKeyPress={() => {}}
+        tabIndex={0}
+    />
+);
 
-    return deviceIsSelected ? logoConnected : logoDisconnected;
-};
-
-const Logo: FC<{ changeWithDeviceState?: boolean }> = ({
-    changeWithDeviceState = false,
-}) => {
+const DynamicLogo = () => {
     const deviceIsSelected = useSelector(deviceIsSelectedSelector);
-    const logo = chooseLogo(changeWithDeviceState, deviceIsSelected);
+
     return (
-        <img
-            className="core19-logo"
-            src={logo}
-            alt="Nordic Semiconductor logo"
-            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
-            role="link"
-            onClick={goToNRFConnectWebsite}
-            onKeyPress={() => {}}
-            tabIndex={0}
-        />
+        <LogoImage src={deviceIsSelected ? logoConnected : logoDisconnected} />
     );
 };
 
-Logo.propTypes = { changeWithDeviceState: bool };
+const StaticLogo = () => <LogoImage src={logoUniform} />;
+
+const Logo: FC<{ changeWithDeviceState?: boolean }> = ({
+    changeWithDeviceState = false,
+}) => (changeWithDeviceState ? <DynamicLogo /> : <StaticLogo />);
 
 export default Logo;

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -91,7 +91,7 @@ const generalInfoReport = async () => {
     ];
 };
 
-const allDevicesReport = (allDevices: Device[]) => [
+const allDevicesReport = (allDevices: Device[] = []) => [
     '- Connected devices:',
     ...allDevices.map(
         d =>
@@ -121,7 +121,7 @@ const currentDeviceReport = (device?: Device, currentSerialNumber?: string) => {
 
 export const generateSystemReport = async (
     timestamp: string,
-    allDevices: Device[],
+    allDevices?: Device[],
     currentDevice?: Device,
     currentSerialNumber?: string
 ) =>

--- a/typings/externals.d.ts
+++ b/typings/externals.d.ts
@@ -24,4 +24,8 @@ interface Window {
 // Let typescript compiler in `npm run lint` resolve css modules
 declare module '*.icss.scss';
 declare module '*.gif';
-declare module '*.png';
+
+declare module '*.png' {
+    const path: string;
+    export default path;
+}

--- a/typings/generated/src/ErrorBoundary/ErrorBoundary.d.ts
+++ b/typings/generated/src/ErrorBoundary/ErrorBoundary.d.ts
@@ -4,7 +4,8 @@ import './error-boundary.scss';
 interface Props {
     children: ReactNode;
     selectedSerialNumber?: string;
-    devices: Map<string, Device>;
+    selectedDevice?: Device;
+    devices?: Device[];
     appName?: string;
     restoreDefaults?: () => void;
     sendUsageData?: (message: string) => void;
@@ -22,5 +23,4 @@ declare class ErrorBoundary extends React.Component<Props, {
     componentDidCatch(error: Error): void;
     render(): React.ReactNode;
 }
-declare const _default: import("react-redux").ConnectedComponent<typeof ErrorBoundary, import("react-redux").Omit<React.ClassAttributes<ErrorBoundary> & Props, "devices" | "selectedSerialNumber">>;
-export default _default;
+export default ErrorBoundary;

--- a/typings/generated/src/utils/systemReport.d.ts
+++ b/typings/generated/src/utils/systemReport.d.ts
@@ -1,4 +1,4 @@
 import { Device } from '../state';
-export declare const generateSystemReport: (timestamp: string, allDevices: Device[], currentDevice?: Device, currentSerialNumber?: string) => Promise<string>;
+export declare const generateSystemReport: (timestamp: string, allDevices?: Device[], currentDevice?: Device, currentSerialNumber?: string) => Promise<string>;
 declare const _default: (allDevices: Device[], currentSerialNumber: string, currentDevice: Device | null) => Promise<void>;
 export default _default;


### PR DESCRIPTION
The components `ErrorBoundary` and `Logo` were broken when used in the previous way from the launcher.