### PR TITLE
Add release scripts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Added
+
+-   Scripts `prepare-shared-release` and `release-shared`to ease releasing new
+    versions of shared.
+
 ## 35 - 2023-04-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
         "prepare": "ts-node scripts/installHusky.ts",
         "compile:publish": "esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning --minify",
         "compile:bootstrap": "node scripts/esbuild-bootstrap.js",
+        "release-shared": "ts-node scripts/release-shared.ts",
+        "prepare-shared-release": "ts-node scripts/prepare-shared-release.ts",
         "postinstall": "run-p compile:*"
     },
     "peerDependencies": {

--- a/scripts/prepare-shared-release.ts
+++ b/scripts/prepare-shared-release.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env ts-node
+
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+/*
+  A script to prepare a new version of shared.
+
+  Requirement for this script: Have [the GitHub CLI tool `gh`](https://cli.github.com)
+  installed and authenticate in it (run `gh auth login`).
+
+  Run
+     npm run prepare-shared-release
+  to update the version in `package.json` and the header of the latest entry
+  in `Changelog.md`.
+*/
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { getNextReleaseNumber } from './release-shared';
+
+const parseJson = <Result>(jsonString: string) =>
+    JSON.parse(jsonString) as Result;
+
+const npm = (...commands) =>
+    spawnSync('npm', commands, {
+        stdio: ['inherit', 'pipe', 'inherit'],
+        encoding: 'utf-8',
+    }).stdout;
+
+const updatePackageJson = (nextReleaseNumber: number) => {
+    const nextVersionString = `${nextReleaseNumber}.0.0`;
+    const currentVersion = parseJson<string>(npm('pkg', 'get', 'version'));
+
+    if (nextVersionString === currentVersion) {
+        console.log(
+            `- The version in \`package.json\` is already \`${currentVersion}\`, no need to change it.`
+        );
+        return false;
+    }
+
+    npm('pkg', 'set', `version=${nextVersionString}`);
+    console.log(
+        `- Updated the version in \`package.json\` to \`${nextVersionString}\`.`
+    );
+
+    return true;
+};
+
+const withoutTime = (date: Date) => date.toISOString().split('T')[0];
+
+const updateChangelog = (nextReleaseNumber: number) => {
+    const changelog = readFileSync('Changelog.md', { encoding: 'utf-8' });
+
+    const match = changelog.match(
+        /(?<beginning>.*?)^## (?<header>.*?)$(?<ending>.*)/ms
+    );
+
+    if (match?.groups == null) {
+        console.error(
+            'x Unable to correctly parse `Changelog.md`, to play it safe I am not changing it.'
+        );
+        return { updated: false, error: true };
+    }
+
+    const { beginning, header, ending } = match.groups;
+
+    const correctHeader = `${nextReleaseNumber} - ${withoutTime(new Date())}`;
+    if (header === correctHeader) {
+        console.log(
+            `- The latest entry in \`Changelog.md\` already has the header \`${header}\`, no need to change it.`
+        );
+        return { updated: false, error: false };
+    }
+
+    if (
+        header === 'Unreleased' ||
+        header === `${nextReleaseNumber} - Unreleased`
+    ) {
+        writeFileSync(
+            'Changelog.md',
+            `${beginning}## ${correctHeader}${ending}`,
+            { encoding: 'utf-8' }
+        );
+        console.log(
+            `- Updated the header of the latest entry in \`Changelog.md\` to \`${correctHeader}\`.`
+        );
+
+        return { updated: true, error: false };
+    }
+
+    console.error(
+        `x The latest entry in \`Changelog.md\` is not named \`Unreleased\` or \`${nextReleaseNumber} - Unreleased\`, to play it safe I am not changing it.`
+    );
+
+    return { updated: false, error: true };
+};
+
+const main = () => {
+    const nextReleaseNumber = getNextReleaseNumber();
+
+    const updatedPackageJson = updatePackageJson(nextReleaseNumber);
+    const { updated: updatedChangelog, error } =
+        updateChangelog(nextReleaseNumber);
+
+    if (!updatedPackageJson && !updatedChangelog) {
+        console.log('\nEverything already up-to-date.');
+    } else if (!error) {
+        console.log(
+            '\nUpdated everything needed. You still need to bring these changes into main.'
+        );
+    }
+};
+
+const runAsScript = require.main === module;
+if (runAsScript) {
+    main();
+}

--- a/scripts/release-shared.test.ts
+++ b/scripts/release-shared.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    changelogIsCorrect,
+    getLatestEntry,
+    getNextReleaseNumber,
+    latestEntryIsNotEmpty,
+    latestHeaderIsCorrect,
+    packageJsonIsCorrect,
+} from './release-shared';
+
+const noop = () => {};
+
+test('determinding the next release number', () => {
+    expect(getNextReleaseNumber('v34', { log: noop })).toBe(35);
+});
+
+describe('checking package.json', () => {
+    test('no errors', () => {
+        expect(
+            packageJsonIsCorrect(34, {
+                fail: noop,
+                packageJson: '{"version": "34.0.0"}',
+            })
+        ).toBe(true);
+    });
+    test('version is wrong', () => {
+        expect(
+            packageJsonIsCorrect(34, {
+                fail: noop,
+                packageJson: '{"version": "33.0.0"}',
+            })
+        ).toBe(false);
+    });
+    test('format is wrong', () => {
+        expect(
+            packageJsonIsCorrect(34, {
+                fail: noop,
+                packageJson: '{"version": "34"}',
+            })
+        ).toBe(false);
+    });
+});
+
+describe('checking Changelod.md', () => {
+    test('no errors', () => {
+        const correctChangelog = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 34 - 2022-03-10
+
+### Changed
+
+-   Something`;
+
+        expect(
+            changelogIsCorrect(34, {
+                fail: noop,
+                now: new Date('2022-03-10T12:38:37.267Z'),
+                changelog: correctChangelog,
+            })
+        ).toBe(true);
+    });
+
+    test('Unreleased entry', () => {
+        const outdatedChangelog = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 33 - 2022-02-01
+
+### Changed
+
+-   Something`;
+
+        expect(
+            latestHeaderIsCorrect(34, {
+                fail: noop,
+                now: new Date('2022-03-10T12:38:37.267Z'),
+                changelog: outdatedChangelog,
+            })
+        ).toBe(false);
+    });
+
+    test('Empty entry', () => {
+        const emptyLatestEntry = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 34 - 2022-03-10
+
+## 33 - 2022-02-01`;
+
+        expect(
+            latestEntryIsNotEmpty({
+                fail: noop,
+                changelog: emptyLatestEntry,
+            })
+        ).toBe(false);
+    });
+});
+
+describe('Parsing Changelog.md', () => {
+    const changelog = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 34 - 2023-04-20
+
+### Changed
+
+-   Something
+
+## 33 - 2023-04-19
+
+### Added
+
+-   Something else
+`;
+
+    test('Extracting the latest entry', () => {
+        expect(getLatestEntry(changelog)).toMatchObject({
+            header: '34 - 2023-04-20',
+            content: '### Changed\n\n-   Something',
+        });
+    });
+});

--- a/scripts/release-shared.ts
+++ b/scripts/release-shared.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env ts-node
+
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+/*
+  A script to release a new version of shared.
+
+  Requirement for this script: Have [the GitHub CLI tool `gh`](https://cli.github.com)
+  installed and authenticate in it (run `gh auth login`).
+
+  Run
+     npm run release-shared -- --dry-run
+  to check whether the script thinks you can release a new version of shared.
+
+  Run
+     npm run release-shared
+  to actually do the release.
+
+  This script checks the contents in the branch `origin/main`.
+  So if locally looks everything fine, please check `origin/main`.
+*/
+import { execSync, spawnSync } from 'node:child_process';
+
+import { PackageJson } from '../src/utils/AppTypes';
+
+const logError = (message: string) => {
+    console.error(message);
+};
+
+const parseJson = <Result>(jsonString: string) =>
+    JSON.parse(jsonString) as Result;
+
+const git = (...commands) =>
+    spawnSync('git', commands, {
+        stdio: ['inherit', 'pipe', 'inherit'],
+        encoding: 'utf-8',
+    }).stdout;
+
+const getLatestReleaseName = () =>
+    parseJson<{ tagName: string }>(
+        execSync(`gh release view --json tagName`, { encoding: 'utf-8' })
+    ).tagName;
+
+export const getNextReleaseNumber = (
+    latestReleaseName = getLatestReleaseName(),
+    { log } = { log: console.log }
+) => {
+    const latestReleaseNumber = Number(
+        /^v(?<versionNumber>\d+)$/.exec(latestReleaseName)?.groups
+            ?.versionNumber
+    );
+
+    const nextReleaseNumber = latestReleaseNumber + 1;
+
+    log(
+        `The currently released version is ${latestReleaseNumber}, so the next one will be ${nextReleaseNumber}.\n`
+    );
+
+    return nextReleaseNumber;
+};
+
+const equality = <T>(
+    expected: T,
+    actual: T,
+    errorMessage: string,
+    fail: typeof logError
+) => {
+    if (expected !== actual) {
+        fail(
+            `${errorMessage}:\n  Expected: ${expected}\n  Actual:   ${actual}\n`
+        );
+    }
+
+    return expected === actual;
+};
+
+const getLatestPackageJson = () => git('show', 'origin/main:package.json');
+
+export const packageJsonIsCorrect = (
+    expectedVersionNumber: number,
+    { fail, packageJson } = {
+        fail: logError,
+        packageJson: getLatestPackageJson(),
+    }
+) => {
+    const expectedVersionString = `${expectedVersionNumber}.0.0`;
+    const actualVersionString = parseJson<PackageJson>(packageJson).version;
+
+    return equality(
+        expectedVersionString,
+        actualVersionString,
+        'Version number in `package.json` is not as expected',
+        fail
+    );
+};
+
+const getLatestChangelog = () => git('show', 'origin/main:Changelog.md');
+
+export const getLatestEntry = (changelog: string) => {
+    const latestEntry = changelog.split('\n## ')[1];
+
+    const header = latestEntry.split('\n')[0];
+    const content = latestEntry.replace(/[^\n]*/, '').trim();
+
+    return { header, content };
+};
+
+export const latestEntryIsNotEmpty = ({
+    fail,
+    changelog,
+}: {
+    fail: (message: string) => void;
+    changelog: string;
+}) => {
+    const correct = getLatestEntry(changelog).content.length > 0;
+
+    if (!correct) {
+        fail('Latest entry in `Changelog.md` does not contain anything.');
+    }
+
+    return correct;
+};
+
+const withoutTime = (date: Date) => date.toISOString().split('T')[0];
+
+export const latestHeaderIsCorrect = (
+    expectedVersionNumber: number,
+    { fail, now, changelog } = {
+        fail: logError,
+        now: new Date(),
+        changelog: getLatestChangelog(),
+    }
+) => {
+    const expectedHeaderline = `${expectedVersionNumber} - ${withoutTime(now)}`;
+    const actualHeaderline = getLatestEntry(changelog).header;
+
+    return equality(
+        expectedHeaderline,
+        actualHeaderline,
+        'Latest entry in `Changelog.md` is not as expected',
+        fail
+    );
+};
+
+export const changelogIsCorrect = (
+    expectedVersionNumber: number,
+    { fail, now, changelog } = {
+        fail: logError,
+        now: new Date(),
+        changelog: getLatestChangelog(),
+    }
+) =>
+    latestEntryIsNotEmpty({ fail, changelog }) &&
+    latestHeaderIsCorrect(expectedVersionNumber, { fail, now, changelog });
+
+const doRelease = (nextReleaseNumber: number) => {
+    const nextReleaseName = `v${nextReleaseNumber}`;
+    const latestChangelogEntry = getLatestEntry(getLatestChangelog()).content;
+
+    const dryRun = process.argv.includes('--dry-run');
+    if (dryRun) {
+        console.log(
+            `Would create a release ${nextReleaseName} now, with this description:\n${latestChangelogEntry}`
+        );
+    } else {
+        console.log(`Creating release ${nextReleaseName} now:`);
+        const result = spawnSync(
+            'gh',
+            [
+                'release',
+                'create',
+                nextReleaseName,
+                '--title',
+                nextReleaseName,
+                '--notes',
+                latestChangelogEntry,
+            ],
+            {
+                stdio: 'inherit',
+                encoding: 'utf-8',
+            }
+        );
+        process.exitCode = result.status ?? 1;
+    }
+};
+
+const main = () => {
+    console.log(git('fetch'));
+    const nextReleaseNumber = getNextReleaseNumber();
+
+    const noErrors =
+        packageJsonIsCorrect(nextReleaseNumber) &&
+        changelogIsCorrect(nextReleaseNumber);
+
+    if (noErrors) {
+        doRelease(nextReleaseNumber);
+    }
+};
+
+const runAsScript = require.main === module;
+if (runAsScript) {
+    main();
+}


### PR DESCRIPTION
This adds two scripts, to ease releasing new versions of shared.

### Requirements

Requirement for these scripts: You must have [the GitHub CLI tool `gh`](https://cli.github.com) installed and authenticated it (run `gh auth login`).

The scripts look at the latest release on GitHub and assume the next release number from that.

### Prepare a release

When you run
```
npm run prepare-shared-release
```
the script will update two things:

- The version number in you local `package.json`
- The heading of the latest entry in `Changelog.md`, but only if it is  `Unreleased` or `36 - Unreleased` (assuming 36 is already the correct  version number)

After this, you will of course still need to commit these changes andmerged them into the main branch.

### Do a release

When you run
```
npm run release-shared -- --dry-run
```
the script checks the latest state on the main branch on the remoterepository, _not_ the local files. It prints what new release it wouldcreate.

Run
```
npm run release-shared
```
to actually do the release.
