### PR TITLE
refactor: extract and rename reducer payload

### DIFF
--- a/src/FlashMessage/FlashMessage.tsx
+++ b/src/FlashMessage/FlashMessage.tsx
@@ -37,19 +37,19 @@ const FlashMessage = ({ flashMessage }: FlashMessageProps) => {
 
     if (timeoutHandler.current == null && dismissTime != null) {
         timeoutHandler.current = setTimeout(() => {
-            dispatch(removeMessage({ id }));
+            dispatch(removeMessage(id));
         }, dismissTime);
     }
 
     const close = () => {
         clearTimeout(timeoutHandler.current);
-        dispatch(removeMessage({ id }));
+        dispatch(removeMessage(id));
     };
 
     const addFadeout = () => {
         if (dismissTime) {
             timeoutHandler.current = setTimeout(() => {
-                dispatch(removeMessage({ id }));
+                dispatch(removeMessage(id));
             }, dismissTime);
             setFadeoutTimer(`${dismissTime}ms`);
         }

--- a/src/FlashMessage/FlashMessageSlice.ts
+++ b/src/FlashMessage/FlashMessageSlice.ts
@@ -37,20 +37,15 @@ const slice = createSlice({
     name: 'flashMessages',
     initialState,
     reducers: {
-        addNewMessage: {
-            reducer: (state, action: PayloadAction<FlashMessage>) => {
-                state.messages.push(action.payload);
-            },
-            prepare: (message: FlashMessagePayload) => ({
-                payload: {
-                    id: nanoid(),
-                    ...message,
-                },
-            }),
+        addNewMessage: (
+            state,
+            { payload: message }: PayloadAction<FlashMessagePayload>
+        ) => {
+            state.messages.push({ ...message, id: nanoid() });
         },
-        removeMessage: (state, action: PayloadAction<{ id: string }>) => {
+        removeMessage: (state, { payload: id }: PayloadAction<string>) => {
             state.messages = state.messages.filter(
-                message => message.id !== action.payload.id
+                message => message.id !== id
             );
         },
     },

--- a/typings/generated/src/FlashMessage/FlashMessageSlice.d.ts
+++ b/typings/generated/src/FlashMessage/FlashMessageSlice.d.ts
@@ -18,12 +18,5 @@ export declare const newWarningFlashMessage: (message: string, dismissTime?: num
 export declare const newErrorFlashMessage: (message: string, dismissTime?: number) => TAction;
 export declare const newInfoFlashMessage: (message: string, dismissTime?: number) => TAction;
 export declare const getMessages: (state: RootState) => FlashMessage[];
-export declare const reducer: import("redux").Reducer<FlashMessages, AnyAction>, addNewMessage: import("@reduxjs/toolkit").ActionCreatorWithPreparedPayload<[message: FlashMessagePayload], {
-    message: string;
-    variant: FlashMessageVariant;
-    dismissTime?: number | undefined;
-    id: string;
-}, "flashMessages/addNewMessage", never, never>, removeMessage: import("@reduxjs/toolkit").ActionCreatorWithPayload<{
-    id: string;
-}, "flashMessages/removeMessage">;
+export declare const reducer: import("redux").Reducer<FlashMessages, AnyAction>, addNewMessage: import("@reduxjs/toolkit").ActionCreatorWithPayload<FlashMessagePayload, "flashMessages/addNewMessage">, removeMessage: import("@reduxjs/toolkit").ActionCreatorWithPayload<string, "flashMessages/removeMessage">;
 export {};


### PR DESCRIPTION
Also remove the prepare in `addNewMessage` reducer, as it is not really needed.