### PR TITLE
feat: list react-dom as an external package

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 47 - Unreleased
+
+### Added
+
+-   `react-dom` is now listed as an external package.
+
 ## 46 - 2023-05-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "46.0.0",
+    "version": "47.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/esbuild-renderer.js
+++ b/scripts/esbuild-renderer.js
@@ -54,6 +54,7 @@ function options(additionalOptions) {
             '@electron/remote',
             'react',
             '@nordicsemiconductor/nrf-device-lib-js',
+            'react-dom',
 
             // App dependencies
             ...Object.keys(dependencies ?? {}),


### PR DESCRIPTION
It's a pretty big package (~700kb) and we already list the related react package as an external.