### PR TITLE
Feature: Create source on publish

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,11 @@ every new version is a new major version.
 
 ## Unreleased
 
+### Added
+
+-   New option `--create-source` to script `nordic-publish` to create a new
+    source when publishing an app.
+
 ### Changed
 
 -   Update TypeScript to 4.9.

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,7 +22,8 @@ every new version is a new major version.
 ### Fixed
 
 -   Error loading SVGs introduced in v31.
--   InlineInput`only emits`onChange`and`onChangeComplete` if value has changed
+-   `InlineInput` only calls `onChange` and `onChangeComplete` if value has
+    changed.
 
 ## 31 - 2023-04-03
 


### PR DESCRIPTION
Added a new option `--create-source` to script `nordic-publish` to create a new source when publishing an app.

When one e.g. runs 
```
npm run nordic-publish -- --source release-test-4.1
``` 
in an app and there is no source with the id `release-test-4.1` on the server yet, it fails. 

Now one can run 
```
npm run nordic-publish -- --source release-test-4.1 --create-source "Release test for 4.1"
``` 
and a source with the id “release-test-4.1” and the name “Release test for 4.1” will automatically be created while publishing the app.