### PR TITLE
Add generic dialog for conflicting serial port settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,14 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 40 - 2023-04-28
+
+### Added
+
+-   ConflictingSettingsDialog component to be utilized when SerialPort from
+    pc-nrfconnect-shared is used, and the serial port may have been claimed by
+    another app.
+
 ## 39 - 2023-04-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "39.0.0",
+    "version": "40.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -222,12 +222,12 @@ export const ConfirmationDialog = ({
                 <DialogButton variant="primary" onClick={onConfirm}>
                     {confirmLabel}
                 </DialogButton>
-                <DialogButton onClick={onCancel}>{cancelLabel}</DialogButton>
                 {optionalLabel && (
                     <DialogButton onClick={onOptional}>
                         {optionalLabel}
                     </DialogButton>
                 )}
+                <DialogButton onClick={onCancel}>{cancelLabel}</DialogButton>
             </>
         }
     >

--- a/src/SerialPort/ConflictingSettingsDialog.tsx
+++ b/src/SerialPort/ConflictingSettingsDialog.tsx
@@ -110,7 +110,7 @@ const ConflictingSettingsDialog = ({
             </p>
 
             <DisplayConflictingSettings
-                appliedSettings={activeSettings}
+                activeSettings={activeSettings}
                 localSettings={localSettings}
             />
         </ConfirmationDialog>
@@ -118,18 +118,18 @@ const ConflictingSettingsDialog = ({
 };
 
 type DisplayConflictingSettings = {
-    appliedSettings?: SerialPortOpenOptions<AutoDetectTypes>;
+    activeSettings?: SerialPortOpenOptions<AutoDetectTypes>;
     localSettings: SerialPortOpenOptions<AutoDetectTypes>;
 };
 
 const DisplayConflictingSettings = ({
-    appliedSettings,
+    activeSettings,
     localSettings,
 }: DisplayConflictingSettings) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const conflictingSettings: { [key: string]: any } = {};
-    if (appliedSettings) {
-        Object.entries(appliedSettings).forEach(([key, value]) => {
+    if (activeSettings) {
+        Object.entries(activeSettings).forEach(([key, value]) => {
             if (
                 localSettings[
                     key as keyof SerialPortOpenOptions<AutoDetectTypes>
@@ -140,7 +140,7 @@ const DisplayConflictingSettings = ({
         });
         Object.entries(localSettings).forEach(([key, value]) => {
             if (
-                appliedSettings[
+                activeSettings[
                     key as keyof SerialPortOpenOptions<AutoDetectTypes>
                 ] !== value
             ) {
@@ -159,9 +159,9 @@ const DisplayConflictingSettings = ({
         >
             <div>
                 <h4>Applied settings</h4>
-                {appliedSettings ? (
+                {activeSettings ? (
                     <ul style={listStyle}>
-                        {Object.entries(appliedSettings).map(([key, value]) => (
+                        {Object.entries(activeSettings).map(([key, value]) => (
                             <li key={key}>
                                 {key}: {JSON.stringify(value)}
                             </li>

--- a/src/SerialPort/ConflictingSettingsDialog.tsx
+++ b/src/SerialPort/ConflictingSettingsDialog.tsx
@@ -45,14 +45,14 @@ const ConflictingSettingsDialog = ({
     localSettings,
     setSerialPortCallback,
 }: ConflictingSettingsDialog) => {
-    const [appliedSettings, setSettings] =
+    const [activeSettings, setSettings] =
         useState<SerialPortOpenOptions<AutoDetectTypes>>();
 
     useEffect(() => {
-        if (!appliedSettings) {
+        if (!activeSettings) {
             getCurrentOptions(localSettings.path, setSettings);
         }
-    }, [isVisible, appliedSettings, localSettings.path]);
+    }, [isVisible, activeSettings, localSettings.path]);
 
     const connectToSelectedSerialPort = async (
         overwrite: boolean,
@@ -87,8 +87,8 @@ const ConflictingSettingsDialog = ({
             confirmLabel="Continue with active settings"
             onConfirm={() => {
                 onCancel();
-                if (appliedSettings) {
-                    connectToSelectedSerialPort(true, appliedSettings);
+                if (activeSettings) {
+                    connectToSelectedSerialPort(true, activeSettings);
                 } else {
                     logger.error(
                         'Could not get the active serial port settings.'
@@ -110,7 +110,7 @@ const ConflictingSettingsDialog = ({
             </p>
 
             <DisplayConflictingSettings
-                appliedSettings={appliedSettings}
+                appliedSettings={activeSettings}
                 localSettings={localSettings}
             />
         </ConfirmationDialog>

--- a/src/SerialPort/ConflictingSettingsDialog.tsx
+++ b/src/SerialPort/ConflictingSettingsDialog.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React, { useEffect, useState } from 'react';
+import type { AutoDetectTypes } from '@serialport/bindings-cpp';
+import { SerialPortOpenOptions } from 'serialport';
+
+import { ConfirmationDialog } from '../Dialog/Dialog';
+import logger from '../logging';
+import {
+    createSerialPort,
+    getSerialPortOptions,
+    SerialPort,
+} from './SerialPort';
+
+const getCurrentOptions = async (
+    portPath: string,
+    setSettings: (options: SerialPortOpenOptions<AutoDetectTypes>) => void
+) => {
+    try {
+        const options = await getSerialPortOptions(portPath);
+        if (options) {
+            setSettings(options);
+        }
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+interface ConflictingSettingsDialog {
+    isVisible: boolean;
+    onOverwrite: () => void;
+    onCancel: () => void;
+    localSettings: SerialPortOpenOptions<AutoDetectTypes>;
+    setSerialPortCallback: (serialPort: SerialPort) => void;
+}
+
+const ConflictingSettingsDialog = ({
+    isVisible,
+    onOverwrite,
+    onCancel,
+    localSettings,
+    setSerialPortCallback,
+}: ConflictingSettingsDialog) => {
+    const [appliedSettings, setSettings] =
+        useState<SerialPortOpenOptions<AutoDetectTypes>>();
+
+    useEffect(() => {
+        if (!appliedSettings) {
+            getCurrentOptions(localSettings.path, setSettings);
+        }
+    }, [isVisible, appliedSettings, localSettings.path]);
+
+    const connectToSelectedSerialPort = async (
+        overwrite: boolean,
+        newSettings: SerialPortOpenOptions<AutoDetectTypes>
+    ) => {
+        try {
+            const port = await createSerialPort(newSettings, {
+                overwrite,
+                settingsLocked: false,
+            });
+            setSerialPortCallback(port);
+        } catch (error) {
+            const msg = (error as Error).message;
+            if (msg.includes('FAILED_DIFFERENT_SETTINGS')) {
+                onCancel();
+            } else {
+                console.error(
+                    'Port could not be opened. Verify it is not used by some other applications'
+                );
+            }
+        }
+    };
+
+    return (
+        <ConfirmationDialog
+            title={`Conflicting Serial Settings for ${localSettings.path}`}
+            isVisible={isVisible}
+            size="lg"
+            onCancel={onCancel}
+            optionalLabel="Continue by overwriting settings"
+            onOptional={onOverwrite}
+            confirmLabel="Continue with active settings"
+            onConfirm={() => {
+                onCancel();
+                if (appliedSettings) {
+                    connectToSelectedSerialPort(true, appliedSettings);
+                } else {
+                    logger.error(
+                        'Could not get the active serial port settings.'
+                    );
+                }
+            }}
+        >
+            <p>
+                You are about to connect to {localSettings.path}. This port is
+                already active with different serial settings - most likely it
+                is opened by another nRF Connect app running on your computer.
+            </p>
+            <p>
+                You may continue with the active serial port settings or choose
+                to overwrite these with the settings you have selected. If you
+                choose to overwrite the active settings, the port will be closed
+                and reopened with the new settings. Alternatively, you can close
+                the port in the other app and try again.
+            </p>
+
+            <DisplayConflictingSettings
+                appliedSettings={appliedSettings}
+                localSettings={localSettings}
+            />
+        </ConfirmationDialog>
+    );
+};
+
+type DisplayConflictingSettings = {
+    appliedSettings?: SerialPortOpenOptions<AutoDetectTypes>;
+    localSettings: SerialPortOpenOptions<AutoDetectTypes>;
+};
+
+const DisplayConflictingSettings = ({
+    appliedSettings,
+    localSettings,
+}: DisplayConflictingSettings) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const conflictingSettings: { [key: string]: any } = {};
+    if (appliedSettings) {
+        Object.entries(appliedSettings).forEach(([key, value]) => {
+            if (
+                localSettings[
+                    key as keyof SerialPortOpenOptions<AutoDetectTypes>
+                ] !== value
+            ) {
+                conflictingSettings[key] = value;
+            }
+        });
+        Object.entries(localSettings).forEach(([key, value]) => {
+            if (
+                appliedSettings[
+                    key as keyof SerialPortOpenOptions<AutoDetectTypes>
+                ] !== value
+            ) {
+                conflictingSettings[key] = value;
+            }
+        });
+    }
+
+    return (
+        <div
+            style={{
+                width: '100%',
+                display: 'flex',
+                justifyContent: 'space-around',
+            }}
+        >
+            <div>
+                <h4>Applied settings</h4>
+                {appliedSettings ? (
+                    <ul style={listStyle}>
+                        {Object.entries(appliedSettings).map(([key, value]) => (
+                            <li key={key}>
+                                {key}: {JSON.stringify(value)}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p>Could not retrieve the current settings</p>
+                )}
+            </div>
+            <div>
+                <h4>Serial Terminal settings</h4>
+                <p>
+                    <ul style={listStyle}>
+                        {Object.entries(localSettings).map(([key, value]) => (
+                            <li key={key}>
+                                {key}: {JSON.stringify(value)}
+                            </li>
+                        ))}
+                    </ul>
+                </p>
+            </div>
+            <div>
+                <h4>Conflicting settings</h4>
+                {Object.entries(conflictingSettings).length > 0 ? (
+                    <ul style={listStyle}>
+                        {Object.entries(conflictingSettings).map(
+                            ([key, value]) => (
+                                <li key={key}>
+                                    {key}: {JSON.stringify(value)}
+                                </li>
+                            )
+                        )}
+                    </ul>
+                ) : (
+                    <p>Could not find the conflicting settings</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ConflictingSettingsDialog;
+
+const listStyle: React.CSSProperties = {
+    listStyleType: 'none',
+    margin: 0,
+    padding: 0,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ export {
     createSerialPort,
     getSerialPortOptions,
 } from './SerialPort/SerialPort';
+export { default as ConflictingSettingsDialog } from './SerialPort/ConflictingSettingsDialog';
 export type { SerialPort } from './SerialPort/SerialPort';
 
 export { openAppWindow } from './OpenApp/openApp';

--- a/typings/generated/src/SerialPort/ConflictingSettingsDialog.d.ts
+++ b/typings/generated/src/SerialPort/ConflictingSettingsDialog.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="react" />
+import type { AutoDetectTypes } from '@serialport/bindings-cpp';
+import { SerialPortOpenOptions } from 'serialport';
+import { SerialPort } from './SerialPort';
+interface ConflictingSettingsDialog {
+    isVisible: boolean;
+    onOverwrite: () => void;
+    onCancel: () => void;
+    localSettings: SerialPortOpenOptions<AutoDetectTypes>;
+    setSerialPortCallback: (serialPort: SerialPort) => void;
+}
+declare const ConflictingSettingsDialog: ({ isVisible, onOverwrite, onCancel, localSettings, setSerialPortCallback, }: ConflictingSettingsDialog) => JSX.Element;
+export default ConflictingSettingsDialog;

--- a/typings/generated/src/index.d.ts
+++ b/typings/generated/src/index.d.ts
@@ -57,6 +57,7 @@ export { default as sdfuOperations, switchToBootloaderMode, switchToApplicationM
 export { defaultInitPacket, HashType, FwType } from './Device/initPacket';
 export { default as describeError } from './logging/describeError';
 export { createSerialPort, getSerialPortOptions, } from './SerialPort/SerialPort';
+export { default as ConflictingSettingsDialog } from './SerialPort/ConflictingSettingsDialog';
 export type { SerialPort } from './SerialPort/SerialPort';
 export { openAppWindow } from './OpenApp/openApp';
 export type { DropdownItem } from './Dropdown/Dropdown';


### PR DESCRIPTION
This dialog will immediately be used in Serial Terminal and Cellular Monitor, and will provide more options and information to the user about why the serial port is not immediately connectable with the selected settings.