### PR TITLE
Slide-out effect and faster effects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,10 @@ every new version is a new major version.
 
 ## 62 - Unreleased
 
+### Added
+
+-   Slide-out effect for Flash messages.
+
 ### Changed
 
 -   Reduced time for CopiedFlashMessage, from 12s to 3s.

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 62 - Unreleased
+
+### Changed
+
+-   Reduced time for CopiedFlashMessage, from 12s to 3s.
+-   Faster slide-in effect for Flash messages.
+
 ## 61 - 2023-06-23
 
 ### Added

--- a/src/FlashMessage/FlashMessage.tsx
+++ b/src/FlashMessage/FlashMessage.tsx
@@ -69,7 +69,10 @@ const FlashMessage = ({ flashMessage }: FlashMessageProps) => {
                 backgroundColor: getBackgroundColorFromVariant(variant),
                 color: colors.white,
                 zIndex: 1000,
-                animation: initialRender() ? 'slide-in 1s' : 'unset',
+                animation:
+                    fadeoutTimer !== 'unset'
+                        ? flashMessageAnimations(initialRender(), dismissTime)
+                        : 'unset',
                 width: '100%',
                 padding: '16px',
                 display: 'flex',
@@ -135,6 +138,20 @@ const FlashMessages = () => {
             ))}
         </div>
     );
+};
+
+const SLIDE_IN = '1s slide-in';
+const SLIDE_OUT = (dismissTime: number) =>
+    `1s slide-out ${dismissTime - 1000}ms`;
+const flashMessageAnimations = (
+    initialRender2: boolean,
+    dismissTime2?: number
+): string => {
+    if (!dismissTime2) {
+        return initialRender2 ? SLIDE_IN : 'unset';
+    }
+
+    return `${SLIDE_OUT(dismissTime2)},${initialRender2 ? SLIDE_IN : ''}`;
 };
 
 const getBackgroundColorFromVariant = (variant: FlashMessageVariant) => {

--- a/src/FlashMessage/FlashMessageSlice.ts
+++ b/src/FlashMessage/FlashMessageSlice.ts
@@ -54,7 +54,7 @@ const slice = createSlice({
 type TAction = ThunkAction<void, RootState, null, AnyAction>;
 
 export const newCopiedFlashMessage = (): TAction => dispatch =>
-    dispatch(newInfoFlashMessage('Copied to clipboard!', 12000));
+    dispatch(newInfoFlashMessage('Copied to clipboard!', 3000));
 
 export const newSuccessFlashMessage =
     (message: string, dismissTime?: number): TAction =>

--- a/src/FlashMessage/flashMessage.css
+++ b/src/FlashMessage/flashMessage.css
@@ -15,7 +15,7 @@
 
 @keyframes slide-in {
     from {
-        transform: translateX(200%);
+        transform: translateX(110%);
     }
     to {
         transform: translateX(0);

--- a/src/FlashMessage/flashMessage.css
+++ b/src/FlashMessage/flashMessage.css
@@ -21,3 +21,12 @@
         transform: translateX(0);
     }
 }
+
+@keyframes slide-out {
+    from {
+        transform: translateX(0);
+    }
+    to {
+        transform: translateX(110%);
+    }
+}

--- a/temp.txt
+++ b/temp.txt
@@ -1,0 +1,1 @@
+pc-nrfconnect-shared-61.0.0.tgz


### PR DESCRIPTION
### This PR:

-  Makes the slide-in effect a bit snappier
- Reduces the dismissTime of the utility message `newCopiedFlashMessage` from 12s to 3s.
- Adds the slide-out effect on all flash-messages with a `dismissTime`.

### Gif showing the slide-in and slide-out effect

![slide-out-effect-flash-messages](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/34618612/92de20dc-3a10-4732-9e1d-b974424b0e9b)



