### PR TITLE
Faster flash message slide-in effect

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 63 - Unreleased
+
+### Changed
+
+-   Flash Messages: slide-in effect duration reduced to 300ms.
+-   Flash Messages: loader effect ends before slide-out effect begins.
+
 ## 62 - 2023-06-26
 
 ### Added

--- a/src/FlashMessage/FlashMessage.tsx
+++ b/src/FlashMessage/FlashMessage.tsx
@@ -21,6 +21,20 @@ import {
 
 import './flashMessage.css';
 
+const SLIDE_IN_DURATION_MS = 300;
+const SLIDE_IN_ANIMATION = `${SLIDE_IN_DURATION_MS}ms slide-in`;
+
+const SLIDE_OUT_DURATION_MS = 1000;
+const SLIDE_OUT_ANIMATION = (dismissTime: number) =>
+    `${SLIDE_OUT_DURATION_MS}ms slide-out ${
+        dismissTime - SLIDE_OUT_DURATION_MS
+    }ms`;
+
+const LOADER_ANIMATION = (dismissTime: number) =>
+    `${
+        dismissTime - SLIDE_OUT_DURATION_MS
+    }ms flash-message-loader linear forwards`;
+
 interface FlashMessageProps {
     flashMessage: FlashMessage;
 }
@@ -104,7 +118,7 @@ const FlashMessage = ({ flashMessage }: FlashMessageProps) => {
                         marginTop: '8px',
                         animation:
                             fadeoutTimer !== 'unset'
-                                ? `flash-message ${dismissTime}ms linear`
+                                ? LOADER_ANIMATION(dismissTime)
                                 : 'unset',
                     }}
                 />
@@ -140,18 +154,17 @@ const FlashMessages = () => {
     );
 };
 
-const SLIDE_IN = '1s slide-in';
-const SLIDE_OUT = (dismissTime: number) =>
-    `1s slide-out ${dismissTime - 1000}ms`;
 const flashMessageAnimations = (
     initialRender2: boolean,
     dismissTime2?: number
 ): string => {
     if (!dismissTime2) {
-        return initialRender2 ? SLIDE_IN : 'unset';
+        return initialRender2 ? SLIDE_IN_ANIMATION : 'unset';
     }
 
-    return `${SLIDE_OUT(dismissTime2)},${initialRender2 ? SLIDE_IN : ''}`;
+    return `${SLIDE_OUT_ANIMATION(dismissTime2)},${
+        initialRender2 ? SLIDE_IN_ANIMATION : ''
+    }`;
 };
 
 const getBackgroundColorFromVariant = (variant: FlashMessageVariant) => {

--- a/src/FlashMessage/flashMessage.css
+++ b/src/FlashMessage/flashMessage.css
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-@keyframes flash-message {
+@keyframes flash-message-loader {
     from {
         width: 100%;
     }


### PR DESCRIPTION
Even faster (reduced duration) slide-in effect. Also deduce the duration of flash-message-loader from `dismissTime` and `slide-out` duration. Then the loader animation can finish before the message slides-out.

#### Time Flow of Flash Message Animations

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/34618612/50183bdb-0fc8-41d8-b97c-ff4803880450)
