### PR TITLE
Cleanups: React node types and `prop-types`

### DIFF
--- a/src/About/DocumentationSection.tsx
+++ b/src/About/DocumentationSection.tsx
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, ReactNode } from 'react';
-import { node, string } from 'prop-types';
+import React, { ReactNode } from 'react';
 
 import AboutButton from './AboutButton';
 import Section from './Section';
@@ -17,23 +16,9 @@ interface Props {
     children?: ReactNode;
 }
 
-export const DocumentationSection: FC<Props> = ({
-    title,
-    link,
-    linkLabel,
-    children,
-}) => (
+export default ({ title, link, linkLabel, children }: Props) => (
     <Section title={title}>
         <p>{children}</p>
         {link && <AboutButton url={link} label={linkLabel as string} />}
     </Section>
 );
-
-DocumentationSection.propTypes = {
-    title: string,
-    link: string,
-    linkLabel: string,
-    children: node,
-};
-
-export default DocumentationSection;

--- a/src/About/Section.tsx
+++ b/src/About/Section.tsx
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, ReactNode } from 'react';
-import { node, string } from 'prop-types';
+import React, { ReactNode } from 'react';
 
 import './section.scss';
 
@@ -14,15 +13,9 @@ interface Props {
     children?: ReactNode;
 }
 
-const Section: FC<Props> = ({ children, title }) => (
+export default ({ children, title }: Props) => (
     <div className="about-section">
         {title != null && <h3 className="about-section-title">{title}</h3>}
         {children}
     </div>
 );
-Section.propTypes = {
-    title: string,
-    children: node,
-};
-
-export default Section;

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -12,7 +12,7 @@ import styles from './Alert.module.scss';
 type Variant = 'info' | 'warning' | 'success' | 'danger';
 export interface AlertProps {
     variant: Variant;
-    label?: React.ReactElement | string;
+    label?: React.ReactNode;
     dismissable?: boolean;
     onClose?: () => void;
 }

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -10,7 +10,6 @@ import React, { FC, ReactNode, useEffect, useMemo } from 'react';
 import Carousel from 'react-bootstrap/Carousel';
 import { useDispatch, useSelector } from 'react-redux';
 import { ipcRenderer } from 'electron';
-import { func } from 'prop-types';
 import { Reducer } from 'redux';
 
 import About from '../About/About';
@@ -214,7 +213,7 @@ const ConnectedErrorBoundary: React.FC = ({ children }) => {
     );
 };
 
