### PR TITLE
fix: position was not set to absolute

### DIFF
--- a/src/FlashMessage/FlashMessage.tsx
+++ b/src/FlashMessage/FlashMessage.tsx
@@ -118,13 +118,14 @@ const FlashMessages = () => {
     return (
         <div
             style={{
+                position: 'absolute',
+                bottom: '32px',
+                right: '16px',
                 width: '256px',
                 gap: '16px',
-                marginBottom: '32px',
                 display: 'flex',
                 flexDirection: 'column-reverse',
             }}
-            className="message-container"
         >
             {messages.map(flashMessage => (
                 <FlashMessage


### PR DESCRIPTION
The app where it was tested had a css file where `.message-container` set the element's position to absolute. This is required in order to make the messages "float" on top of the app layout.