### PR TITLE
Enhance Redux backed error dialog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## Unreleased
+## 52 - 2023-06-02
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,9 @@ every new version is a new major version.
 ### Changed
 
 -   Error dialog: If there are multiple errors, state so more clearly.
+-   Error dialog: Add the option to provide details to each error. To use this,
+    pass a third parameter to the action creator
+    `ErrorDialogActions.showDialog`.
 
 ## 51 - 2023-05-31
 
@@ -23,7 +26,7 @@ every new version is a new major version.
 
 ### Fixed
 
--   `dialog` text wrapping opts to keep words as whole of possible
+-   `dialog` text wrapping opts to keep words as whole of possible.
 
 ## 49 - 2023-05-30
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Changed
+
+-   Error dialog: If there are multiple errors, state so more clearly.
+
 ## 51 - 2023-05-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "51.0.0",
+    "version": "52.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/ErrorDialog/ErrorDialog.tsx
+++ b/src/ErrorDialog/ErrorDialog.tsx
@@ -9,6 +9,7 @@ import ReactMarkdown from 'react-markdown';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Dialog, DialogButton } from '../Dialog/Dialog';
+import { ErrorMessage } from '../state';
 import {
     errorResolutions as errorResolutionsSelector,
     hideDialog,
@@ -18,17 +19,29 @@ import {
 
 import './error.scss';
 
-const ErrorMessage = ({ message }: { message: string }) => (
-    <ReactMarkdown source={message} linkTarget="_blank" />
+const ErrorMessage = ({
+    error: { message, detail },
+}: {
+    error: ErrorMessage;
+}) => (
+    <>
+        <ReactMarkdown source={message} linkTarget="_blank" />
+        {detail != null && (
+            <details className="details">
+                <summary>Show technical details</summary>
+                <pre>{detail}</pre>
+            </details>
+        )}
+    </>
 );
 
-const MultipleErrorMessages = ({ messages }: { messages: string[] }) => (
+const MultipleErrorMessages = ({ messages }: { messages: ErrorMessage[] }) => (
     <>
         There are multiple errors:
         <ul>
             {messages.map(message => (
-                <li key={message}>
-                    <ErrorMessage message={message} />
+                <li key={message.message}>
+                    <ErrorMessage error={message} />
                 </li>
             ))}
         </ul>
@@ -56,7 +69,7 @@ const ErrorDialog = () => {
             <Dialog.Header title="Error" headerIcon="alert" />
             <Dialog.Body>
                 {messages.length === 1 ? (
-                    <ErrorMessage message={messages[0]} />
+                    <ErrorMessage error={messages[0]} />
                 ) : (
                     <MultipleErrorMessages messages={messages} />
                 )}

--- a/src/ErrorDialog/ErrorDialog.tsx
+++ b/src/ErrorDialog/ErrorDialog.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -17,6 +17,23 @@ import {
 } from './errorDialogSlice';
 
 import './error.scss';
+
+const ErrorMessage = ({ message }: { message: string }) => (
+    <ReactMarkdown source={message} linkTarget="_blank" />
+);
+
+const MultipleErrorMessages = ({ messages }: { messages: string[] }) => (
+    <>
+        There are multiple errors:
+        <ul>
+            {messages.map(message => (
+                <li key={message}>
+                    <ErrorMessage message={message} />
+                </li>
+            ))}
+        </ul>
+    </>
+);
 
 const ErrorDialog = () => {
     const dispatch = useDispatch();
@@ -38,13 +55,11 @@ const ErrorDialog = () => {
         >
             <Dialog.Header title="Error" headerIcon="alert" />
             <Dialog.Body>
-                {messages.map(message => (
-                    <ReactMarkdown
-                        key={message}
-                        source={message}
-                        linkTarget="_blank"
-                    />
-                ))}
+                {messages.length === 1 ? (
+                    <ErrorMessage message={messages[0]} />
+                ) : (
+                    <MultipleErrorMessages messages={messages} />
+                )}
             </Dialog.Body>
             <Dialog.Footer>
                 {Object.entries(errorResolutions).map(

--- a/src/ErrorDialog/error.scss
+++ b/src/ErrorDialog/error.scss
@@ -6,4 +6,9 @@
 
 .core19-error-body {
     user-select: text;
+
+    .details {
+        margin-bottom: 1rem;
+        font-size: 14px;
+    }
 }

--- a/src/ErrorDialog/errorDialogSlice.test.ts
+++ b/src/ErrorDialog/errorDialogSlice.test.ts
@@ -22,7 +22,9 @@ describe('errorDialogReducer', () => {
             showDialog(anErrorMessage, {}),
         ]);
         expect(withAnError.isVisible).toEqual(true);
-        expect(withAnError.messages).toContain(anErrorMessage);
+        expect(withAnError.messages).toContainEqual({
+            message: 'An error occurred',
+        });
     });
 
     it('should be visible and have all messages after multiple show actions have been dispatched', () => {
@@ -31,8 +33,12 @@ describe('errorDialogReducer', () => {
             showDialog(anotherErrorMessage, {}),
         ]);
         expect(withTwoErrors.isVisible).toEqual(true);
-        expect(withTwoErrors.messages).toContain(anErrorMessage);
-        expect(withTwoErrors.messages).toContain(anotherErrorMessage);
+        expect(withTwoErrors.messages).toContainEqual({
+            message: anErrorMessage,
+        });
+        expect(withTwoErrors.messages).toContainEqual({
+            message: anotherErrorMessage,
+        });
     });
 
     it('should not add message if it already exists in list', () => {
@@ -41,7 +47,9 @@ describe('errorDialogReducer', () => {
             showDialog(anErrorMessage, {}),
         ]);
 
-        expect(withAnError.messages).toEqual([anErrorMessage]);
+        expect(withAnError.messages).toEqual([
+            expect.objectContaining({ message: anErrorMessage }),
+        ]);
     });
 
     it('should set dialog to invisible and clear message list when hide action has been dispatched', () => {

--- a/src/ErrorDialog/errorDialogSlice.ts
+++ b/src/ErrorDialog/errorDialogSlice.ts
@@ -6,10 +6,22 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { ErrorDialog, ErrorResolutions, RootState } from '../state';
+import {
+    ErrorDialog,
+    ErrorMessage,
+    ErrorResolutions,
+    RootState,
+} from '../state';
 
-const appendIfNew = (messages: string[], message: string) =>
-    messages.includes(message) ? messages : [...messages, message];
+const appendIfNew = (messages: ErrorMessage[], message: ErrorMessage) => {
+    const messageExists = messages.some(
+        existingMessage =>
+            existingMessage.message === message.message &&
+            existingMessage.detail === message.detail
+    );
+
+    return messageExists ? messages : [...messages, message];
+};
 
 const initialState: ErrorDialog = {
     messages: [],
@@ -24,23 +36,23 @@ const slice = createSlice({
         showDialog: {
             prepare: (
                 message: string,
-                errorResolutions?: ErrorResolutions
+                errorResolutions?: ErrorResolutions,
+                detail?: string
             ) => ({
-                payload: { message, errorResolutions },
+                payload: { message: { message, detail }, errorResolutions },
             }),
             reducer: (
                 state,
-                action: PayloadAction<{
-                    message: string;
+                {
+                    payload: error,
+                }: PayloadAction<{
+                    message: ErrorMessage;
                     errorResolutions?: ErrorResolutions;
                 }>
             ) => {
                 state.isVisible = true;
-                state.errorResolutions = action.payload.errorResolutions;
-                state.messages = appendIfNew(
-                    state.messages,
-                    action.payload.message
-                );
+                state.errorResolutions = error.errorResolutions;
+                state.messages = appendIfNew(state.messages, error.message);
             },
         },
         hideDialog: () => initialState,

--- a/src/state.ts
+++ b/src/state.ts
@@ -41,9 +41,14 @@ export interface AppLayout {
     paneNames: string[];
 }
 
+export interface ErrorMessage {
+    message: string;
+    detail?: string;
+}
+
 export interface ErrorDialog {
     isVisible: boolean;
-    messages: string[];
+    messages: ErrorMessage[];
     errorResolutions?: ErrorResolutions;
 }
 

--- a/typings/generated/src/ErrorDialog/errorDialogSlice.d.ts
+++ b/typings/generated/src/ErrorDialog/errorDialogSlice.d.ts
@@ -1,8 +1,11 @@
-import { ErrorDialog, ErrorResolutions, RootState } from '../state';
-export declare const reducer: import("redux").Reducer<ErrorDialog, import("redux").AnyAction>, hideDialog: import("@reduxjs/toolkit").ActionCreatorWithoutPayload<"errorDialog/hideDialog">, showDialog: import("@reduxjs/toolkit").ActionCreatorWithPreparedPayload<[message: string, errorResolutions?: ErrorResolutions | undefined], {
-    message: string;
+import { ErrorDialog, ErrorMessage, ErrorResolutions, RootState } from '../state';
+export declare const reducer: import("redux").Reducer<ErrorDialog, import("redux").AnyAction>, hideDialog: import("@reduxjs/toolkit").ActionCreatorWithoutPayload<"errorDialog/hideDialog">, showDialog: import("@reduxjs/toolkit").ActionCreatorWithPreparedPayload<[message: string, errorResolutions?: ErrorResolutions | undefined, detail?: string | undefined], {
+    message: {
+        message: string;
+        detail: string | undefined;
+    };
     errorResolutions: ErrorResolutions | undefined;
 }, "errorDialog/showDialog", never, never>;
 export declare const isVisible: (state: RootState) => boolean;
-export declare const messages: (state: RootState) => string[];
+export declare const messages: (state: RootState) => ErrorMessage[];
 export declare const errorResolutions: (state: RootState) => ErrorResolutions | undefined;

--- a/typings/generated/src/index.d.ts
+++ b/typings/generated/src/index.d.ts
@@ -1,7 +1,10 @@
 declare const ErrorDialogActions: {
     hideDialog: import("@reduxjs/toolkit").ActionCreatorWithoutPayload<"errorDialog/hideDialog">;
-    showDialog: import("@reduxjs/toolkit").ActionCreatorWithPreparedPayload<[message: string, errorResolutions?: import("./state").ErrorResolutions | undefined], {
-        message: string;
+    showDialog: import("@reduxjs/toolkit").ActionCreatorWithPreparedPayload<[message: string, errorResolutions?: import("./state").ErrorResolutions | undefined, detail?: string | undefined], {
+        message: {
+            message: string;
+            detail: string | undefined;
+        };
         errorResolutions: import("./state").ErrorResolutions | undefined;
     }, "errorDialog/showDialog", never, never>;
 };

--- a/typings/generated/src/state.d.ts
+++ b/typings/generated/src/state.d.ts
@@ -28,9 +28,13 @@ export interface AppLayout {
     currentPane: number;
     paneNames: string[];
 }
+export interface ErrorMessage {
+    message: string;
+    detail?: string;
+}
 export interface ErrorDialog {
     isVisible: boolean;
-    messages: string[];
+    messages: ErrorMessage[];
     errorResolutions?: ErrorResolutions;
 }
 export interface ErrorResolutions {


### PR DESCRIPTION
For https://trello.com/c/r6e7BZHe: 

This current error dialog two disadvantages we want to enhance:

- The error dialog can already show multiple error messages at the same time. But it often isn't obvious that there are multiple errors and were one error message ends and the next starts.
- We sometimes want to add technical details to an error which are irrelevant to most users.

This PR addresses both. 

Before the error dialog could look like this:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/efbe135b-70c0-465a-900c-792341ce6954)

In this particular case shown in the screenshot, it actually shows two messages: The first one consists of the first two paragraphs and the second message is the third paragraph, starting with “EBUSY”. This is not obvious.

After the PR the error dialog could look like this (clicking on “Show technical details” could e.g. reveal a stacktrace):

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/8b0fa67d-fb6f-43dc-a86b-6dd330ddef78)