-const App = ({
+export default ({
     appReducer,
     ...props
 }: { appReducer?: Reducer } & ConnectedAppProps) => (
@@ -224,12 +223,6 @@ const App = ({
         </ConnectedErrorBoundary>
     </ConnectedToStore>
 );
-
-App.propTypes = {
-    appReducer: func,
-};
-
-export default App;
 
 const usePersistedPane = () => {
     const dispatch = useDispatch();

--- a/src/App/ConnectedToStore.tsx
+++ b/src/App/ConnectedToStore.tsx
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { Provider } from 'react-redux';
-import { func, node } from 'prop-types';
 import { applyMiddleware, createStore, Reducer } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
@@ -21,10 +20,13 @@ const composeEnhancers = composeWithDevTools({
     serialize: ifBuiltForDevelopment(true),
 });
 
-const ConnectedToStore: FC<{
+export default ({
+    appReducer,
+    children,
+}: {
     appReducer?: Reducer;
     children: ReactNode;
-}> = ({ appReducer, children }) => (
+}) => (
     <Provider
         store={createStore(
             rootReducer(appReducer),
@@ -34,9 +36,3 @@ const ConnectedToStore: FC<{
         {children}
     </Provider>
 );
-ConnectedToStore.propTypes = {
-    appReducer: func,
-    children: node.isRequired,
-};
-
-export default ConnectedToStore;

--- a/src/App/VisibilityBar.tsx
+++ b/src/App/VisibilityBar.tsx
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { bool } from 'prop-types';
 
 import {
     autoScroll as autoScrollSelector,
@@ -25,9 +24,7 @@ import {
 
 import './visibility-bar.scss';
 
-const VisibilityBar: FC<{ isSidePanelEnabled: boolean }> = ({
-    isSidePanelEnabled,
-}) => {
+export default ({ isSidePanelEnabled }: { isSidePanelEnabled: boolean }) => {
     const dispatch = useDispatch();
     const isSidePanelVisible = useSelector(isSidePanelVisibleSelector);
     const isLogVisible = useSelector(isLogVisibleSelector);
@@ -104,9 +101,3 @@ const VisibilityBar: FC<{ isSidePanelEnabled: boolean }> = ({
         </div>
     );
 };
-
-VisibilityBar.propTypes = {
-    isSidePanelEnabled: bool.isRequired,
-};
-
-export default VisibilityBar;

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -11,7 +11,7 @@ import { element, oneOfType, string } from 'prop-types';
 import styles from './card.module.scss';
 
 type NrfCardProps = {
-    title: React.ReactElement | string;
+    title: React.ReactNode;
 };
 
 const NrfCard: React.FC<NrfCardProps> = ({ children, title }) => (

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -6,15 +6,15 @@
 
 import React from 'react';
 import Card from 'react-bootstrap/Card';
-import { element, oneOfType, string } from 'prop-types';
 
 import styles from './card.module.scss';
 
 type NrfCardProps = {
+    children: React.ReactNode;
     title: React.ReactNode;
 };
 
-const NrfCard: React.FC<NrfCardProps> = ({ children, title }) => (
+export default ({ children, title }: NrfCardProps) => (
     <Card className={styles.card}>
         <Card.Header className={styles.header}>
             <Card.Title>
@@ -24,9 +24,3 @@ const NrfCard: React.FC<NrfCardProps> = ({ children, title }) => (
         <Card.Body className={styles.body}>{children}</Card.Body>
     </Card>
 );
-
-NrfCard.propTypes = {
-    title: oneOfType([element, string]).isRequired,
-};
-
-export default NrfCard;

--- a/src/Device/DeviceSelector/DeviceList/BrokenDevice.tsx
+++ b/src/Device/DeviceSelector/DeviceList/BrokenDevice.tsx
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-import { bool, func } from 'prop-types';
 
 import PseudoButton from '../../../PseudoButton/PseudoButton';
 import { Device as DeviceProps } from '../../../state';
@@ -15,27 +14,7 @@ import BasicDeviceInfo from '../BasicDeviceInfo';
 
 import './broken-device.scss';
 
-const ShowMoreInfo: FC<{ isVisible: boolean; toggleVisible: () => void }> = ({
-    isVisible,
-    toggleVisible,
-}) => (
-    <PseudoButton
-        className={`show-more mdi mdi-chevron-${isVisible ? 'up' : 'down'}`}
-        testId="show-more-device-info"
-        onClick={toggleVisible}
-    />
-);
-
-ShowMoreInfo.propTypes = {
-    isVisible: bool.isRequired,
-    toggleVisible: func.isRequired,
-};
-
-interface Props {
-    device: DeviceProps;
-}
-
-const Device: FC<Props> = ({ device }) => {
+export default ({ device }: { device: DeviceProps }) => {
     const dispatch = useDispatch();
 
     return (
@@ -53,5 +32,3 @@ const Device: FC<Props> = ({ device }) => {
         </PseudoButton>
     );
 };
-
-export default Device;

--- a/src/Device/DeviceSelector/DeviceList/Device.tsx
+++ b/src/Device/DeviceSelector/DeviceList/Device.tsx
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, useRef, useState } from 'react';
-import { bool, func } from 'prop-types';
+import React, { useRef, useState } from 'react';
 
 import PseudoButton from '../../../PseudoButton/PseudoButton';
 import { Device as DeviceProps } from '../../../state';
@@ -17,9 +16,12 @@ import MoreDeviceInfo from './MoreDeviceInfo';
 
 import './device.scss';
 
-const ShowMoreInfo: FC<{ isVisible: boolean; toggleVisible: () => void }> = ({
+const ShowMoreInfo = ({
     isVisible,
     toggleVisible,
+}: {
+    isVisible: boolean;
+    toggleVisible: () => void;
 }) => (
     <PseudoButton
         className={`show-more mdi mdi-chevron-${isVisible ? 'up' : 'down'}`}
@@ -28,22 +30,13 @@ const ShowMoreInfo: FC<{ isVisible: boolean; toggleVisible: () => void }> = ({
     />
 );
 
-ShowMoreInfo.propTypes = {
-    isVisible: bool.isRequired,
-    toggleVisible: func.isRequired,
-};
-
 interface Props {
     device: DeviceProps;
     doSelectDevice: (device: DeviceProps, autoReselected: boolean) => void;
     allowMoreInfoVisible: boolean;
 }
 
-const Device: FC<Props> = ({
-    device,
-    doSelectDevice,
-    allowMoreInfoVisible,
-}) => {
+export default ({ device, doSelectDevice, allowMoreInfoVisible }: Props) => {
     const [moreVisible, setMoreVisible] = useState(false);
     const toggleMoreVisible = () => setMoreVisible(!moreVisible);
 
@@ -89,5 +82,3 @@ const Device: FC<Props> = ({
         </PseudoButton>
     );
 };
-
-export default Device;

--- a/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.tsx
+++ b/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.tsx
@@ -4,26 +4,22 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { SerialPort } from '@nordicsemiconductor/nrf-device-lib-js';
-import { node } from 'prop-types';
 
 import { Device } from '../../../state';
 import { displayedDeviceName } from '../../deviceInfo/deviceInfo';
 
 import './more-device-info.scss';
 
-const Row: FC<{ children: ReactNode }> = ({ children }) => (
+const Row = ({ children }: { children: ReactNode }) => (
     <div className="info-row">
         <div className="flex-space" />
         {children}
     </div>
 );
-Row.propTypes = {
-    children: node.isRequired,
-};
 
-const PcaNumber: FC<{ device: Device }> = ({ device }) => {
+const PcaNumber = ({ device }: { device: Device }) => {
     if (device.boardVersion == null) {
         return null;
     }
@@ -31,7 +27,7 @@ const PcaNumber: FC<{ device: Device }> = ({ device }) => {
     return <div>{device.boardVersion}</div>;
 };
 
-const MaybeDeviceName: FC<{ device: Device }> = ({ device }) => {
+const MaybeDeviceName = ({ device }: { device: Device }) => {
     const hasNickname = device.nickname !== '';
     if (!hasNickname) {
         return null;
@@ -44,7 +40,7 @@ const MaybeDeviceName: FC<{ device: Device }> = ({ device }) => {
     );
 };
 
-const Serialports: FC<{ ports: SerialPort[] }> = ({ ports }) => (
+const Serialports = ({ ports }: { ports: SerialPort[] }) => (
     <ul className="ports">
         {ports.map(port => (
             <li key={port.path}>{port.comName}</li>
@@ -52,7 +48,7 @@ const Serialports: FC<{ ports: SerialPort[] }> = ({ ports }) => (
     </ul>
 );
 
-const MoreDeviceInfo: FC<{ device: Device }> = ({ device }) => (
+export default ({ device }: { device: Device }) => (
     <div className="more-infos">
         <Row>
             <PcaNumber device={device} />
@@ -67,5 +63,3 @@ const MoreDeviceInfo: FC<{ device: Device }> = ({ device }) => (
         )}
     </div>
 );
-
-export default MoreDeviceInfo;

--- a/src/Device/DeviceSelector/DeviceList/RenameDevice.tsx
+++ b/src/Device/DeviceSelector/DeviceList/RenameDevice.tsx
@@ -4,23 +4,19 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
-import { func } from 'prop-types';
+import React from 'react';
 
 import PseudoButton from '../../../PseudoButton/PseudoButton';
 
 import './rename-device.scss';
 
-const RenameDevice: FC<{ startEditingDeviceName: () => void }> = ({
+export default ({
     startEditingDeviceName,
+}: {
+    startEditingDeviceName: () => void;
 }) => (
     <PseudoButton className="rename-button" onClick={startEditingDeviceName}>
         <span className="mdi mdi-pencil-circle pencil" />
         Rename device
     </PseudoButton>
 );
-RenameDevice.propTypes = {
-    startEditingDeviceName: func.isRequired,
-};
-
-export default RenameDevice;

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -17,7 +17,7 @@ type CoreProps = {
     onHide?: () => void;
     className?: string;
     size?: 'sm' | 'm' | 'lg' | 'xl';
-    children: ReactNode | string;
+    children: ReactNode;
 };
 
 type DialogProps = CoreProps & {
@@ -73,7 +73,7 @@ Dialog.Header = ({
     </Modal.Header>
 );
 
-Dialog.Body = ({ children }: { children: ReactNode | string }) => (
+Dialog.Body = ({ children }: { children: ReactNode }) => (
     <Modal.Body>{children}</Modal.Body>
 );
 
@@ -86,7 +86,7 @@ export interface DialogButtonProps {
     variant?: ButtonVariants;
     className?: string;
     disabled?: boolean;
-    children: ReactNode | string;
+    children: ReactNode;
 }
 
 export const DialogButton = ({
@@ -109,7 +109,7 @@ export const DialogButton = ({
 
 interface GenericDialogProps extends CoreProps {
     title: string;
-    footer: React.ReactNode;
+    footer: ReactNode;
     headerIcon?: string;
     showSpinner?: boolean;
     closeOnUnfocus?: boolean;

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import FormLabel from 'react-bootstrap/FormLabel';
 import styles from './Dropdown.module.scss';
 
 export interface DropdownItem {
-    label: string | React.ReactNode;
+    label: React.ReactNode;
     value: string;
 }
 

--- a/src/Log/LogEntry.tsx
+++ b/src/Log/LogEntry.tsx
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import formatDate from 'date-fns/format';
-import { number, shape, string } from 'prop-types';
-import { LogEntry as winstonLogEntry } from 'winston';
+import { LogEntry } from 'winston';
 
 import { openUrl } from '../utils/open';
 
@@ -50,11 +49,7 @@ function hrefReplacer(str: string) {
     return message;
 }
 
-interface Props {
-    entry: winstonLogEntry;
-}
-
-const LogEntry: FC<Props> = ({ entry }) => {
+export default ({ entry }: { entry: LogEntry }) => {
     const className = `core19-log-entry core19-log-level-${entry.level}`;
     const time = formatDate(new Date(entry.timestamp), 'HH:mm:ss.SSS');
 
@@ -65,16 +60,3 @@ const LogEntry: FC<Props> = ({ entry }) => {
         </div>
     );
 };
-
-const entryShape = shape({
-    id: number.isRequired,
-    timestamp: string.isRequired,
-    level: string.isRequired,
-    message: string.isRequired,
-});
-
-LogEntry.propTypes = {
-    entry: entryShape.isRequired,
-};
-
-export default LogEntry;

--- a/src/Main/Main.tsx
+++ b/src/Main/Main.tsx
@@ -4,15 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, ReactNode } from 'react';
-import { node } from 'prop-types';
+import React, { ReactNode } from 'react';
 
 import './main.scss';
 
-const Main: FC<{ children?: ReactNode }> = ({ children }) => (
+export default ({ children }: { children?: ReactNode }) => (
     <div className="core19-main-view">{children}</div>
 );
-
-Main.propTypes = { children: node };
-
-export default Main;

--- a/src/NavBar/NavBar.tsx
+++ b/src/NavBar/NavBar.tsx
@@ -4,15 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC, ReactNode } from 'react';
-import { node } from 'prop-types';
+import React, { ReactNode } from 'react';
 
 import Logo from '../Logo/Logo';
 import NavMenu from './NavMenu';
 
 import './nav-bar.scss';
 
-const NavBar: FC<{ deviceSelect?: ReactNode }> = ({ deviceSelect }) => (
+export default ({ deviceSelect }: { deviceSelect?: ReactNode }) => (
     <div className="core19-nav-bar">
         {deviceSelect && (
             <div className="core19-nav-bar-device-selector">{deviceSelect}</div>
@@ -21,9 +20,3 @@ const NavBar: FC<{ deviceSelect?: ReactNode }> = ({ deviceSelect }) => (
         <Logo changeWithDeviceState />
     </div>
 );
-
-NavBar.propTypes = {
-    deviceSelect: node,
-};
-
-export default NavBar;

--- a/src/PseudoButton/PseudoButton.tsx
+++ b/src/PseudoButton/PseudoButton.tsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import { func, string } from 'prop-types';
 
 import './pseudo-button.scss';
 
@@ -30,12 +29,19 @@ const blurAndInvoke =
 
 // Motivation for this class: A normal button in HTML must not contain divs or other buttons,
 // but we do have things that behave like buttons and at the same time should contain such things
-const PseudoButton: React.FC<{
-    className?: string;
-    title?: string;
+export default ({
+    onClick = () => {},
+    className = '',
+    children,
+    title,
+    testId,
+}: {
     onClick?: React.EventHandler<React.SyntheticEvent>;
+    className?: string;
+    children?: React.ReactNode;
+    title?: string;
     testId?: string;
-}> = ({ onClick = () => {}, className = '', children, title, testId }) => (
+}) => (
     <div
         role="button"
         className={`core19-pseudo-button ${className}`}
@@ -48,11 +54,3 @@ const PseudoButton: React.FC<{
         {children}
     </div>
 );
-PseudoButton.propTypes = {
-    onClick: func,
-    className: string,
-    title: string,
-    testId: string,
-};
-
-export default PseudoButton;

--- a/src/SidePanel/Group.tsx
+++ b/src/SidePanel/Group.tsx
@@ -8,33 +8,30 @@ import React, { useContext, useRef } from 'react';
 import Accordion from 'react-bootstrap/Accordion';
 import AccordionContext from 'react-bootstrap/AccordionContext';
 import { useAccordionToggle } from 'react-bootstrap/AccordionToggle';
-import { bool, func, string } from 'prop-types';
 
 import PseudoButton from '../PseudoButton/PseudoButton';
 import classNames from '../utils/classNames';
 
 import './group.scss';
 
-const Heading: React.FC<{
-    label?: string;
-    title?: string;
-}> = ({ label, title }) =>
+const Heading = ({ label, title }: { label?: string; title?: string }) =>
     label == null ? null : (
         <h2 className="heading" title={title}>
             {label}
         </h2>
     );
-Heading.propTypes = {
-    label: string,
-    title: string,
-};
 
-const ContextAwareToggle: React.FC<{
+const ContextAwareToggle = ({
+    heading,
+    title,
+    eventKey,
+    onToggled,
+}: {
     heading: string;
     title?: string;
     eventKey: string;
     onToggled?: ((isNowExpanded: boolean) => void) | null;
-}> = ({ heading, title, eventKey, onToggled }) => {
+}) => {
     const currentEventKey = useContext(AccordionContext);
     const isCurrentEventKey = currentEventKey === eventKey;
     const decoratedOnClick = useAccordionToggle(
@@ -52,26 +49,21 @@ const ContextAwareToggle: React.FC<{
         </PseudoButton>
     );
 };
-ContextAwareToggle.propTypes = {
-    heading: string.isRequired,
-    title: string,
-    eventKey: string.isRequired,
-    onToggled: func,
-};
 
-export const CollapsibleGroup: React.FC<{
-    className?: string;
-    heading: string;
-    title?: string;
-    defaultCollapsed?: boolean | null;
-    onToggled?: ((isNowExpanded: boolean) => void) | null;
-}> = ({
+export const CollapsibleGroup = ({
     className = '',
     heading,
     title,
     children = null,
     defaultCollapsed = true,
     onToggled,
+}: {
+    className?: string;
+    heading: string;
+    title?: string;
+    children?: React.ReactNode;
+    defaultCollapsed?: boolean | null;
+    onToggled?: ((isNowExpanded: boolean) => void) | null;
 }) => {
     const eventKey = useRef(Math.random().toString());
 
@@ -96,26 +88,19 @@ export const CollapsibleGroup: React.FC<{
     );
 };
 
-CollapsibleGroup.propTypes = {
-    className: string,
-    heading: string.isRequired,
-    title: string,
-    defaultCollapsed: bool,
-    onToggled: func,
-};
-
-export const Group: React.FC<{
+export const Group = ({
+    className = '',
+    heading,
+    title,
+    children,
+}: {
     className?: string;
     heading?: string;
     title?: string;
-}> = ({ className = '', heading, title, children }) => (
+    children?: React.ReactNode;
+}) => (
     <div className={`sidepanel-group ${className}`}>
         <Heading label={heading} title={title} />
         <div className="body">{children}</div>
     </div>
 );
-Group.propTypes = {
-    className: string,
-    heading: string,
-    title: string,
-};

--- a/src/SidePanel/SidePanel.tsx
+++ b/src/SidePanel/SidePanel.tsx
@@ -5,18 +5,15 @@
  */
 
 import React from 'react';
-import { string } from 'prop-types';
 
 import './sidepanel.scss';
 
-const SidePanel: React.FC<{
+const SidePanel = ({
+    children,
+    className = '',
+}: {
+    children?: React.ReactNode;
     className?: string;
-}> = ({ children, className = '' }) => (
-    <div className={`core19-side-panel ${className}`}>{children}</div>
-);
-
-SidePanel.propTypes = {
-    className: string,
-};
+}) => <div className={`core19-side-panel ${className}`}>{children}</div>;
 
 export default SidePanel;

--- a/src/StateSelector/StateSelector.tsx
+++ b/src/StateSelector/StateSelector.tsx
@@ -11,7 +11,7 @@ import './state-selector.scss';
 
 interface ComplexItem {
     key: string;
-    renderItem: string | React.ReactElement;
+    renderItem: React.ReactNode;
 }
 
 type SelectItem = string | ComplexItem;

--- a/typings/generated/src/About/DocumentationSection.d.ts
+++ b/typings/generated/src/About/DocumentationSection.d.ts
@@ -1,9 +1,9 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 interface Props {
     title?: string;
     link?: string;
     linkLabel?: string;
     children?: ReactNode;
 }
-export declare const DocumentationSection: FC<Props>;
-export default DocumentationSection;
+declare const _default: ({ title, link, linkLabel, children }: Props) => JSX.Element;
+export default _default;

--- a/typings/generated/src/About/Section.d.ts
+++ b/typings/generated/src/About/Section.d.ts
@@ -1,8 +1,8 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import './section.scss';
 interface Props {
     title?: string;
     children?: ReactNode;
 }
-declare const Section: FC<Props>;
-export default Section;
+declare const _default: ({ children, title }: Props) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Alert/Alert.d.ts
+++ b/typings/generated/src/Alert/Alert.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 type Variant = 'info' | 'warning' | 'success' | 'danger';
 export interface AlertProps {
     variant: Variant;
-    label?: React.ReactElement | string;
+    label?: React.ReactNode;
     dismissable?: boolean;
     onClose?: () => void;
 }

--- a/typings/generated/src/App/App.d.ts
+++ b/typings/generated/src/App/App.d.ts
@@ -21,12 +21,7 @@ interface ConnectedAppProps {
     children?: ReactNode;
     autoReselectByDefault?: boolean;
 }
-declare const App: {
-    ({ appReducer, ...props }: {
-        appReducer?: Reducer<any, import("redux").AnyAction> | undefined;
-    } & ConnectedAppProps): JSX.Element;
-    propTypes: {
-        appReducer: import("prop-types").Requireable<(...args: any[]) => any>;
-    };
-};
-export default App;
+declare const _default: ({ appReducer, ...props }: {
+    appReducer?: Reducer<any, import("redux").AnyAction> | undefined;
+} & ConnectedAppProps) => JSX.Element;
+export default _default;

--- a/typings/generated/src/App/ConnectedToStore.d.ts
+++ b/typings/generated/src/App/ConnectedToStore.d.ts
@@ -1,7 +1,7 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Reducer } from 'redux';
-declare const ConnectedToStore: FC<{
-    appReducer?: Reducer;
+declare const _default: ({ appReducer, children, }: {
+    appReducer?: Reducer<any, import("redux").AnyAction> | undefined;
     children: ReactNode;
-}>;
-export default ConnectedToStore;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/App/VisibilityBar.d.ts
+++ b/typings/generated/src/App/VisibilityBar.d.ts
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+/// <reference types="react" />
 import './visibility-bar.scss';
-declare const VisibilityBar: FC<{
+declare const _default: ({ isSidePanelEnabled }: {
     isSidePanelEnabled: boolean;
-}>;
-export default VisibilityBar;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Card/Card.d.ts
+++ b/typings/generated/src/Card/Card.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 type NrfCardProps = {
-    title: React.ReactElement | string;
+    title: React.ReactNode;
 };
 declare const NrfCard: React.FC<NrfCardProps>;
 export default NrfCard;

--- a/typings/generated/src/Card/Card.d.ts
+++ b/typings/generated/src/Card/Card.d.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 type NrfCardProps = {
+    children: React.ReactNode;
     title: React.ReactNode;
 };
-declare const NrfCard: React.FC<NrfCardProps>;
-export default NrfCard;
+declare const _default: ({ children, title }: NrfCardProps) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Device/DeviceSelector/DeviceList/BrokenDevice.d.ts
+++ b/typings/generated/src/Device/DeviceSelector/DeviceList/BrokenDevice.d.ts
@@ -1,8 +1,7 @@
-import { FC } from 'react';
+/// <reference types="react" />
 import { Device as DeviceProps } from '../../../state';
 import './broken-device.scss';
-interface Props {
+declare const _default: ({ device }: {
     device: DeviceProps;
-}
-declare const Device: FC<Props>;
-export default Device;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Device/DeviceSelector/DeviceList/Device.d.ts
+++ b/typings/generated/src/Device/DeviceSelector/DeviceList/Device.d.ts
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+/// <reference types="react" />
 import { Device as DeviceProps } from '../../../state';
 import './device.scss';
 interface Props {
@@ -6,5 +6,5 @@ interface Props {
     doSelectDevice: (device: DeviceProps, autoReselected: boolean) => void;
     allowMoreInfoVisible: boolean;
 }
-declare const Device: FC<Props>;
-export default Device;
+declare const _default: ({ device, doSelectDevice, allowMoreInfoVisible }: Props) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.d.ts
+++ b/typings/generated/src/Device/DeviceSelector/DeviceList/MoreDeviceInfo.d.ts
@@ -1,7 +1,7 @@
-import { FC } from 'react';
+/// <reference types="react" />
 import { Device } from '../../../state';
 import './more-device-info.scss';
-declare const MoreDeviceInfo: FC<{
+declare const _default: ({ device }: {
     device: Device;
-}>;
-export default MoreDeviceInfo;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Device/DeviceSelector/DeviceList/RenameDevice.d.ts
+++ b/typings/generated/src/Device/DeviceSelector/DeviceList/RenameDevice.d.ts
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+/// <reference types="react" />
 import './rename-device.scss';
-declare const RenameDevice: FC<{
+declare const _default: ({ startEditingDeviceName, }: {
     startEditingDeviceName: () => void;
-}>;
-export default RenameDevice;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Dialog/Dialog.d.ts
+++ b/typings/generated/src/Dialog/Dialog.d.ts
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { ButtonVariants } from '../Button/Button';
 import './dialog.scss';
 type CoreProps = {
@@ -6,7 +6,7 @@ type CoreProps = {
     onHide?: () => void;
     className?: string;
     size?: 'sm' | 'm' | 'lg' | 'xl';
-    children: ReactNode | string;
+    children: ReactNode;
 };
 type DialogProps = CoreProps & {
     closeOnUnfocus?: boolean;
@@ -20,7 +20,7 @@ export declare const Dialog: {
         showSpinner?: boolean | undefined;
     }): JSX.Element;
     Body({ children }: {
-        children: ReactNode | string;
+        children: ReactNode;
     }): JSX.Element;
     Footer({ children }: {
         children: ReactNode;
@@ -31,12 +31,12 @@ export interface DialogButtonProps {
     variant?: ButtonVariants;
     className?: string;
     disabled?: boolean;
-    children: ReactNode | string;
+    children: ReactNode;
 }
 export declare const DialogButton: ({ variant, onClick, className, disabled, children, }: DialogButtonProps) => JSX.Element;
 interface GenericDialogProps extends CoreProps {
     title: string;
-    footer: React.ReactNode;
+    footer: ReactNode;
     headerIcon?: string;
     showSpinner?: boolean;
     closeOnUnfocus?: boolean;

--- a/typings/generated/src/Dropdown/Dropdown.d.ts
+++ b/typings/generated/src/Dropdown/Dropdown.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 export interface DropdownItem {
-    label: string | React.ReactNode;
+    label: React.ReactNode;
     value: string;
 }
 export interface DropdownProps {
@@ -12,5 +12,6 @@ export interface DropdownProps {
     selectedItem: DropdownItem;
     numItemsBeforeScroll?: number;
 }
-declare const _default: ({ id, label, items, onSelect, disabled, selectedItem, numItemsBeforeScroll, }: DropdownProps) => JSX.Element;
-export default _default;
+export declare const X: () => JSX.Element;
+declare const Dropdown: ({ id, label, items, onSelect, disabled, selectedItem, numItemsBeforeScroll, }: DropdownProps) => JSX.Element;
+export default Dropdown;

--- a/typings/generated/src/Dropdown/Dropdown.d.ts
+++ b/typings/generated/src/Dropdown/Dropdown.d.ts
@@ -12,6 +12,5 @@ export interface DropdownProps {
     selectedItem: DropdownItem;
     numItemsBeforeScroll?: number;
 }
-export declare const X: () => JSX.Element;
-declare const Dropdown: ({ id, label, items, onSelect, disabled, selectedItem, numItemsBeforeScroll, }: DropdownProps) => JSX.Element;
-export default Dropdown;
+declare const _default: ({ id, label, items, onSelect, disabled, selectedItem, numItemsBeforeScroll, }: DropdownProps) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Log/LogEntry.d.ts
+++ b/typings/generated/src/Log/LogEntry.d.ts
@@ -1,8 +1,7 @@
-import { FC } from 'react';
-import { LogEntry as winstonLogEntry } from 'winston';
+/// <reference types="react" />
+import { LogEntry } from 'winston';
 import './log-entry.scss';
-interface Props {
-    entry: winstonLogEntry;
-}
-declare const LogEntry: FC<Props>;
-export default LogEntry;
+declare const _default: ({ entry }: {
+    entry: LogEntry;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/Main/Main.d.ts
+++ b/typings/generated/src/Main/Main.d.ts
@@ -1,6 +1,6 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import './main.scss';
-declare const Main: FC<{
+declare const _default: ({ children }: {
     children?: ReactNode;
-}>;
-export default Main;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/NavBar/NavBar.d.ts
+++ b/typings/generated/src/NavBar/NavBar.d.ts
@@ -1,6 +1,6 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import './nav-bar.scss';
-declare const NavBar: FC<{
+declare const _default: ({ deviceSelect }: {
     deviceSelect?: ReactNode;
-}>;
-export default NavBar;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/PseudoButton/PseudoButton.d.ts
+++ b/typings/generated/src/PseudoButton/PseudoButton.d.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 import './pseudo-button.scss';
-declare const PseudoButton: React.FC<{
-    className?: string;
-    title?: string;
-    onClick?: React.EventHandler<React.SyntheticEvent>;
-    testId?: string;
-}>;
-export default PseudoButton;
+declare const _default: ({ onClick, className, children, title, testId, }: {
+    onClick?: ((event: React.SyntheticEvent<Element, Event>) => void) | undefined;
+    className?: string | undefined;
+    children?: React.ReactNode;
+    title?: string | undefined;
+    testId?: string | undefined;
+}) => JSX.Element;
+export default _default;

--- a/typings/generated/src/SidePanel/Group.d.ts
+++ b/typings/generated/src/SidePanel/Group.d.ts
@@ -1,14 +1,16 @@
 import React from 'react';
 import './group.scss';
-export declare const CollapsibleGroup: React.FC<{
-    className?: string;
+export declare const CollapsibleGroup: ({ className, heading, title, children, defaultCollapsed, onToggled, }: {
+    className?: string | undefined;
     heading: string;
-    title?: string;
-    defaultCollapsed?: boolean | null;
-    onToggled?: ((isNowExpanded: boolean) => void) | null;
-}>;
-export declare const Group: React.FC<{
-    className?: string;
-    heading?: string;
-    title?: string;
-}>;
+    title?: string | undefined;
+    children?: React.ReactNode;
+    defaultCollapsed?: boolean | null | undefined;
+    onToggled?: ((isNowExpanded: boolean) => void) | null | undefined;
+}) => JSX.Element;
+export declare const Group: ({ className, heading, title, children, }: {
+    className?: string | undefined;
+    heading?: string | undefined;
+    title?: string | undefined;
+    children?: React.ReactNode;
+}) => JSX.Element;

--- a/typings/generated/src/SidePanel/SidePanel.d.ts
+++ b/typings/generated/src/SidePanel/SidePanel.d.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import './sidepanel.scss';
-declare const SidePanel: React.FC<{
-    className?: string;
-}>;
+declare const SidePanel: ({ children, className, }: {
+    children?: React.ReactNode;
+    className?: string | undefined;
+}) => JSX.Element;
 export default SidePanel;

--- a/typings/generated/src/StateSelector/StateSelector.d.ts
+++ b/typings/generated/src/StateSelector/StateSelector.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import './state-selector.scss';
 interface ComplexItem {
     key: string;
-    renderItem: string | React.ReactElement;
+    renderItem: React.ReactNode;
 }
 type SelectItem = string | ComplexItem;
 export interface Props {


### PR DESCRIPTION
Two cleanups: 
- Utilise `ReactNode` type 
- Remove use of package `prop-types`

See the commits and commit messages for details.