### PR TITLE
Add hook `useFocusedOnVisible`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 63 - Unreleased
+## 63 - 2023-06-27
+
+### Added
+
+-   Hook `useFocusedOnVisible` to focus an element when a dialog becomes
+    visible.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-shared",
-    "version": "62.0.0",
+    "version": "63.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export { default as NumberInlineInput } from './InlineInput/NumberInlineInput';
 export { default as MasonryLayout } from './MasonryLayout/MasonryLayout';
 
 export { default as useStopwatch } from './utils/useStopwatch';
+export { default as useFocusedOnVisible } from './utils/useFocusedOnVisible';
 
 export { reducer as errorDialogReducer } from './ErrorDialog/errorDialogSlice';
 export { default as logger } from './logging';

--- a/src/utils/useFocusedOnVisible.ts
+++ b/src/utils/useFocusedOnVisible.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Focus an element (usually an input) when a dialog becomes visible.
+ * Use the concrete elements type as a type parameter.
+ *
+ * @param {boolean} isVisible - Whether the dialog is visible
+ * @returns {React.RefObject<T>} A ref to pass to the element which should be focused
+ */
+export default <T extends HTMLElement>(isVisible: boolean) => {
+    const ref = useRef<T>(null);
+
+    useEffect(() => {
+        if (isVisible) {
+            ref.current?.focus();
+        }
+    }, [isVisible]);
+
+    return ref;
+};

--- a/typings/generated/src/index.d.ts
+++ b/typings/generated/src/index.d.ts
@@ -35,6 +35,7 @@ export { default as InlineInput } from './InlineInput/InlineInput';
 export { default as NumberInlineInput } from './InlineInput/NumberInlineInput';
 export { default as MasonryLayout } from './MasonryLayout/MasonryLayout';
 export { default as useStopwatch } from './utils/useStopwatch';
+export { default as useFocusedOnVisible } from './utils/useFocusedOnVisible';
 export { reducer as errorDialogReducer } from './ErrorDialog/errorDialogSlice';
 export { default as logger } from './logging';
 export { default as bleChannels } from './utils/bleChannels';

--- a/typings/generated/src/utils/useFocusedOnVisible.d.ts
+++ b/typings/generated/src/utils/useFocusedOnVisible.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="react" />
+/**
+ * Focus an element (usually an input) when a dialog becomes visible.
+ * Use the concrete elements type as a type parameter.
+ *
+ * @param {boolean} isVisible - Whether the dialog is visible
+ * @returns {React.RefObject<T>} A ref to pass to the element which should be focused
+ */
+declare const _default: <T extends HTMLElement>(isVisible: boolean) => import("react").RefObject<T>;
+export default _default;


### PR DESCRIPTION
Adds the hook `useFocusedOnVisible` to focus an element when a dialog becomes visible.

You can see it in action in the launcher: https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/ac09b41b7a26dd24aca1dab81b4a3607bf993998/src/launcher/features/sources/AddSourceDialog.tsx#L39 (There a local copy of this hook is still used, because this change wasn't available from shared yet)