### PR TITLE
Allow persistent store migrations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,11 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 44 - Unreleased
+## 44 - 2023-05-05
 
 ### Fixed
 
 -   Feedback pane link to Nordiv DevZone did not open in the browser.
+-   Properly update package version when running the prepare script on windows.
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ every new version is a new major version.
 
 -   Feedback pane link to Nordiv DevZone did not open in the browser.
 
+### Changed
+
+-   Persistent store now allows to send more options to the internal store.
+
 ## 43 - 2023-05-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "43.0.0",
+    "version": "44.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/prepare-shared-release.ts
+++ b/scripts/prepare-shared-release.ts
@@ -25,8 +25,9 @@ import { getNextReleaseNumber } from './release-shared';
 const parseJson = <Result>(jsonString: string) =>
     JSON.parse(jsonString) as Result;
 
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const npm = (...commands) =>
-    spawnSync('npm', commands, {
+    spawnSync(npmCommand, commands, {
         stdio: ['inherit', 'pipe', 'inherit'],
         encoding: 'utf-8',
     }).stdout;

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -114,11 +114,15 @@ interface SharedAppSpecificStoreSchema {
 export const getAppSpecificStore = <
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     StoreSchema extends Record<string, any>
->() => {
+>(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    options?: Store.Options<any>
+) => {
     if (appSpecificStore == null) {
         appSpecificStore = new Store({
             name: packageJson().name,
             clearInvalidConfig: true,
+            ...options,
         });
     }
 

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -122,6 +122,8 @@ export const getAppSpecificStore = <
         appSpecificStore = new Store({
             name: packageJson().name,
             clearInvalidConfig: true,
+            // @ts-expect-error `electron-store` assumes the app is the version of the launcher, override this to be the same as the app version
+            projectVersion: packageJson().version,
             ...options,
         });
     }

--- a/typings/generated/src/utils/persistentStore.d.ts
+++ b/typings/generated/src/utils/persistentStore.d.ts
@@ -29,7 +29,7 @@ export declare const getIsLoggingVerbose: () => boolean;
 interface SharedAppSpecificStoreSchema {
     currentPane?: number;
 }
-export declare const getAppSpecificStore: <StoreSchema extends Record<string, any>>() => Store<StoreSchema & SharedAppSpecificStoreSchema>;
+export declare const getAppSpecificStore: <StoreSchema extends Record<string, any>>(options?: Store.Options<any>) => Store<StoreSchema & SharedAppSpecificStoreSchema>;
 export declare const persistCurrentPane: (currentPane: number) => void;
 export declare const getPersistedCurrentPane: () => number | undefined;
 export {};


### PR DESCRIPTION
This is mainly in order to allow apps to use migrations

e.g. from cellularmonitor
```typescript
const store = getPersistentStore<StoreSchema>({
    migrations: {
        '0.4.5': instance => {
            instance.set(TRACE_FORMATS, ['raw', 'tshark']);
        },
    },
});
```

will run this migration from when the app is release with at least v0.4.5