### PR TITLE
[FIX] Scrollbar overlays modal's content

### DIFF
--- a/src/App/app.scss
+++ b/src/App/app.scss
@@ -67,7 +67,7 @@
 
     .core19-side-panel-container {
         width: $side-panel-width;
-        padding: 0 24px;
+        padding: 0 10px 0 24px; // 24-14(scrollbar width)=10
         background-color: $gray-50;
         height: 100%;
         margin-left: 0;
@@ -77,7 +77,8 @@
             margin-left: -$side-panel-width;
         }
 
-        overflow-y: overlay;
+        overflow-y: scroll;
+
         @include scrollbars($gray-50);
     }
 }


### PR DESCRIPTION
`overflow: overlay` is the reason why scrollbar overlays other content like modals.
Replacing with `overflow: scroll` is fixing this issue https://nordicsemi.atlassian.net/browse/NCD-157

Note: also affects any other areas where scrollbar is used. **If this solution is good to go, same should be applied to every area where scrollbar is used**