### PR TITLE
fix: properties not on global Window

### DIFF
--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -11,6 +11,14 @@ import { loadPackageJson } from './packageJson';
 
 const getUserDataDir = () => getGlobal('userDataDir');
 
+declare global {
+    interface Window {
+        appDir: string;
+        appDataDir: string;
+        appLogDir: string;
+    }
+}
+
 function setAppDirs(
     newAppDir: string,
     newAppDataDir: string,

--- a/typings/generated/src/utils/appDirs.d.ts
+++ b/typings/generated/src/utils/appDirs.d.ts
@@ -1,4 +1,11 @@
 declare const getUserDataDir: () => any;
+declare global {
+    interface Window {
+        appDir: string;
+        appDataDir: string;
+        appLogDir: string;
+    }
+}
 declare function setAppDirs(newAppDir: string, newAppDataDir: string, newAppLogDir: string): void;
 /**
  * Get the filesystem path of the currently loaded app.


### PR DESCRIPTION
Explicitly add data directories to the global Window interface, in order to make typescript aware that the attributes should exist.

### Problem

These are the errors after running `npm run check` in pc-nrfconnect-cellularmonitor

![image](https://user-images.githubusercontent.com/34618612/221568485-78e3caf2-ac7b-40e9-8dc1-6db59dff3dde.png)

### Solution

Append the relevant attributes to the global `Window` interface.
