### PR TITLE
feat: move needSerialport check into supportProgrammingMode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,22 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 47 - Unreleased
+
+### Added
+
+-   `needSerialport` parameter for `jprogDeviceSetup` and `sdfuDeviceSetup`.
+
+### Removed
+
+-   `needSerialport` property from `DeviceSetup`.
+
+### Steps to upgrade when using this package
+
+-   `needSerialport` has been removed from `IDeviceSetup`. If needed, it should
+    be placed into the `supportsProgrammingMode` callback or can be passed as a
+    parameter to the `jprogDeviceSetup` or `sdfuDeviceSetup` wrappers.
+
 ## 46 - 2023-05-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "46.0.0",
+    "version": "47.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/DeviceSelector/DeviceSelector.test.tsx
+++ b/src/Device/DeviceSelector/DeviceSelector.test.tsx
@@ -105,7 +105,6 @@ const validFirmware = {
         ]),
     ],
     allowCustomDevice: false,
-    needSerialport: false,
 };
 
 describe('DeviceSelector', () => {
@@ -244,7 +243,6 @@ describe('DeviceSelector', () => {
                         ]),
                     ],
                     allowCustomDevice: true,
-                    needSerialport: false,
                 }}
             />,
             [setDevices([testDevice])]
@@ -277,7 +275,6 @@ describe('DeviceSelector', () => {
                         ]),
                     ],
                     allowCustomDevice: false,
-                    needSerialport: false,
                 }}
             />,
             [setDevices([testDevice])]

--- a/src/Device/jprogOperations.ts
+++ b/src/Device/jprogOperations.ts
@@ -152,8 +152,13 @@ const firmwareOptions = (device: Device, firmware: JprogEntry[]) =>
         );
     });
 
-export const jprogDeviceSetup = (firmware: JprogEntry[]): IDeviceSetup => ({
-    supportsProgrammingMode: (device: Device) => device.traits.jlink === true,
+export const jprogDeviceSetup = (
+    firmware: JprogEntry[],
+    needSerialport = false
+): IDeviceSetup => ({
+    supportsProgrammingMode: (device: Device) =>
+        (needSerialport === !!device.traits.serialPorts || !needSerialport) &&
+        !!device.traits.jlink,
     getFirmwareOptions: device =>
         firmwareOptions(device, firmware).map(firmwareOption => ({
             key: firmwareOption.key,

--- a/src/Device/sdfuOperations.ts
+++ b/src/Device/sdfuOperations.ts
@@ -546,11 +546,15 @@ const programDeviceWithFw =
             );
         });
 
-export const sdfuDeviceSetup = (dfuFirmware: DfuEntry[]): IDeviceSetup => ({
+export const sdfuDeviceSetup = (
+    dfuFirmware: DfuEntry[],
+    needSerialport = false
+): IDeviceSetup => ({
     supportsProgrammingMode: (device: Device) =>
-        (device.dfuTriggerVersion !== undefined &&
+        ((!!device.dfuTriggerVersion &&
             device.dfuTriggerVersion.semVer.length > 0) ||
-        isDeviceInDFUBootloader(device),
+            isDeviceInDFUBootloader(device)) &&
+        (needSerialport === device.traits.serialPorts || !needSerialport),
     getFirmwareOptions: device =>
         dfuFirmware.map(firmwareOption => ({
             key: firmwareOption.key,

--- a/typings/generated/src/Device/deviceSetup.d.ts
+++ b/typings/generated/src/Device/deviceSetup.d.ts
@@ -31,7 +31,6 @@ export interface IDeviceSetup {
 }
 export interface DeviceSetup {
     deviceSetups: IDeviceSetup[];
-    needSerialport: boolean;
     allowCustomDevice?: boolean;
 }
 export declare const prepareDevice: (device: Device, deviceSetupConfig: DeviceSetup, onSuccess: (device: Device) => void, onFail: (reason?: unknown) => void, checkCurrentFirmwareVersion?: boolean, requireUserConfirmation?: boolean) => (dispatch: TDispatch) => Promise<void>;

--- a/typings/generated/src/Device/jprogOperations.d.ts
+++ b/typings/generated/src/Device/jprogOperations.d.ts
@@ -1,2 +1,2 @@
 import { IDeviceSetup, JprogEntry } from './deviceSetup';
-export declare const jprogDeviceSetup: (firmware: JprogEntry[]) => IDeviceSetup;
+export declare const jprogDeviceSetup: (firmware: JprogEntry[], needSerialport?: boolean) => IDeviceSetup;

--- a/typings/generated/src/Device/sdfuOperations.d.ts
+++ b/typings/generated/src/Device/sdfuOperations.d.ts
@@ -6,7 +6,7 @@ export declare const isDeviceInDFUBootloader: (device: Device) => boolean;
 export declare const ensureBootloaderMode: (device: Device) => boolean;
 export declare const switchToBootloaderMode: (device: Device, onSuccess: (device: Device) => void, onFail: (reason?: unknown) => void) => (dispatch: TDispatch) => void;
 export declare const switchToApplicationMode: (device: Device, onSuccess: (device: Device) => void, onFail: (reason?: unknown) => void) => (dispatch: TDispatch) => void;
-export declare const sdfuDeviceSetup: (dfuFirmware: DfuEntry[]) => IDeviceSetup;
+export declare const sdfuDeviceSetup: (dfuFirmware: DfuEntry[], needSerialport?: boolean) => IDeviceSetup;
 declare const _default: {
     createDfuZipBuffer: (dfuImages: DfuImage[]) => Promise<Buffer>;
 };


### PR DESCRIPTION
Additionally, the check for if the serialport is available has been removed. This is because this should be up to the app to handle (which is generally being done already).