### PR TITLE
Make `shasum` property optional

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 11 - 2023-02-22
+
+### Changed
+
+-   `shasum` property on apps became optional.
+
 ## 10 - 2023-02-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "10.0.0",
+    "version": "11.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/utils/AppTypes.ts
+++ b/src/utils/AppTypes.ts
@@ -11,7 +11,7 @@ export interface SourceJson {
 
 export type AppVersions = {
     [version: string]: {
-        shasum: string;
+        shasum?: string;
         tarballUrl: string;
     };
 };
@@ -27,7 +27,7 @@ export interface AppInfo {
     versions: AppVersions;
     installed?: {
         path: string;
-        shasum: string;
+        shasum?: string;
     };
 }
 

--- a/typings/generated/src/utils/AppTypes.d.ts
+++ b/typings/generated/src/utils/AppTypes.d.ts
@@ -4,7 +4,7 @@ export interface SourceJson {
 }
 export declare type AppVersions = {
     [version: string]: {
-        shasum: string;
+        shasum?: string;
         tarballUrl: string;
     };
 };
@@ -19,7 +19,7 @@ export interface AppInfo {
     versions: AppVersions;
     installed?: {
         path: string;
-        shasum: string;
+        shasum?: string;
     };
 }
 interface ObjectContainingOptionalStrings {


### PR DESCRIPTION
There are situations, where we cannot determine the `shasum` easily, e.g. when an app was installed before we started recording the shasum. For these cases it is easier to treat it generally as optional.