### PR TITLE
[Work in progress] Switch to using nrf-fw-update-bundle-lib for dfu generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
                 "lodash.range": "3.2.0",
                 "mousetrap": "1.6.5",
                 "npm-run-all2": "5.0.2",
+                "nrf-fw-update-bundle-lib": "file:../nrf-fw-update-bundle-lib/js",
                 "nrf-intel-hex": "^1.3.0",
                 "postcss-modules": "^6.0.0",
                 "prettier": "2.8.7",
@@ -112,6 +113,18 @@
             },
             "peerDependencies": {
                 "@nordicsemiconductor/nrf-device-lib-js": "*"
+            }
+        },
+        "../nrf-fw-update-bundle-lib": {},
+        "../nrf-fw-update-bundle-lib/js": {
+            "version": "0.0.0",
+            "license": "MIT",
+            "devDependencies": {
+                "@napi-rs/cli": "^2.15.0",
+                "ava": "^5.1.1"
+            },
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -11699,6 +11712,10 @@
                 "are-we-there-yet": "~1.0.0",
                 "gauge": "~1.2.0"
             }
+        },
+        "node_modules/nrf-fw-update-bundle-lib": {
+            "resolved": "../nrf-fw-update-bundle-lib/js",
+            "link": true
         },
         "node_modules/nrf-intel-hex": {
             "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,7 @@
         },
         "../nrf-fw-update-bundle-lib": {},
         "../nrf-fw-update-bundle-lib/js": {
+            "name": "nrf-fw-update-bundle-lib",
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "mousetrap": "1.6.5",
         "npm-run-all2": "5.0.2",
         "nrf-intel-hex": "^1.3.0",
+        "nrf-fw-update-bundle-lib": "file:../nrf-fw-update-bundle-lib/js",
         "postcss-modules": "^6.0.0",
         "prettier": "2.8.7",
         "prettysize": "2.0.0",

--- a/src/Device/sdfuOperations.ts
+++ b/src/Device/sdfuOperations.ts
@@ -585,5 +585,5 @@ export const performDFU = (
 };
 
 export default {
-    createDfuZipBuffer,
+    createDfuZipBufferFromImages,
 };

--- a/src/Device/sdfuOperations.ts
+++ b/src/Device/sdfuOperations.ts
@@ -395,37 +395,28 @@ const createDfuZipBufferFromImages = async (dfuImages: DfuImage[]) => {
         dfuImage => dfuImage.initPacket.fwType == FwType.BOOTLOADER
     );
 
-    const application = applicationDfuImage
-        ? {
-              data: applicationDfuImage,
-              spec: dfu.ApplicationSpec.copyFromBuffer({
-                  name: applicationDfuImage.name,
-                  version: applicationDfuImage.initPacket.fwVersion || 4,
-                  buffer: applicationDfuImage.firmwareImage,
-              }),
-          }
-        : null;
+    const applicationSpec = applicationDfuImage
+        ? dfu.ApplicationSpec.copyFromBuffer({
+              name: applicationDfuImage.name,
+              version: applicationDfuImage.initPacket.fwVersion || 4,
+              buffer: applicationDfuImage.firmwareImage,
+          })
+        : undefined;
 
-    const bootloader = bootloaderDfuImage
-        ? {
-              data: bootloaderDfuImage,
-              spec: dfu.BootloaderSpec.copyFromBuffer({
-                  name: bootloaderDfuImage.name,
-                  buffer: bootloaderDfuImage.firmwareImage,
-                  version: bootloaderDfuImage.initPacket.fwVersion || 4,
-              }),
-          }
-        : null;
+    const bootloaderSpec = bootloaderDfuImage
+        ? dfu.BootloaderSpec.copyFromBuffer({
+              name: bootloaderDfuImage.name,
+              buffer: bootloaderDfuImage.firmwareImage,
+              version: bootloaderDfuImage.initPacket.fwVersion || 4,
+          })
+        : undefined;
 
-    const softDevice = softDeviceDfuImage
-        ? {
-              data: softDeviceDfuImage,
-              spec: dfu.SoftDeviceSpec.copyFromBuffer({
-                  name: softDeviceDfuImage.name,
-                  buffer: softDeviceDfuImage.firmwareImage,
-              }),
-          }
-        : null;
+    const softDeviceSpec = softDeviceDfuImage
+        ? dfu.SoftDeviceSpec.copyFromBuffer({
+              name: softDeviceDfuImage.name,
+              buffer: softDeviceDfuImage.firmwareImage,
+          })
+        : undefined;
 
     const hwVersion = applicationDfuImage
         ? applicationDfuImage.initPacket.hwVersion
@@ -436,9 +427,9 @@ const createDfuZipBufferFromImages = async (dfuImages: DfuImage[]) => {
         : undefined;
 
     let input = dfu.input({
-        applicationSpec: application?.spec,
-        softDeviceSpec: softDevice?.spec,
-        bootloaderSpec: bootloader?.spec,
+        applicationSpec,
+        softDeviceSpec,
+        bootloaderSpec,
         // @ts-expect-error This parameter is set.
         sdId: applicationDfuImage?.initPacket.sdId,
         sdReq: unique(


### PR DESCRIPTION
*This is a work in progress pull request aimed at sharing the potential changes for using the `nrf-fw-update-bundle-lib` to generate S/DFUs. Not looking to merge in this state.* 

This is an initial attempt at using the library instead of the current typescript-based dfu generation code.

These changes aim for minimal disruption and I haven't removed any dead code that is no longer used.

This change will break the pc-nrfconnect-programmer code base which relies on the exported createDfuZipBuffer function which we've changed here.