### PR TITLE
Fix: Reactivate the check for unused variables

### DIFF
--- a/config/eslintrc.js
+++ b/config/eslintrc.js
@@ -75,8 +75,6 @@ module.exports = {
         'no-shadow': 'off',
         'no-undef': 'error',
         'no-unused-expressions': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
-        'no-unused-vars': 'off',
         'no-use-before-define': 'off',
         'prettier/prettier': 'error',
         'react-hooks/exhaustive-deps': 'error',

--- a/src/Device/deviceSlice.ts
+++ b/src/Device/deviceSlice.ts
@@ -179,6 +179,7 @@ const slice = createSlice({
                 );
 
                 if (vComIndex !== undefined && vComIndex !== -1) {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used to filter out the path property
                     const { path: _, ...serialPortOptions } = action.payload;
 
                     persistSerialPortSettingsToStore(

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import FormLabel from 'react-bootstrap/FormLabel';
 
 import styles from './Dropdown.module.scss';

--- a/src/utils/useStopwatch.test.tsx
+++ b/src/utils/useStopwatch.test.tsx
@@ -23,7 +23,7 @@ const setup = (stopwatch: Stopwatch) => {
 
 describe('Stop Watch', () => {
     const mockNow = jest.fn(() => 0);
-    const mockSetTimeout = jest.fn((callback: () => void, _ms: number) => {
+    const mockSetTimeout = jest.fn((callback: () => void) => {
         appCallback = callback;
         return () => {};
     });


### PR DESCRIPTION
The check is useful most of the times.

`@typescript-eslint/no-unused-vars` was turned off because `no-unused-vars` was already turned off. But this is wrong: `no-unused-vars` was turned off because it is not well suited for TypeScript, by having false positives and false negatives for certain TypeScript structures. So, it is superseded by `@typescript-eslint/no-unused-vars`.

So, this change turns `@typescript-eslint/no-unused-vars` back on.

This also removes the configuration to turn off `no-unused-vars` because that is already done by `plugin:@typescript-eslint/recommended`.

This reverts #539.
