### PR TITLE
Enhance pipeline release to npm

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ every new version is a new major version.
 
 ### Steps to upgrade when using this package
 
+-   Remove the old dependency by running `npm rm pc-nrfconnect-shared`.
 -   Change all references from `pc-nrfconnect-shared` to
     `@nordicsemiconductor/pc-nrfconnect-shared`
 
@@ -41,7 +42,6 @@ The tsconfig can use the namespace directly like this
 {
     "extends": "@nordicsemiconductor/pc-nrfconnect-shared/config/tsconfig.json"
 }
-
 ```
 
 The package.json can be changed as follows:

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,13 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 82 - 09.08.2023
+## 82 - 2023-08-09
 
 ### Fixed
 
 -   Jest tests were broken due to missing config changes.
 
-## 81 - 09.08.2023
+## 81 - 2023-08-09
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "pc-nrfconnect-shared",
-    "version": "68.0.0",
+    "name": "@nordicsemiconductor/pc-nrfconnect-shared",
+    "version": "82.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "pc-nrfconnect-shared",
-            "version": "68.0.0",
+            "name": "@nordicsemiconductor/pc-nrfconnect-shared",
+            "version": "82.0.0",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
@@ -109,12 +109,11 @@
             "bin": {
                 "check-app-properties": "scripts/check-app-properties.ts",
                 "check-for-typescript": "scripts/check-for-typescript.ts",
-                "nordic-publish": "scripts/nordic-publish.ts",
                 "nrfconnect-license": "scripts/nrfconnect-license.ts",
                 "run-esbuild": "scripts/esbuild.js"
             },
             "peerDependencies": {
-                "@nordicsemiconductor/nrf-device-lib-js": "*"
+                "@nordicsemiconductor/nrf-device-lib-js": ">=0.6.13"
             }
         },
         "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "postinstall": "ts-node scripts/postinstall.ts"
     },
     "peerDependencies": {
-        "@nordicsemiconductor/nrf-device-lib-js": "*"
+        "@nordicsemiconductor/nrf-device-lib-js": ">=0.6.13"
     },
     "dependencies": {
         "@electron/remote": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
     "author": "Nordic Semiconductor ASA",
     "license": "ISC",
     "bin": {
-        "check-for-typescript": "./scripts/check-for-typescript.js",
-        "check-app-properties": "./scripts/check-app-properties.js",
-        "nordic-publish": "./scripts/nordic-publish.js",
-        "nrfconnect-license": "./scripts/nrfconnect-license.js",
+        "check-for-typescript": "./scripts/check-for-typescript.ts",
+        "check-app-properties": "./scripts/check-app-properties.ts",
+        "nrfconnect-license": "./scripts/nrfconnect-license.ts",
         "run-esbuild": "./scripts/esbuild.js"
     },
     "files": [

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
         "check:lint": "eslint --color .",
         "check:types": "tsc --noEmit",
         "check:license": "ts-node scripts/nrfconnect-license.ts check",
-        "clean-generate-types": "rimraf ./typings/generated",
         "generate-types": "tsc --emitDeclarationOnly --declaration --declarationMap --outDir ./typings/generated --rootDir .",
         "prepare": "ts-node scripts/installHusky.ts",
         "release-shared": "ts-node scripts/release-shared.ts",
         "prepare-shared-release": "ts-node scripts/prepare-shared-release.ts",
+        "clean": "rimraf dist typings/generated dist scripts/nordic-publish.js",
         "postinstall": "node scripts/postinstall.js"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "release-shared": "ts-node scripts/release-shared.ts",
         "prepare-shared-release": "ts-node scripts/prepare-shared-release.ts",
         "clean": "rimraf dist typings/generated dist scripts/nordic-publish.js",
-        "postinstall": "node scripts/postinstall.js"
+        "postinstall": "ts-node scripts/postinstall.ts"
     },
     "peerDependencies": {
         "@nordicsemiconductor/nrf-device-lib-js": "*"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -35,8 +35,9 @@ if (!existsSync(`dist/bootstrap.css`)) {
     });
 }
 
-const root = resolve(__dirname, '..');
-process.chdir(root);
+if (!existsSync(`typings/generated/src/index.d.ts`)) {
+    const root = resolve(__dirname, '..');
+    process.chdir(root);
 
-// Generate types
-execSync('npm run generate-types', { encoding: 'utf-8' });
+    execSync('npm run generate-types', { encoding: 'utf-8' });
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -11,20 +11,10 @@ const { existsSync } = require('fs');
 const { resolve } = require('path');
 const { build } = require('./esbuild-renderer');
 
-const scripts = [
-    'nordic-publish',
-    'check-app-properties',
-    'check-for-typescript',
-    'nrfconnect-license',
-];
-
-scripts.forEach(script => {
-    // compile scripts if they don't exist
-    if (!existsSync(`scripts/${script}.js`)) {
-        const command = `npx esbuild scripts/${script}.ts --bundle --outfile=scripts/${script}.js --platform=node --log-level=warning --minify`;
-        execSync(command, { encoding: 'utf-8' });
-    }
-});
+if (!existsSync(`scripts/nordic-publish.js`)) {
+    const command = `npx esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning --minify`;
+    execSync(command, { encoding: 'utf-8' });
+}
 
 if (!existsSync(`dist/bootstrap.css`)) {
     build({

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -13,11 +13,13 @@ import { resolve } from 'path';
 import { build } from './esbuild-renderer';
 
 if (!existsSync(`scripts/nordic-publish.js`)) {
+    console.log('Building nordic-publish.js');
     const command = `npx esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning --minify`;
     execSync(command, { encoding: 'utf-8' });
 }
 
 if (!existsSync(`dist/bootstrap.css`)) {
+    console.log('Building bootstrap.css');
     build({
         logLevel: 'warning',
         entryPoints: ['./src/bootstrap.scss'],
@@ -27,6 +29,7 @@ if (!existsSync(`dist/bootstrap.css`)) {
 }
 
 if (!existsSync(`typings/generated/src/index.d.ts`)) {
+    console.log('Generating types');
     const root = resolve(__dirname, '..');
     process.chdir(root);
 

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node
 
 /*
  * Copyright (c) 2015 Nordic Semiconductor ASA
@@ -6,10 +6,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-const { execSync } = require('child_process');
-const { existsSync } = require('fs');
-const { resolve } = require('path');
-const { build } = require('./esbuild-renderer');
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+import { build } from './esbuild-renderer';
 
 if (!existsSync(`scripts/nordic-publish.js`)) {
     const command = `npx esbuild scripts/nordic-publish.ts --bundle --outfile=scripts/nordic-publish.js --platform=node --log-level=warning --minify`;

--- a/typings/generated/src/utils/udevInstalled.d.ts
+++ b/typings/generated/src/utils/udevInstalled.d.ts
@@ -1,3 +1,0 @@
-declare const _default: () => boolean;
-export default _default;
-//# sourceMappingURL=udevInstalled.d.ts.map

--- a/typings/generated/src/utils/udevInstalled.d.ts.map
+++ b/typings/generated/src/utils/udevInstalled.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"udevInstalled.d.ts","sourceRoot":"","sources":["../../../../src/utils/udevInstalled.ts"],"names":[],"mappings":";AAQA,wBAYE"}


### PR DESCRIPTION
Some smaller enhancements.

The changes to the postinstall script are a bit obscured, because I also converted it to TypeScript during the branch. Besides the conversion I also did these three changes to it:
- Generate types only if needed
- Only compile the `nordic-publish` script
- Add logging for each step, so one can see what is done