### PR TITLE
feat: remove releaseCurrentDevice callback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 47 - Unreleased
+
+### Removed
+
+-   `releaseCurrentDevice` callback from `DeviceSelector`.
+
 ## 46 - 2023-05-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "46.0.0",
+    "version": "47.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/DeviceSelector/DeviceSelector.tsx
+++ b/src/Device/DeviceSelector/DeviceSelector.tsx
@@ -36,7 +36,6 @@ interface OutdatedDeviceTraits {
 export interface Props {
     deviceListing: DeviceTraits & OutdatedDeviceTraits;
     deviceSetup?: DeviceSetupShared;
-    releaseCurrentDevice?: () => void;
     onDeviceSelected?: (device: Device, autoReselected: boolean) => void;
     onDeviceDeselected?: () => void;
     onDeviceConnected?: (device: Device) => void;
@@ -49,7 +48,6 @@ const noop = () => {};
 export default ({
     deviceListing,
     deviceSetup,
-    releaseCurrentDevice = noop,
     onDeviceSelected = noop,
     onDeviceDeselected = noop,
     onDeviceConnected = noop,
@@ -87,7 +85,6 @@ export default ({
                     setupDevice(
                         device,
                         deviceSetup,
-                        releaseCurrentDevice,
                         onDeviceIsReady,
                         doDeselectDevice
                     )
@@ -100,7 +97,6 @@ export default ({
             doDeselectDevice,
             onDeviceIsReady,
             onDeviceSelected,
-            releaseCurrentDevice,
         ]
     );
 

--- a/src/Device/deviceSetup.ts
+++ b/src/Device/deviceSetup.ts
@@ -268,12 +268,10 @@ export const setupDevice =
     (
         device: Device,
         deviceSetup: DeviceSetup,
-        releaseCurrentDevice: () => void,
         onDeviceIsReady: (device: Device) => void,
         doDeselectDevice: () => void
     ) =>
     (dispatch: TDispatch, getState: () => RootState) => {
-        releaseCurrentDevice();
         const deviceSetupConfig = {
             allowCustomDevice: false,
             ...deviceSetup,

--- a/typings/generated/src/Device/DeviceSelector/DeviceSelector.d.ts
+++ b/typings/generated/src/Device/DeviceSelector/DeviceSelector.d.ts
@@ -9,7 +9,6 @@ interface OutdatedDeviceTraits {
 export interface Props {
     deviceListing: DeviceTraits & OutdatedDeviceTraits;
     deviceSetup?: DeviceSetupShared;
-    releaseCurrentDevice?: () => void;
     onDeviceSelected?: (device: Device, autoReselected: boolean) => void;
     onDeviceDeselected?: () => void;
     onDeviceConnected?: (device: Device) => void;
@@ -17,5 +16,5 @@ export interface Props {
     onDeviceIsReady?: (device: Device) => void;
     deviceFilter?: (device: Device) => boolean;
 }
-declare const _default: ({ deviceListing, deviceSetup, releaseCurrentDevice, onDeviceSelected, onDeviceDeselected, onDeviceConnected, onDeviceDisconnected, onDeviceIsReady, deviceFilter, }: Props) => JSX.Element;
+declare const _default: ({ deviceListing, deviceSetup, onDeviceSelected, onDeviceDeselected, onDeviceConnected, onDeviceDisconnected, onDeviceIsReady, deviceFilter, }: Props) => JSX.Element;
 export default _default;

--- a/typings/generated/src/Device/deviceSetup.d.ts
+++ b/typings/generated/src/Device/deviceSetup.d.ts
@@ -35,4 +35,4 @@ export interface DeviceSetup {
     allowCustomDevice?: boolean;
 }
 export declare const prepareDevice: (device: Device, deviceSetupConfig: DeviceSetup, onSuccess: (device: Device) => void, onFail: (reason?: unknown) => void, checkCurrentFirmwareVersion?: boolean, requireUserConfirmation?: boolean) => (dispatch: TDispatch) => Promise<void>;
-export declare const setupDevice: (device: Device, deviceSetup: DeviceSetup, releaseCurrentDevice: () => void, onDeviceIsReady: (device: Device) => void, doDeselectDevice: () => void) => (dispatch: TDispatch, getState: () => RootState) => void;
+export declare const setupDevice: (device: Device, deviceSetup: DeviceSetup, onDeviceIsReady: (device: Device) => void, doDeselectDevice: () => void) => (dispatch: TDispatch, getState: () => RootState) => void;


### PR DESCRIPTION
This callback is not being used and is a duplicate of onDeviceDeselected
