### PR TITLE
Fix: Error when installing shared as dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.17.2 - 2023-01-24
+
+### Fixed
+
+-   `husky install` sometimes was ran even if `shared` was installed only as a
+    dependency. That was wrong and also failed, because it found no `.git`
+    directory.
+
 ## 6.17.1 - 2023-01-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "check:types": "tsc --noEmit",
         "check:license": "ts-node scripts/nrfconnect-license.ts check",
         "generate-types": "tsc --emitDeclarationOnly --declaration --incremental --outDir ./typings/generated",
-        "prepare": "husky install",
+        "prepare": "ts-node scripts/installHusky.ts",
         "compile:publish": "esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning --minify",
         "compile:bootstrap": "node scripts/esbuild-bootstrap.js",
         "postinstall": "run-p compile:*"

--- a/scripts/installHusky.ts
+++ b/scripts/installHusky.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env ts-node
+
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { existsSync } from 'fs';
+import { install as installHusky } from 'husky';
+import { cwd } from 'process';
+
+if (existsSync('.git')) {
+    installHusky();
+} else {
+    console.log(`Not installing husky, because ${cwd()} is no git repo.`);
+}


### PR DESCRIPTION
This was sometimes triggered when installing shared as a dependency with npm@7 or later.

The `prepare` script of `shared` is at least sometimes executed in that case, which failed because it contained `husky install`. That in turn expects a `.git` directory. So now the script first checks if that folders exists (which is only correct if `shared` was cloned for development) and only then executes `husky install`.