### PR TITLE
feat: automatic open device and port on 'open:app'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,15 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 12 - 2023-02-23
+
+### Added
+
+-   `openAppWindow` sends IPC call to launcher, in order to open an app,
+    identified by its `name` and `source`. And gives the ability to provide
+    `openAppOptions` with `device` and `serialPortPath`, in order to directly
+    connect to a device, and its serial port.
+
 ## 11 - 2023-02-22
 
 ### Changed

--- a/main/index.ts
+++ b/main/index.ts
@@ -25,3 +25,7 @@ export type OverwriteOptions = {
     overwrite?: boolean;
     settingsLocked?: boolean;
 };
+
+export type OpenAppOptions = {
+    device?: { serialNumber: string; serialPortPath?: string };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "6.17.3",
+    "version": "11.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1976,9 +1976,9 @@
             }
         },
         "@nordicsemiconductor/nrf-device-lib-js": {
-            "version": "0.5.0-pre7",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.5.0-pre7.tgz",
-            "integrity": "sha512-rOBGA9l1EOiSUCkRvaPtmYjXwIHPOYl83GYsALdDTJ5E8oguCwmk4el+h+YVm3Uq94DFOjFJQ2t9CHE0z+Y31Q==",
+            "version": "0.5.0-pre9",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.5.0-pre9.tgz",
+            "integrity": "sha512-gJEyZEwORLa+ARCBJHzCl0FZYQfds+g+L61dFeCe3K3miCPWm07rKVlcqk04EHBi8NZ7qCzeRG8c49e+6ZNkqg==",
             "requires": {
                 "cmake-js": "^6.1.0",
                 "fs": "0.0.1-security",
@@ -3791,9 +3791,9 @@
                     "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -4388,9 +4388,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "version": "3.6.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+                    "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -6026,9 +6026,9 @@
                     "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -11744,9 +11744,9 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -12008,9 +12008,9 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -12970,9 +12970,9 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+                    "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -15592,9 +15592,9 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "version": "3.6.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+                    "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@babel/preset-typescript": "7.18.6",
         "@electron/remote": "^2.0.4",
         "@mdi/font": "7.0.96",
-        "@nordicsemiconductor/nrf-device-lib-js": "0.5.0-pre7",
+        "@nordicsemiconductor/nrf-device-lib-js": "^0.5.0-pre9",
         "@reduxjs/toolkit": "1.8.3",
         "@svgr/core": "^6.5.1",
         "@svgr/webpack": "5.5.0",

--- a/src/OpenApp/openApp.ts
+++ b/src/OpenApp/openApp.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { ipcRenderer } from 'electron/renderer';
+
+import type { OpenAppOptions } from '../../main';
+
+type AppSpec = { name: string; source: string };
+
+export const openAppWindow = (
+    app: AppSpec,
+    openAppOptions?: OpenAppOptions
+) => {
+    ipcRenderer.send('open:app', app, openAppOptions);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,8 @@ export { default as describeError } from './logging/describeError';
 export { createSerialPort } from './SerialPort/SerialPort';
 export type { SerialPort } from './SerialPort/SerialPort';
 
+export { openAppWindow } from './OpenApp/openApp';
+
 export type { DropdownItem } from './Dropdown/Dropdown';
 
 export type { Device, NrfConnectState } from './state';

--- a/typings/generated/main/index.d.ts
+++ b/typings/generated/main/index.d.ts
@@ -16,3 +16,9 @@ export declare type OverwriteOptions = {
     overwrite?: boolean;
     settingsLocked?: boolean;
 };
+export declare type OpenAppOptions = {
+    device?: {
+        serialNumber: string;
+        serialPortPath?: string;
+    };
+};

--- a/typings/generated/src/OpenApp/openApp.d.ts
+++ b/typings/generated/src/OpenApp/openApp.d.ts
@@ -1,0 +1,7 @@
+import type { OpenAppOptions } from '../../main';
+declare type AppSpec = {
+    name: string;
+    source: string;
+};
+export declare const openAppWindow: (app: AppSpec, openAppOptions?: OpenAppOptions) => void;
+export {};

--- a/typings/generated/src/index.d.ts
+++ b/typings/generated/src/index.d.ts
@@ -52,6 +52,7 @@ export { defaultInitPacket, HashType, FwType } from './Device/initPacket';
 export { default as describeError } from './logging/describeError';
 export { createSerialPort } from './SerialPort/SerialPort';
 export type { SerialPort } from './SerialPort/SerialPort';
+export { openAppWindow } from './OpenApp/openApp';
 export type { DropdownItem } from './Dropdown/Dropdown';
 export type { Device, NrfConnectState } from './state';
 export type { Props as DeviceSelectorProps } from './Device/DeviceSelector/DeviceSelector';


### PR DESCRIPTION
This PR adds the `openAppWindow` functions in shared, and will be used to a new app from an existing app. E.g. open Serial Terminal from Cellular Monitor, and has to option to include `openAppOptions` with `device` and `serialPortPath`, in order to directly connect to the device and serial port when the app is opened.