### PR TITLE
Expose `getOptions` on SerialPort

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,14 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 39 - 2023-04-28
+
+### Added
+
+-   SerialPort `getOptions` function in order to request the settings that was
+    used to open the serial port.
+-   Extended SERIALPORT_CHANNEL with entry GET_OPTIONS.
+
 ## 38 - 2023-04-28
 
 ### Fixed

--- a/main/index.ts
+++ b/main/index.ts
@@ -19,6 +19,7 @@ export const SERIALPORT_CHANNEL = {
     ON_WRITE: 'serialport:on-write',
 
     IS_OPEN: 'serialport:is-open',
+    GET_OPTIONS: 'serialport:get-options',
 };
 
 export type OverwriteOptions = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "38.0.0",
+    "version": "39.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/esbuild-renderer.js
+++ b/scripts/esbuild-renderer.js
@@ -46,6 +46,7 @@ function options(additionalOptions) {
             'url',
             'module',
             'constants',
+            'buffer',
 
             // launcher includes
             'electron',

--- a/src/SerialPort/SerialPort.ts
+++ b/src/SerialPort/SerialPort.ts
@@ -179,3 +179,17 @@ export const createSerialPort = async (
         },
     };
 };
+
+export const getSerialPortOptions = async (
+    path: string
+): Promise<SerialPortOpenOptions<AutoDetectTypes> | undefined> => {
+    try {
+        console.log('will fetch options from path=', path);
+        return (await ipcRenderer.invoke(
+            SERIALPORT_CHANNEL.GET_OPTIONS,
+            path
+        )) as SerialPortOpenOptions<AutoDetectTypes> | undefined;
+    } catch (error) {
+        logger.error(`Failed to get options for port: ${path}`);
+    }
+};

--- a/src/SerialPort/SerialPort.ts
+++ b/src/SerialPort/SerialPort.ts
@@ -89,6 +89,9 @@ export const createSerialPort = async (
         ipcRenderer.invoke(SERIALPORT_CHANNEL.SET, path, newOptions);
     };
 
+    const getOptions = (): Promise<SerialPortOpenOptions<AutoDetectTypes>> =>
+        ipcRenderer.invoke(SERIALPORT_CHANNEL.GET_OPTIONS, path);
+
     const openWithRetries = async (retryCount: number) => {
         try {
             return (await ipcRenderer.invoke(
@@ -133,6 +136,7 @@ export const createSerialPort = async (
         isOpen,
         update,
         set,
+        getOptions,
         onData: (handler: (data: Uint8Array) => void) => {
             eventEmitter.on('onData', handler);
             return () => {

--- a/src/SerialPort/SerialPort.ts
+++ b/src/SerialPort/SerialPort.ts
@@ -89,8 +89,9 @@ export const createSerialPort = async (
         ipcRenderer.invoke(SERIALPORT_CHANNEL.SET, path, newOptions);
     };
 
-    const getOptions = (): Promise<SerialPortOpenOptions<AutoDetectTypes>> =>
-        ipcRenderer.invoke(SERIALPORT_CHANNEL.GET_OPTIONS, path);
+    const getOptions = ():
+        | Promise<SerialPortOpenOptions<AutoDetectTypes>>
+        | undefined => ipcRenderer.invoke(SERIALPORT_CHANNEL.GET_OPTIONS, path);
 
     const openWithRetries = async (retryCount: number) => {
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,10 @@ export { defaultInitPacket, HashType, FwType } from './Device/initPacket';
 
 export { default as describeError } from './logging/describeError';
 
-export { createSerialPort } from './SerialPort/SerialPort';
+export {
+    createSerialPort,
+    getSerialPortOptions,
+} from './SerialPort/SerialPort';
 export type { SerialPort } from './SerialPort/SerialPort';
 
 export { openAppWindow } from './OpenApp/openApp';

--- a/typings/generated/main/index.d.ts
+++ b/typings/generated/main/index.d.ts
@@ -11,6 +11,7 @@ export declare const SERIALPORT_CHANNEL: {
     ON_CHANGED: string;
     ON_WRITE: string;
     IS_OPEN: string;
+    GET_OPTIONS: string;
 };
 export type OverwriteOptions = {
     overwrite?: boolean;

--- a/typings/generated/src/SerialPort/SerialPort.d.ts
+++ b/typings/generated/src/SerialPort/SerialPort.d.ts
@@ -10,7 +10,7 @@ export declare const createSerialPort: (options: SerialPortOpenOptions<AutoDetec
     isOpen: () => Promise<boolean>;
     update: (newOptions: UpdateOptions) => void;
     set: (newOptions: SetOptions) => void;
-    getOptions: () => Promise<SerialPortOpenOptions<AutoDetectTypes>>;
+    getOptions: () => Promise<SerialPortOpenOptions<AutoDetectTypes>> | undefined;
     onData: (handler: (data: Uint8Array) => void) => () => void;
     onClosed: (handler: () => void) => () => void;
     onUpdate: (handler: (newOptions: UpdateOptions) => void) => () => void;

--- a/typings/generated/src/SerialPort/SerialPort.d.ts
+++ b/typings/generated/src/SerialPort/SerialPort.d.ts
@@ -18,3 +18,4 @@ export declare const createSerialPort: (options: SerialPortOpenOptions<AutoDetec
     onChange: (handler: (newOptions: SerialPortOpenOptions<AutoDetectTypes>) => void) => () => void;
     onDataWritten: (handler: (data: Uint8Array) => void) => () => void;
 }>;
+export declare const getSerialPortOptions: (path: string) => Promise<SerialPortOpenOptions<AutoDetectTypes> | undefined>;

--- a/typings/generated/src/SerialPort/SerialPort.d.ts
+++ b/typings/generated/src/SerialPort/SerialPort.d.ts
@@ -10,6 +10,7 @@ export declare const createSerialPort: (options: SerialPortOpenOptions<AutoDetec
     isOpen: () => Promise<boolean>;
     update: (newOptions: UpdateOptions) => void;
     set: (newOptions: SetOptions) => void;
+    getOptions: () => Promise<SerialPortOpenOptions<AutoDetectTypes>>;
     onData: (handler: (data: Uint8Array) => void) => () => void;
     onClosed: (handler: () => void) => () => void;
     onUpdate: (handler: (newOptions: UpdateOptions) => void) => () => void;

--- a/typings/generated/src/index.d.ts
+++ b/typings/generated/src/index.d.ts
@@ -56,7 +56,7 @@ export { isDeviceInDFUBootloader } from './Device/sdfuOperations';
 export { default as sdfuOperations, switchToBootloaderMode, switchToApplicationMode, } from './Device/sdfuOperations';
 export { defaultInitPacket, HashType, FwType } from './Device/initPacket';
 export { default as describeError } from './logging/describeError';
-export { createSerialPort } from './SerialPort/SerialPort';
+export { createSerialPort, getSerialPortOptions, } from './SerialPort/SerialPort';
 export type { SerialPort } from './SerialPort/SerialPort';
 export { openAppWindow } from './OpenApp/openApp';
 export type { DropdownItem } from './Dropdown/Dropdown';


### PR DESCRIPTION
Typical use case for getOptions is for an app that is trying to connect to a port cannot because the port is claimed with different settings. Then, with getOptions, you'll be able to adapt to the current settings.