### PR TITLE
Fix: Spacing in dialog footer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 113 - 2023-09-25
+
+### Fixed
+
+-   The buttons in a dialog footer had too little space between them.
+
 ## 112 - 2023-09-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "112.0.0",
+    "version": "113.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -82,7 +82,7 @@ Dialog.Body = ({ children }: { children: ReactNode }) => (
 );
 
 Dialog.Footer = ({ children }: { children: ReactNode }) => (
-    <Modal.Footer className="tw-preflight tw-flex tw-flex-row-reverse tw-justify-start tw-gap-1 tw-border-none tw-p-4">
+    <Modal.Footer className="tw-preflight tw-flex tw-flex-row-reverse tw-justify-start tw-gap-2 tw-border-none tw-p-4">
         {children}
     </Modal.Footer>
 );


### PR DESCRIPTION
This example component

```jsx
<ConfirmationDialog
    onConfirm={() => {}}
    onCancel={() => {}}
    isVisible
>
    Test
</ConfirmationDialog>
```

was before rendered like this:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/92169e03-6071-45fa-9702-612aa39b95a1)
(note the little space between the buttons). Now it looks like this:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/bc961b96-21ce-4e09-a7dd-c958c0bfc993)

