### PR TITLE
Feat/link

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ every new version is a new major version.
 -   Logging for nrf-probe-lib
 -   Persisted api keys securely using `getPersistedApiKey` and `persistApiKey`
 -   `xl` size for `Button` component with bigger font.
+-   `ExternalLink` component.
+-   `FileLink` component.
 
 ### Fixed
 
@@ -23,9 +25,15 @@ every new version is a new major version.
 
 -   `Button` component now uses a `size` property instead of a boolean `large`.
 
+### Removed
+
+-   `link` variant of `Button` component.
+
 ### Steps to upgrade
 
 -   Replace `large` properties of the `Button` component with `size="lg"`
+-   Replace any occurrence of `link` variant `Button`s with `ExternalLink` or
+    `FileLink`.
 
 ## 97 - 2023-08-29
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -60,8 +60,6 @@ const Button: React.FC<ButtonProps> = ({
                     'tw-bg-orange tw-text-white active:enabled:tw-bg-orange-700',
                 variant === 'danger' &&
                     'tw-bg-red tw-text-white active:enabled:tw-bg-red-700',
-                variant === 'link' &&
-                    'tw-bg-transparent tw-p-0 tw-text-nordicBlue hover:tw-underline',
                 variant === 'link-button' &&
                     'tw-border tw-border-nordicBlue tw-bg-white tw-text-nordicBlue active:enabled:tw-bg-gray-50',
                 className

--- a/src/Link/ExternalLink.tsx
+++ b/src/Link/ExternalLink.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+
+import classNames from '../utils/classNames';
+
+export default ({ label, href }: { label: string; href: string }) => (
+    <a
+        target="_blank"
+        rel="noreferrer noopener"
+        href={href}
+        className={classNames(
+            'tw-preflight tw-text-nordicBlue hover:tw-underline'
+        )}
+    >
+        {label}
+    </a>
+);

--- a/src/Link/FileLink.tsx
+++ b/src/Link/FileLink.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+
+import classNames from '../utils/classNames';
+import { openFile } from '../utils/open';
+
+export default ({
+    label,
+    fileLocation,
+}: {
+    label: string;
+    fileLocation: string;
+}) => (
+    <button
+        type="button"
+        onClick={() => openFile(fileLocation)}
+        className={classNames(
+            'tw-preflight tw-text-nordicBlue hover:tw-underline'
+        )}
+    >
+        {label}
+    </button>
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ export { default as StartStopButton } from './StartStopButton/StartStopButton';
 export { default as DocumentationSection } from './About/DocumentationSection';
 export { default as Stepper } from './Stepper/Stepper';
 export type { Step } from './Stepper/Stepper';
+export { default as ExternalLink } from './Link/ExternalLink';
+export { default as FileLink } from './Link/FileLink';
 
 export { default as SidePanel } from './SidePanel/SidePanel';
 export { Group, CollapsibleGroup } from './SidePanel/Group';


### PR DESCRIPTION
The `link` variant of the `Button` component currently is annoying to work with when wanting to create links.
- It has inbuilt padding (due to default button styling) which has to either be removed after or requires another check in the classNames.
- It is not inlined by default and needs flex to be centered with other text. 
- You need to add `openFile` or `openUrl` to the `onClick` event.
- The font size was controlled with the `large` property