### PR TITLE
Give more user friendly list of info collected

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,11 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 58 - 2023-06-09
+
+-   FeedbackPane: Change **Platform** to **Operating system**, and remove the
+    link, which opened nodejs documentation.
+
 ## 57 - 2023-06-09
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,14 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-
 ## Unreleased
 
 ### Changed
 
 -   FeedbackPane: Change **Platform** to **Operating system**, and remove the
     link, which opened nodejs documentation.
-    
+
 ## 59 - 2023-06-16
 
 ### Added
@@ -31,7 +30,6 @@ every new version is a new major version.
 
 -   Opening port with error `FAILED_DIFFERENT_SETTINGS` will now log a warning
     not error
-
 
 ## 57 - 2023-06-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "57.0.0",
+    "version": "58.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Panes/FeedbackPane.tsx
+++ b/src/Panes/FeedbackPane.tsx
@@ -87,17 +87,9 @@ export default () => {
                         We only collect this information when you send feedback:
                     </p>
                     <ul>
-                        <li>Application Name</li>
+                        <li>Application name</li>
                         <li>Your feedback</li>
-                        <li>
-                            <a
-                                href="https://nodejs.org/api/process.html#processplatform"
-                                target="_blank"
-                                rel="noreferrer noopener"
-                            >
-                                Platform
-                            </a>
-                        </li>
+                        <li>Operating system</li>
                     </ul>
                 </section>
                 <Button


### PR DESCRIPTION
The link to the nodejs documentation could perhaps confuse more then it was helping the user understand we are collecting the operating system of the OS the app is built for, and not what the user is running.