### PR TITLE
Better Redux DevTools config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Changed
+
+-   Better Redux dev tools configuration: More actions (100 instead of 50) and
+    show some more objects, e.g. Maps and Sets.
+
 ## 7 - 2023-02-13
 
 ### Changed

--- a/src/App/ConnectedToStore.tsx
+++ b/src/App/ConnectedToStore.tsx
@@ -13,13 +13,24 @@ import thunk from 'redux-thunk';
 
 import rootReducer from '../rootReducer';
 
-const middleware = composeWithDevTools(applyMiddleware(thunk));
+const ifBuiltForDevelopment = <X,>(value: X) =>
+    process.env.NODE_ENV === 'development' ? value : undefined;
+
+const composeEnhancers = composeWithDevTools({
+    maxAge: ifBuiltForDevelopment(100),
+    serialize: ifBuiltForDevelopment(true),
+});
 
 const ConnectedToStore: FC<{
     appReducer?: Reducer;
     children: ReactNode;
 }> = ({ appReducer, children }) => (
-    <Provider store={createStore(rootReducer(appReducer), middleware)}>
+    <Provider
+        store={createStore(
+            rootReducer(appReducer),
+            composeEnhancers(applyMiddleware(thunk))
+        )}
+    >
         {children}
     </Provider>
 );

--- a/src/Device/DeviceSelector/DeviceSelector.tsx
+++ b/src/Device/DeviceSelector/DeviceSelector.tsx
@@ -18,7 +18,6 @@ import {
     deviceIsSelected as deviceIsSelectedSelector,
     selectDevice,
     selectedSerialNumber,
-    setReadbackProtected,
 } from '../deviceSlice';
 import DeviceList from './DeviceList/DeviceList';
 import SelectDevice from './SelectDevice';


### PR DESCRIPTION
More actions (100 instead of 50) and show some more objects, e.g. Maps and Sets [by serialising them](https://github.com/reduxjs/redux-devtools/blob/bef71f4a0eb7335ee942f25c6a2ca5bf81bff5e5/extension/docs/API/Arguments.md#serialize). When building for production the changes are not effective.