### PR TITLE
Suggestions for `feat/use-nrfutil-device`

### DIFF
--- a/ipc/MetaFiles.ts
+++ b/ipc/MetaFiles.ts
@@ -44,6 +44,7 @@ interface ObjectContainingOptionalStrings {
 
 interface nrfConnectForDesktop {
     nrfutil?: nrfutilModules;
+    html?: string;
 }
 
 interface nrfutilModules {
@@ -73,7 +74,4 @@ export interface PackageJson {
         url: UrlString;
     };
     scripts?: ObjectContainingOptionalStrings;
-    nrfConnectForDesktop?: {
-        html?: string;
-    };
 }

--- a/nrfutil/device/batchTypes.ts
+++ b/nrfutil/device/batchTypes.ts
@@ -13,11 +13,11 @@ import {
     ProgrammingOptions,
 } from './program';
 
-export interface BatchOperationWrapper<OperationType, T = void> {
+export interface BatchOperationWrapper<OperationType, Result = void> {
     operation: GenericOperation<OperationType>;
     onProgress?: (progress: Progress, task?: Task) => void;
     onTaskBegin?: TaskBeginCallback;
-    onTaskEnd?: TaskEndCallback<T>;
+    onTaskEnd?: TaskEndCallback<Result>;
     onException?: (error: Error) => void;
 }
 

--- a/nrfutil/device/common.ts
+++ b/nrfutil/device/common.ts
@@ -200,9 +200,7 @@ export const getDeviceSandbox = async () => {
     if (!promiseDeviceSandbox) {
         promiseDeviceSandbox = sandbox(
             path.join(getAppDataDir(), '../'),
-            'device',
-            undefined,
-            undefined
+            'device'
         );
         deviceSandbox = await promiseDeviceSandbox;
 

--- a/nrfutil/index.ts
+++ b/nrfutil/index.ts
@@ -19,7 +19,8 @@ export type { ImageType } from './device/getFwInfo';
 
 export { default as prepareSandbox } from './sandbox';
 export { NrfutilSandbox } from './sandbox';
-export type { Progress, SemanticVersion } from './sandboxTypes';
+export type { Progress } from './sandboxTypes';
+export type { SemanticVersion } from './moduleVersion';
 export type { Batch as DeviceBatch } from './device/batch';
 export type { Callbacks as BatchCallbacks } from './device/batchTypes';
 export type { GetProtectionStatusResult } from './device/getProtectionStatus';

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -4,13 +4,77 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import {
-    Dependency,
-    isIncrementalVersion,
-    isSemanticVersion,
-    isStringVersion,
-    SubDependency,
-} from './sandboxTypes';
+import packageJson from '../src/utils/packageJson';
+
+type FeatureClassification =
+    | 'nrf-internal-confidential'
+    | 'nrf-internal'
+    | 'nrf-external-confidential'
+    | 'nrf-external';
+
+export interface SemanticVersion {
+    major: number;
+    minor: number;
+    patch: number;
+    semverPreNumeric?: number;
+    semverPreAlphaNumeric?: number;
+    semverMetadataNumeric?: number;
+    semverMetadataAlphaNumeric?: number;
+}
+
+type VersionFormat = 'incremental' | 'semantic' | 'string';
+
+type Plugin = {
+    dependencies: Dependency[];
+    name: string;
+    versionFormat: VersionFormat;
+    version: VersionType;
+};
+
+type Dependency = {
+    classification?: FeatureClassification;
+    name: string;
+    plugins?: Plugin[];
+    dependencies?: SubDependency[];
+    versionFormat: VersionFormat;
+    version: VersionType;
+};
+
+type VersionType = SemanticVersion | string | number;
+
+export interface SubDependency {
+    name: string;
+    description?: string;
+    dependencies?: SubDependency[];
+    versionFormat: VersionFormat;
+    version: VersionType;
+}
+
+export type ModuleVersion = {
+    build_timestamp: string;
+    classification: FeatureClassification;
+    commit_date: string;
+    commit_hash: string;
+    dependencies: Dependency[];
+    host: string;
+    name: string;
+    version: string;
+};
+
+const isSemanticVersion = (
+    version?: SubDependency
+): version is SubDependency & { version: SemanticVersion } =>
+    version?.versionFormat === 'semantic';
+
+const isIncrementalVersion = (
+    version?: SubDependency
+): version is SubDependency & { version: number } =>
+    version?.versionFormat === 'incremental';
+
+const isStringVersion = (
+    version?: SubDependency
+): version is SubDependency & { version: string } =>
+    version?.versionFormat === 'string';
 
 export const describeVersion = (version?: SubDependency | string) => {
     if (typeof version === 'string') {
@@ -55,3 +119,27 @@ export const resolveModuleVersion = (
     versions: Dependency[] = []
 ): Dependency | SubDependency | undefined =>
     findTopLevel(module, versions) ?? findInDependencies(module, versions);
+
+const getOverriddenVersion = (module: string) => {
+    const allowOverride =
+        process.env.NODE_ENV !== 'production' ||
+        !!process.env.NRF_OVERRIDE_NRFUTIL_SETTINGS;
+
+    return allowOverride
+        ? process.env[`NRF_OVERRIDE_VERSION_${module.toLocaleUpperCase()}`]
+        : undefined;
+};
+
+const getVersionFromPackageJson = (module: string) => {
+    const moduleVersions =
+        packageJson().nrfConnectForDesktop?.nrfutil?.[module];
+
+    if (moduleVersions?.[0] == null) {
+        throw new Error(`No version specified for nrfutil-${module}`);
+    }
+
+    return moduleVersions[0];
+};
+
+export const getRequiredNrfutilModuleVersion = (module: string) =>
+    getOverriddenVersion(module) ?? getVersionFromPackageJson(module);

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -92,18 +92,20 @@ export const describeVersion = (version?: SubDependency | string) => {
     return 'Unknown';
 };
 
-type KnownModule = 'nrfdl' | 'jprog' | 'JlinkARM';
+type KnownDependencies = 'nrfdl' | 'jprog' | 'JlinkARM';
 
-const findTopLevel = (module: KnownModule, dependencies: Dependency[]) =>
-    dependencies.find(dependency => dependency.name === module);
+const findTopLevel = (
+    dependencyName: KnownDependencies,
+    dependencies: Dependency[]
+) => dependencies.find(dependency => dependency.name === dependencyName);
 
 const findInDependencies = (
-    module: KnownModule,
+    dependencyName: KnownDependencies,
     dependencies: Dependency[]
 ) => {
     if (dependencies.length > 0) {
-        return resolveModuleVersion(
-            module,
+        return findDependency(
+            dependencyName,
             dependencies.flatMap(dependency => [
                 ...(dependency.dependencies ?? []),
                 ...(dependency.plugins?.flatMap(
@@ -114,11 +116,12 @@ const findInDependencies = (
     }
 };
 
-export const resolveModuleVersion = (
-    module: KnownModule,
+export const findDependency = (
+    dependencyName: KnownDependencies,
     versions: Dependency[] = []
 ): Dependency | SubDependency | undefined =>
-    findTopLevel(module, versions) ?? findInDependencies(module, versions);
+    findTopLevel(dependencyName, versions) ??
+    findInDependencies(dependencyName, versions);
 
 const getOverriddenVersion = (module: string) => {
     const allowOverride =

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -57,32 +57,32 @@ export type ModuleVersion = {
     version: string;
 };
 
-const isSemanticVersion = (
-    version?: Dependency
-): version is Dependency & { version: SemanticVersion } =>
-    version?.versionFormat === 'semantic';
+const isDependency = (
+    versioned?: Dependency | ModuleVersion
+): versioned is Dependency => versioned != null && 'versionFormat' in versioned;
 
-const isIncrementalVersion = (
-    version?: Dependency
-): version is Dependency & { version: number } =>
-    version?.versionFormat === 'incremental';
+const hasSemanticVersion = (
+    versioned?: Dependency | ModuleVersion
+): versioned is Dependency & { version: SemanticVersion } =>
+    isDependency(versioned) && versioned.versionFormat === 'semantic';
 
-const isStringVersion = (
-    version?: Dependency
-): version is Dependency & { version: string } =>
-    version?.versionFormat === 'string';
+const hasIncrementalVersion = (
+    versioned?: Dependency | ModuleVersion
+): versioned is Dependency & { version: number } =>
+    isDependency(versioned) && versioned.versionFormat === 'incremental';
 
-export const describeVersion = (version?: Dependency | string) => {
-    if (typeof version === 'string') {
-        return version;
+const hasStringVersion = (
+    versioned?: Dependency | ModuleVersion
+): versioned is ModuleVersion | (Dependency & { version: string }) =>
+    !isDependency(versioned) || versioned.versionFormat === 'string';
+
+export const describeVersion = (dependency?: Dependency | ModuleVersion) => {
+    if (hasSemanticVersion(dependency)) {
+        return `${dependency.version.major}.${dependency.version.minor}.${dependency.version.patch}`;
     }
 
-    if (isSemanticVersion(version)) {
-        return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
-    }
-
-    if (isIncrementalVersion(version) || isStringVersion(version)) {
-        return String(version.version);
+    if (hasIncrementalVersion(dependency) || hasStringVersion(dependency)) {
+        return String(dependency.version);
     }
 
     return 'Unknown';

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -25,27 +25,23 @@ export interface SemanticVersion {
 type VersionFormat = 'incremental' | 'semantic' | 'string';
 
 type Plugin = {
-    dependencies: Dependency[];
+    dependencies: TopLevelDependency[];
     name: string;
     versionFormat: VersionFormat;
     version: VersionType;
 };
 
-type Dependency = {
+interface TopLevelDependency extends Dependency {
     classification?: FeatureClassification;
-    name: string;
     plugins?: Plugin[];
-    dependencies?: SubDependency[];
-    versionFormat: VersionFormat;
-    version: VersionType;
-};
+}
 
 type VersionType = SemanticVersion | string | number;
 
-export interface SubDependency {
+export interface Dependency {
     name: string;
     description?: string;
-    dependencies?: SubDependency[];
+    dependencies?: Dependency[];
     versionFormat: VersionFormat;
     version: VersionType;
 }
@@ -55,28 +51,28 @@ export type ModuleVersion = {
     classification: FeatureClassification;
     commit_date: string;
     commit_hash: string;
-    dependencies: Dependency[];
+    dependencies: TopLevelDependency[];
     host: string;
     name: string;
     version: string;
 };
 
 const isSemanticVersion = (
-    version?: SubDependency
-): version is SubDependency & { version: SemanticVersion } =>
+    version?: Dependency
+): version is Dependency & { version: SemanticVersion } =>
     version?.versionFormat === 'semantic';
 
 const isIncrementalVersion = (
-    version?: SubDependency
-): version is SubDependency & { version: number } =>
+    version?: Dependency
+): version is Dependency & { version: number } =>
     version?.versionFormat === 'incremental';
 
 const isStringVersion = (
-    version?: SubDependency
-): version is SubDependency & { version: string } =>
+    version?: Dependency
+): version is Dependency & { version: string } =>
     version?.versionFormat === 'string';
 
-export const describeVersion = (version?: SubDependency | string) => {
+export const describeVersion = (version?: Dependency | string) => {
     if (typeof version === 'string') {
         return version;
     }
@@ -96,12 +92,12 @@ type KnownDependencies = 'nrfdl' | 'jprog' | 'JlinkARM';
 
 const findTopLevel = (
     dependencyName: KnownDependencies,
-    dependencies: Dependency[]
+    dependencies: TopLevelDependency[]
 ) => dependencies.find(dependency => dependency.name === dependencyName);
 
 const findInDependencies = (
     dependencyName: KnownDependencies,
-    dependencies: Dependency[]
+    dependencies: TopLevelDependency[]
 ) => {
     if (dependencies.length > 0) {
         return findDependency(
@@ -118,8 +114,8 @@ const findInDependencies = (
 
 export const findDependency = (
     dependencyName: KnownDependencies,
-    versions: Dependency[] = []
-): Dependency | SubDependency | undefined =>
+    versions: TopLevelDependency[] = []
+): Dependency | undefined =>
     findTopLevel(dependencyName, versions) ??
     findInDependencies(dependencyName, versions);
 

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -39,24 +39,29 @@ const parseJsonBuffers = <T>(data: Buffer): T[] | undefined => {
     }
 };
 
-const prepareEnv = (baseDir: string, module: string, version: string) => {
+const cleanedEnv = () => {
     const env = { ...process.env };
-    env.NRFUTIL_HOME = path.join(baseDir, 'nrfutil-sandboxes', module, version);
-    fs.mkdirSync(env.NRFUTIL_HOME, { recursive: true });
-
-    env.NRFUTIL_EXEC_PATH = path.join(env.NRFUTIL_HOME, 'bin');
-
-    if (env.NODE_ENV === 'production' && !env.NRF_OVERRIDE_NRFUTIL_SETTINGS) {
-        delete env.NRFUTIL_BOOTSTRAP_CONFIG_URL;
-        delete env.NRFUTIL_BOOTSTRAP_TARBALL_PATH;
-        delete env.NRFUTIL_DEVICE_PLUGINS_DIR_FORCE_NRFDL_LOCATION;
-        delete env.NRFUTIL_DEVICE_PLUGINS_DIR_FORCE_NRFUTIL_LIBDIR;
-        delete env.NRFUTIL_IGNORE_MISSING_SUBCOMMAND;
-        delete env.NRFUTIL_LOG;
-        delete env.NRFUTIL_PACKAGE_INDEX_URL;
+    if (
+        process.env.NODE_ENV === 'production' &&
+        !process.env.NRF_OVERRIDE_NRFUTIL_SETTINGS
+    ) {
+        Object.keys(env)
+            .filter(name => name.startsWith('NRFUTIL_'))
+            .forEach(name => delete env[name]);
     }
 
     return env;
+};
+
+const prepareEnv = (baseDir: string, module: string, version: string) => {
+    const home = path.join(baseDir, 'nrfutil-sandboxes', module, version);
+    fs.mkdirSync(home, { recursive: true });
+
+    return {
+        ...cleanedEnv(),
+        NRFUTIL_HOME: home,
+        NRFUTIL_EXEC_PATH: path.join(home, 'bin'),
+    };
 };
 
 const commonParser = <Result>(

--- a/nrfutil/sandboxTypes.ts
+++ b/nrfutil/sandboxTypes.ts
@@ -11,12 +11,6 @@ export interface BackgroundTask<T> {
 
 export type LogLevel = 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
 
-export type FeatureClassification =
-    | 'nrf-internal-confidential'
-    | 'nrf-internal'
-    | 'nrf-external-confidential'
-    | 'nrf-external';
-
 export type Task = {
     id: string;
     description: string;
@@ -112,67 +106,3 @@ export type LogMessage = {
     level: 'OFF' | 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE' | 'CRITICAL';
     message: string;
 };
-
-export interface SemanticVersion {
-    major: number;
-    minor: number;
-    patch: number;
-    semverPreNumeric?: number;
-    semverPreAlphaNumeric?: number;
-    semverMetadataNumeric?: number;
-    semverMetadataAlphaNumeric?: number;
-}
-
-type VersionFormat = 'incremental' | 'semantic' | 'string';
-
-export type Plugin = {
-    dependencies: Dependency[];
-    name: string;
-    versionFormat: VersionFormat;
-    version: VersionType;
-};
-
-export type Dependency = {
-    classification?: FeatureClassification;
-    name: string;
-    plugins?: Plugin[];
-    dependencies?: SubDependency[];
-    versionFormat: VersionFormat;
-    version: VersionType;
-};
-
-export type VersionType = SemanticVersion | string | number;
-
-export interface SubDependency {
-    name: string;
-    description?: string;
-    dependencies?: SubDependency[];
-    versionFormat: VersionFormat;
-    version: VersionType;
-}
-
-export type ModuleVersion = {
-    build_timestamp: string;
-    classification: FeatureClassification;
-    commit_date: string;
-    commit_hash: string;
-    dependencies: Dependency[];
-    host: string;
-    name: string;
-    version: string;
-};
-
-export const isSemanticVersion = (
-    version?: SubDependency
-): version is SubDependency & { version: SemanticVersion } =>
-    version?.versionFormat === 'semantic';
-
-export const isIncrementalVersion = (
-    version?: SubDependency
-): version is SubDependency & { version: number } =>
-    version?.versionFormat === 'incremental';
-
-export const isStringVersion = (
-    version?: SubDependency
-): version is SubDependency & { version: string } =>
-    version?.versionFormat === 'string';

--- a/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.tsx
@@ -6,9 +6,9 @@
 
 import React, { ReactNode } from 'react';
 import { getCurrentWindow } from '@electron/remote';
-import { Device } from '@nordicsemiconductor/nrf-device-lib-js';
 
 import Button from '../Button/Button';
+import { Device } from '../Device/deviceSlice';
 import FactoryResetButton from '../FactoryReset/FactoryResetButton';
 import { CollapsibleGroup } from '../SidePanel/Group';
 import Spinner from '../Spinner/Spinner';

--- a/src/logging/sendInitialLogMessages.ts
+++ b/src/logging/sendInitialLogMessages.ts
@@ -6,10 +6,7 @@
 
 import { inMain as appDetails } from '../../ipc/appDetails';
 import NrfutilDeviceLib from '../../nrfutil/device/device';
-import {
-    describeVersion,
-    resolveModuleVersion,
-} from '../../nrfutil/moduleVersion';
+import { describeVersion, findDependency } from '../../nrfutil/moduleVersion';
 import { getAppDataDir } from '../utils/appDirs';
 import logLibVersions from '../utils/logLibVersions';
 import udevInstalled from '../utils/udevInstalled';
@@ -50,7 +47,7 @@ export default async () => {
     if (bundledJlink) {
         const dependencies = (await NrfutilDeviceLib.getModuleVersion())
             .dependencies;
-        const jlinkVersion = resolveModuleVersion('JlinkARM', dependencies);
+        const jlinkVersion = findDependency('JlinkARM', dependencies);
 
         if (!describeVersion(jlinkVersion).includes(bundledJlink)) {
             logger.info(

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -9,13 +9,13 @@ import os from 'os';
 
 import NrfutilDeviceLib from '../../nrfutil/device/device';
 import {
+    Dependency,
     describeVersion,
     findDependency,
-    SubDependency,
 } from '../../nrfutil/moduleVersion';
 import logger from '../logging';
 
-const log = (description: string, moduleVersion?: SubDependency | string) => {
+const log = (description: string, moduleVersion?: Dependency | string) => {
     if (moduleVersion == null) {
         logger.warn(`Unable to detect version of ${description}.`);
     } else {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -12,10 +12,14 @@ import {
     Dependency,
     describeVersion,
     findDependency,
+    ModuleVersion,
 } from '../../nrfutil/moduleVersion';
 import logger from '../logging';
 
-const log = (description: string, moduleVersion?: Dependency | string) => {
+const log = (
+    description: string,
+    moduleVersion?: Dependency | ModuleVersion
+) => {
     if (moduleVersion == null) {
         logger.warn(`Unable to detect version of ${description}.`);
     } else {
@@ -72,7 +76,7 @@ export default async () => {
         const moduleVersion = await NrfutilDeviceLib.getModuleVersion();
         const dependencies = moduleVersion.dependencies;
 
-        log('nrfutil-device', moduleVersion.version);
+        log('nrfutil-device', moduleVersion);
         log('nrf-device-lib', findDependency('nrfdl', dependencies));
         log('nrfjprog DLL', findDependency('jprog', dependencies));
         log('JLink', findDependency('JlinkARM', dependencies));

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -11,8 +11,8 @@ import NrfutilDeviceLib from '../../nrfutil/device/device';
 import {
     describeVersion,
     resolveModuleVersion,
+    SubDependency,
 } from '../../nrfutil/moduleVersion';
-import { SubDependency } from '../../nrfutil/sandboxTypes';
 import logger from '../logging';
 
 const log = (description: string, moduleVersion?: SubDependency | string) => {

--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -10,7 +10,7 @@ import os from 'os';
 import NrfutilDeviceLib from '../../nrfutil/device/device';
 import {
     describeVersion,
-    resolveModuleVersion,
+    findDependency,
     SubDependency,
 } from '../../nrfutil/moduleVersion';
 import logger from '../logging';
@@ -73,9 +73,9 @@ export default async () => {
         const dependencies = moduleVersion.dependencies;
 
         log('nrfutil-device', moduleVersion.version);
-        log('nrf-device-lib', resolveModuleVersion('nrfdl', dependencies));
-        log('nrfjprog DLL', resolveModuleVersion('jprog', dependencies));
-        log('JLink', resolveModuleVersion('JlinkARM', dependencies));
+        log('nrf-device-lib', findDependency('nrfdl', dependencies));
+        log('nrfjprog DLL', findDependency('jprog', dependencies));
+        log('JLink', findDependency('JlinkARM', dependencies));
         if (
             process.platform === 'darwin' &&
             os.cpus()[0].model.includes('Apple')

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -11,10 +11,7 @@ import pretty from 'prettysize';
 import type Systeminformation from 'systeminformation';
 
 import NrfutilDeviceLib from '../../nrfutil/device/device';
-import {
-    describeVersion,
-    resolveModuleVersion,
-} from '../../nrfutil/moduleVersion';
+import { describeVersion, findDependency } from '../../nrfutil/moduleVersion';
 import {
     deviceInfo as getDeviceInfo,
     productPageUrl,
@@ -75,10 +72,10 @@ const generalInfoReport = async () => {
         `    - python3: ${python3}`,
         `    - nrfutil-device: ${moduleVersion.version}`,
         `    - nrfjprog DLL: ${describeVersion(
-            resolveModuleVersion('jprog', dependencies)
+            findDependency('jprog', dependencies)
         )}`,
         `    - JLink: ${describeVersion(
-            resolveModuleVersion('JlinkARM', dependencies)
+            findDependency('JlinkARM', dependencies)
         )}`,
         '',
     ];


### PR DESCRIPTION
Some ideas for the `feat/use-nrfutil-device`. 

Some would rather belong to `feat/nrfutil-device-clean` but I thought it is easier to make them on top of `feat/use-nrfutil-device`. Doing them on the former branch would mean that we would afterwards rebase and adjust the latter branch.

This change swapes the last two parameters of `prepareSandbox` because we have an ESLint rule that default parameters must come last. (The rule does not respect optional parameters, which is a shame) But this change will only affect the launcher minimally.