### PR TITLE
Small changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ every new version is a new major version.
 
 -   Optional property `nrfConnectForDesktop.supportedDevices` in `package.json`.
     Will for now only be used by the Quickstart app.
+-   Output link to where in Azure a release should be created.
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,12 @@ every new version is a new major version.
 -   Optional property `nrfConnectForDesktop.supportedDevices` in `package.json`.
     Will for now only be used by the Quickstart app.
 
+### Fixed
+
+-   List items in dialog bodies had the wrong size: They inherited the size from
+    the document body instead of using the same size as was used in the dialog
+    in paragraphs.
+
 ## 110 - 2023-09-22
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Added
+
+-   Optional property `nrfConnectForDesktop.supportedDevices` in `package.json`.
+    Will for now only be used by the Quickstart app.
+
 ## 110 - 2023-09-22
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## Unreleased
+## 111 - 2023-09-22
 
 ### Added
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -77,7 +77,8 @@ every new version is a new major version.
 
 ### Steps to upgrade
 
--   Update `nrfConnectForDesktop.nrfutil` to version 1.4.2 in `package.json`
+-   Update `nrfConnectForDesktop.nrfutil.device` to version 1.4.2 in
+    `package.json`
 
 ## 102 - 2023-09-05
 

--- a/ipc/MetaFiles.ts
+++ b/ipc/MetaFiles.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { DevicePCA } from '../src/Device/deviceInfo/deviceInfo';
+
 export type UrlString = string;
 
 export interface SourceJson {
@@ -43,6 +45,7 @@ interface ObjectContainingOptionalStrings {
 }
 
 interface NrfConnectForDesktop {
+    supportedDevices?: DevicePCA[];
     nrfutil?: NrfutilModules;
     html?: string;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "110.0.0",
+    "version": "111.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/release-shared.ts
+++ b/scripts/release-shared.ts
@@ -199,6 +199,9 @@ const main = () => {
 
     if (noErrors) {
         doRelease(nextReleaseNumber);
+        console.log(
+            'All done on GitHub. Now go to Azure and create a release there:\nhttps://dev.azure.com/NordicSemiconductor/Wayland/_release?definitionId=33'
+        );
     }
 };
 

--- a/src/Device/deviceInfo/deviceInfo.ts
+++ b/src/Device/deviceInfo/deviceInfo.ts
@@ -43,7 +43,7 @@ import unknownNordicLogo from '!!@svgr!./unknown-nordic-logo.svg';
 
 type Device = NrfutilDevice | WrappedDevice;
 
-type DevicePCA =
+export type DevicePCA =
     | 'PCA10028'
     | 'PCA10031'
     | 'PCA10040'

--- a/src/Dialog/dialog.scss
+++ b/src/Dialog/dialog.scss
@@ -36,7 +36,8 @@
         overflow-wrap: anywhere;
         padding: 32px 16px 16px 16px;
         margin: 0;
-        p {
+        p,
+        li {
             font-size: 14px;
         }
     }


### PR DESCRIPTION
### Added

-   Optional property `nrfConnectForDesktop.supportedDevices` in `package.json`.    Will for now only be used by the Quickstart app.
-   Output link to where in Azure a release should be created.

### Fixed

-   List items in dialog bodies had the wrong size: They inherited the size from    the document body instead of using the same size as was used in the dialog    in paragraphs.
- Old changelog entry.