### PR TITLE
change: FeedbackPane design header and buttons

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Changed
+
+-   FeedbackPane headers is now 14px, similar to all text, but is bold.
+-   FeedbackPane Buttons are moved to the bottom right corner, from bottom left.
+
 ## 45 - 2023-05-09
 
 ### Fixed

--- a/src/Panes/FeedbackPane.tsx
+++ b/src/Panes/FeedbackPane.tsx
@@ -19,7 +19,7 @@ export default () => {
         return (
             <div className="w-100 d-flex justify-content-center">
                 <div className="d-flex flex-column justify-content-center align-items-start bg-white px-3 py-4">
-                    <h2 className="mb-3">Thank you!</h2>
+                    <b className="mb-3">Thank you!</b>
                     <section>
                         <p>
                             We value your feedback and any ideas you may have
@@ -32,6 +32,7 @@ export default () => {
                     </section>
                     <Button
                         large
+                        className="align-self-end"
                         onClick={() => {
                             setSayThankYou(false);
                             setFeedback('');
@@ -48,7 +49,7 @@ export default () => {
     return (
         <div className="w-100 d-flex justify-content-center">
             <div className="d-flex flex-column justify-content-center align-items-start bg-white px-3 py-4">
-                <h2 className="mb-3">Give Feedback</h2>
+                <b className="mb-3">Give Feedback</b>
                 <section>
                     <p>
                         We value your feedback and any ideas you may have for
@@ -101,6 +102,7 @@ export default () => {
                 </section>
                 <Button
                     large
+                    className="align-self-end"
                     variant="primary"
                     onClick={() => handleFormData(feedback, setSayThankYou)}
                     disabled={feedback === ''}


### PR DESCRIPTION
Headers are now same size as the rest of the text, and buttons are placed in the bottom right corner.

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/34618612/66a97f9d-1916-4e3a-b64e-fd8b9807107d)