### PR TITLE
Fix/html bundle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 88 - 2023-08-15
+## 88 - 2023-08-17
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,17 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 88 - 2023-08-15
+
+### Changed
+
+-   `html` package json property has been moved to `nrfConnectForDesktop.html`.
+-   `nrfConnectForDesktop.html` is now opt-in and apps can be built without it.
+
+### Steps to upgrade
+
+-   Change `html` to `nrfConnectForDesktop.html` in the app package json.
+
 ## 87 - 2023-08-14
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -58,9 +58,10 @@ every new version is a new major version.
 
 ### Steps to upgrade when using this package
 
--   Add an `index`-property to package.json. The following example will use the
-    index bundled with shared that works with our apps, but apps can also make
-    their own instead if needed.
+-   Following this step will make the app incompatible with the currently
+    released launcher (v4.1.2): Add an `index`-property to package.json. The
+    following example will use the index bundled with shared that works with our
+    apps, but apps can also make their own instead if needed.
 
 ```json
 {

--- a/ipc/MetaFiles.ts
+++ b/ipc/MetaFiles.ts
@@ -61,5 +61,7 @@ export interface PackageJson {
         url: UrlString;
     };
     scripts?: ObjectContainingOptionalStrings;
-    html?: string;
+    nrfConnectForDesktop?: {
+        html?: string;
+    };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "87.0.0",
+    "version": "88.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -68,7 +68,6 @@ const checkMandatoryProperties = (packageJson: PackageJson) => {
         `description`,
         `displayName`,
         `engines.nrfconnect`,
-        `html`,
     ];
 
     const missingProperties = mandatoryProperties.filter(
@@ -84,6 +83,12 @@ const checkMandatoryProperties = (packageJson: PackageJson) => {
 const checkOptionalProperties = (packageJson: PackageJson) => {
     if (propertyIsMissing(packageJson)('homepage')) {
         warn('Please provide a property `homepage` in package.json.');
+    }
+
+    if (propertyIsMissing(packageJson)('nrfConnectForDesktop')) {
+        warn(
+            'Please provide a property `nrfConnectForDesktop.html` in package.json'
+        );
     }
 
     if (propertyIsMissing(packageJson)('repository.url')) {

--- a/scripts/esbuild-renderer.js
+++ b/scripts/esbuild-renderer.js
@@ -27,7 +27,7 @@ const tailwindConfig = () =>
           );
 
 function options(additionalOptions) {
-    const { dependencies } = JSON.parse(
+    const { dependencies, nrfConnectForDesktop } = JSON.parse(
         fs.readFileSync('package.json', 'utf8')
     );
 
@@ -37,8 +37,10 @@ function options(additionalOptions) {
             : undefined;
     const outdir = outfile ? undefined : './dist';
 
+    const appHasOwnHtml = nrfConnectForDesktop?.html !== undefined;
+
     return {
-        format: 'iife',
+        format: appHasOwnHtml ? 'iife' : 'cjs',
         outfile,
         outdir,
         target: 'chrome89',
@@ -55,6 +57,7 @@ function options(additionalOptions) {
             'serialport',
             '@electron/remote',
             '@nordicsemiconductor/nrf-device-lib-js',
+            ...(appHasOwnHtml ? [] : ['react']),
 
             // App dependencies
             ...Object.keys(dependencies ?? {}),

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,8 @@
     <link rel="stylesheet" href="bundle.css">
     <script>
         const path = require('path');
-        const launcherPath = require('@electron/remote').app.getAppPath()
+        const params = new URL(window.location).searchParams;
+        const launcherPath = params.get('launcherPath')
         module.paths.unshift(path.join(launcherPath, '/node_modules'));
         document.write(
             '<link rel="stylesheet" href="'+launcherPath+'/dist/fonts.css" type="text/css" />'

--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -17,7 +17,7 @@ const getUserDataDir = () => getGlobal('userDataDir');
  * @returns {string|undefined} Absolute path of current app.
  */
 function getAppDir() {
-    const html = packageJson()?.html ?? '';
+    const html = packageJson()?.nrfConnectForDesktop?.html ?? '';
     return __filename.replace(html, '');
 }
 


### PR DESCRIPTION
Currently the official launcher doesn't support when an app is built with `cjs` and without externalised `react`.

I made the `html` property opt-in and also renamed it (as we want to have it in the `nrfConnectForDesktop` property.

The launcher pr using this change is: https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/pull/865