### PR TITLE
Add NumberInputWithDropdown component

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,12 @@ every new version is a new major version.
 
 ## 121 - 2023-10-20
 
+### Added
+
+-   **NumberInputWithDropdown** component, which combines the
+    **NumberInlineInput** and the **Dropdown** components. Example usage found
+    in `Baudrate.tsx` in `pc-nrfconnect-serial-terminal`.
+
 ### Fixed
 
 -   Device might end up stuck in device list of left event occurred while we are

--- a/src/InlineInput/InlineInput.tsx
+++ b/src/InlineInput/InlineInput.tsx
@@ -57,6 +57,7 @@ interface Props {
     onKeyboardIncrementAction?: () => string;
     onKeyboardDecrementAction?: () => string;
     className?: string;
+    textAlignLeft?: boolean;
 }
 
 const InlineInput = React.forwardRef<HTMLInputElement, Props>(
@@ -70,6 +71,7 @@ const InlineInput = React.forwardRef<HTMLInputElement, Props>(
             onKeyboardIncrementAction = () => externalValue,
             onKeyboardDecrementAction = () => externalValue,
             className = '',
+            textAlignLeft = false,
         },
         ref
     ) => {
@@ -142,12 +144,12 @@ const InlineInput = React.forwardRef<HTMLInputElement, Props>(
             <input
                 ref={ref}
                 type="text"
-                className={classNames(
+                className={`${classNames(
                     'inline-input',
                     isValid(internalValue) || 'invalid',
                     disabled && 'disabled',
                     className
-                )}
+                )} ${textAlignLeft && 'tw-pl-1 tw-text-left'}`}
                 size={
                     Math.max(1, internalValue.length) +
                     (process.platform === 'darwin' ? 2 : 0)

--- a/src/InlineInput/InlineInput.tsx
+++ b/src/InlineInput/InlineInput.tsx
@@ -144,12 +144,13 @@ const InlineInput = React.forwardRef<HTMLInputElement, Props>(
             <input
                 ref={ref}
                 type="text"
-                className={`${classNames(
+                className={classNames(
                     'inline-input',
                     isValid(internalValue) || 'invalid',
                     disabled && 'disabled',
+                    textAlignLeft && 'tw-pl-2 tw-text-left',
                     className
-                )} ${textAlignLeft && 'tw-pl-2 tw-text-left'}`}
+                )}
                 size={
                     Math.max(1, internalValue.length) +
                     (process.platform === 'darwin' ? 2 : 0)

--- a/src/InlineInput/InlineInput.tsx
+++ b/src/InlineInput/InlineInput.tsx
@@ -149,7 +149,7 @@ const InlineInput = React.forwardRef<HTMLInputElement, Props>(
                     isValid(internalValue) || 'invalid',
                     disabled && 'disabled',
                     className
-                )} ${textAlignLeft && 'tw-pl-1 tw-text-left'}`}
+                )} ${textAlignLeft && 'tw-pl-2 tw-text-left'}`}
                 size={
                     Math.max(1, internalValue.length) +
                     (process.platform === 'darwin' ? 2 : 0)

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -27,7 +27,8 @@ export interface NumberInlineInput {
     onChange: (value: number) => void;
     onChangeComplete?: (value: number) => void;
     textAlignLeft?: boolean;
-    valueIsValidCallback?: (validity: boolean) => void;
+    onValidityChanged?: (validity: boolean) => void;
+    preventDefaultInvalidStyle?: boolean;
 }
 
 const isInValues = (value: number, values: Values) => values.includes(value);
@@ -88,7 +89,8 @@ export default ({
     onChange,
     onChangeComplete = () => {},
     textAlignLeft,
-    valueIsValidCallback,
+    onValidityChanged,
+    preventDefaultInvalidStyle,
 }: NumberInlineInput) => {
     useValidatedRangeOrValues(range);
 
@@ -97,15 +99,6 @@ export default ({
             className={`${className} number-inline-input`}
             disabled={disabled}
             value={String(value)}
-            isValid={newValue => {
-                const validity = isValid(Number(newValue), range);
-                if (valueIsValidCallback != null) {
-                    // Then propagate the validity back to parent
-                    valueIsValidCallback(validity);
-                    return true;
-                }
-                return validity;
-            }}
             onChange={newValue => onChange(Number(newValue))}
             onChangeComplete={newValue => onChangeComplete(Number(newValue))}
             onKeyboardIncrementAction={() =>
@@ -115,6 +108,16 @@ export default ({
                 changeValueStepwise(value, range, -1).toString()
             }
             textAlignLeft={textAlignLeft}
+            isValid={newValue => {
+                const validity = isValid(Number(newValue), range);
+                if (onValidityChanged != null) {
+                    // Then propagate the validity back to parent
+                    onValidityChanged(validity);
+                }
+                return validity;
+            }}
+            onValidityChanged={onValidityChanged}
+            preventDefaultInvalidStyle={preventDefaultInvalidStyle}
         />
     );
 };

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -27,6 +27,7 @@ export interface NumberInlineInput {
     onChange: (value: number) => void;
     onChangeComplete?: (value: number) => void;
     textAlignLeft?: boolean;
+    valueIsValidCallback?: (validity: boolean) => void;
 }
 
 const isInValues = (value: number, values: Values) => values.includes(value);
@@ -87,7 +88,7 @@ export default ({
     onChange,
     onChangeComplete = () => {},
     textAlignLeft,
-    valueIsInvalidCallback,
+    valueIsValidCallback,
 }: NumberInlineInput) => {
     useValidatedRangeOrValues(range);
 
@@ -96,7 +97,15 @@ export default ({
             className={`${className} number-inline-input`}
             disabled={disabled}
             value={String(value)}
-            isValid={newValue => isValid(Number(newValue), range)}
+            isValid={newValue => {
+                const validity = isValid(Number(newValue), range);
+                if (valueIsValidCallback != null) {
+                    // Then propagate the validity back to parent
+                    valueIsValidCallback(validity);
+                    return true;
+                }
+                return validity;
+            }}
             onChange={newValue => onChange(Number(newValue))}
             onChangeComplete={newValue => onChangeComplete(Number(newValue))}
             onKeyboardIncrementAction={() =>

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 
 import { isFactor } from '../Slider/factor';
 import {
@@ -19,7 +19,7 @@ import InlineInput from './InlineInput';
 
 import './number-inline-input.scss';
 
-export interface Props {
+export interface NumberInlineInput {
     disabled?: boolean;
     value: number;
     range: RangeOrValues;
@@ -79,7 +79,7 @@ const changeValueStepwise = (
     return nextValue != null ? nextValue : current;
 };
 
-const NumberInlineInput: FC<Props> = ({
+export default ({
     disabled,
     value,
     range,
@@ -87,7 +87,8 @@ const NumberInlineInput: FC<Props> = ({
     onChange,
     onChangeComplete = () => {},
     textAlignLeft,
-}) => {
+    valueIsInvalidCallback,
+}: NumberInlineInput) => {
     useValidatedRangeOrValues(range);
 
     return (
@@ -108,5 +109,3 @@ const NumberInlineInput: FC<Props> = ({
         />
     );
 };
-
-export default NumberInlineInput;

--- a/src/InlineInput/NumberInlineInput.tsx
+++ b/src/InlineInput/NumberInlineInput.tsx
@@ -23,8 +23,10 @@ export interface Props {
     disabled?: boolean;
     value: number;
     range: RangeOrValues;
+    className?: string;
     onChange: (value: number) => void;
     onChangeComplete?: (value: number) => void;
+    textAlignLeft?: boolean;
 }
 
 const isInValues = (value: number, values: Values) => values.includes(value);
@@ -81,14 +83,16 @@ const NumberInlineInput: FC<Props> = ({
     disabled,
     value,
     range,
+    className,
     onChange,
     onChangeComplete = () => {},
+    textAlignLeft,
 }) => {
     useValidatedRangeOrValues(range);
 
     return (
         <InlineInput
-            className="number-inline-input"
+            className={`${className} number-inline-input`}
             disabled={disabled}
             value={String(value)}
             isValid={newValue => isValid(Number(newValue), range)}
@@ -100,6 +104,7 @@ const NumberInlineInput: FC<Props> = ({
             onKeyboardDecrementAction={() =>
                 changeValueStepwise(value, range, -1).toString()
             }
+            textAlignLeft={textAlignLeft}
         />
     );
 };

--- a/src/InlineInput/NumberInputWithDropdown.tsx
+++ b/src/InlineInput/NumberInputWithDropdown.tsx
@@ -43,7 +43,7 @@ export default ({
 }: DropdownProps) => {
     const [isActive, setIsActive] = useState(false);
     const [inlineValue, setInlineValue] = useState(value);
-    const [valueIsValid, setValueIsValid] = useState(true);
+    const [isValid, setIsValid] = useState(true);
 
     const setNewValue = (newValue: number) => {
         setInlineValue(newValue);
@@ -74,12 +74,11 @@ export default ({
                     onChange={val => setInlineValue(val)}
                     onChangeComplete={val => setNewValue(val)}
                     className={`tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-underline tw-underline-offset-2 ${
-                        valueIsValid
-                            ? 'tw-decoration-white'
-                            : 'tw-decoration-red'
+                        isValid ? 'tw-decoration-white' : 'tw-decoration-red'
                     }`}
                     textAlignLeft
-                    valueIsValidCallback={setValueIsValid}
+                    onValidityChanged={setIsValid}
+                    preventDefaultInvalidStyle
                 />
                 <button
                     id={id}

--- a/src/InlineInput/NumberInputWithDropdown.tsx
+++ b/src/InlineInput/NumberInputWithDropdown.tsx
@@ -1,47 +1,53 @@
 /*
- * Copyright (c) 2015 Nordic Semiconductor ASA
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
 import React, { useState } from 'react';
-import FormLabel from 'react-bootstrap/FormLabel';
+import FormLabel from 'react-bootstrap/esm/FormLabel';
 
+import { DropdownItem } from '../Dropdown/Dropdown';
 import classNames from '../utils/classNames';
+import NumberInlineInput from './NumberInlineInput';
 
-import styles from './Dropdown.module.scss';
+import styles from '../Dropdown/Dropdown.module.scss';
 
-export interface DropdownItem<T = string> {
-    label: React.ReactNode;
-    value: T;
-}
+export type NumberDropdownItem = DropdownItem<number>;
 
-export interface DropdownProps {
+interface DropdownProps {
     id?: string;
     label?: React.ReactNode;
-    items: DropdownItem[];
-    onSelect: (item: DropdownItem) => void;
-    disabled?: boolean;
-    selectedItem: DropdownItem;
+    items: NumberDropdownItem[];
+    value: number;
+    onChange: (value: number) => void;
     numItemsBeforeScroll?: number;
     className?: string;
+    disabled?: boolean;
 }
 
 export default ({
     id,
     label,
     items,
-    onSelect,
-    disabled = false,
-    selectedItem,
+    value,
+    onChange,
     numItemsBeforeScroll = 0,
     className = '',
+    disabled = false,
 }: DropdownProps) => {
     const [isActive, setIsActive] = useState(false);
+    const [inlineValue, setInlineValue] = useState(value);
 
-    const onClickItem = (item: DropdownItem) => {
-        onSelect(item);
+    const setNewValue = (newValue: number) => {
+        setInlineValue(newValue);
+        onChange(newValue);
         setIsActive(false);
+    };
+    const onClickItem = (item: NumberDropdownItem) => {
+        if (item.value != null && typeof item.value === 'number') {
+            setNewValue(item.value);
+        }
     };
 
     return (
@@ -53,27 +59,30 @@ export default ({
                 }
             }}
         >
-            {label && (
-                <FormLabel className="tw-mb-1 tw-text-xs">{label}</FormLabel>
-            )}
-            <button
-                id={id}
-                type="button"
-                className="tw-flex tw-h-8 tw-w-full tw-items-center tw-justify-between tw-border-0 tw-bg-gray-700 tw-px-2 tw-text-white"
-                onClick={() => setIsActive(!isActive)}
-                disabled={disabled}
-            >
-                <span>
-                    {items.findIndex(e => e.value === selectedItem.value) === -1
-                        ? ''
-                        : selectedItem.label}
-                </span>
-                <span
-                    className={`mdi mdi-chevron-down tw-text-lg ${classNames(
-                        isActive && 'tw-rotate-180'
-                    )}`}
+            <FormLabel className="tw-mb-1 tw-text-xs">{label}</FormLabel>
+            <div className="tw-flex tw-h-8 tw-w-full">
+                <NumberInlineInput
+                    value={inlineValue}
+                    range={{ min: 1, max: 1_000_000, step: 1, decimals: 0 }}
+                    onChange={val => setInlineValue(val)}
+                    onChangeComplete={val => setNewValue(val)}
+                    className="tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-outline-white"
+                    textAlignLeft
                 />
-            </button>
+                <button
+                    id={id}
+                    type="button"
+                    className="tw-overflow-hidden tw-border-b tw-border-solid tw-border-b-gray-200 tw-bg-gray-700 tw-px-2 tw-text-white"
+                    onClick={() => setIsActive(!isActive)}
+                    disabled={disabled}
+                >
+                    <span
+                        className={`mdi mdi-chevron-down tw-text-lg ${classNames(
+                            isActive && 'tw-rotate-180'
+                        )}`}
+                    />
+                </button>
+            </div>
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- We need an interactive handler as described below */}
             <div
                 onMouseDown={ev => {

--- a/src/InlineInput/NumberInputWithDropdown.tsx
+++ b/src/InlineInput/NumberInputWithDropdown.tsx
@@ -12,6 +12,7 @@ import classNames from '../utils/classNames';
 import NumberInlineInput from './NumberInlineInput';
 
 import styles from '../Dropdown/Dropdown.module.scss';
+import { RangeOrValues } from '../Slider/range';
 
 export type NumberDropdownItem = DropdownItem<number>;
 
@@ -21,6 +22,7 @@ interface DropdownProps {
     items: NumberDropdownItem[];
     value: number;
     onChange: (value: number) => void;
+    range: RangeOrValues;
     numItemsBeforeScroll?: number;
     className?: string;
     disabled?: boolean;
@@ -32,6 +34,7 @@ export default ({
     items,
     value,
     onChange,
+    range,
     numItemsBeforeScroll = 0,
     className = '',
     disabled = false,
@@ -63,7 +66,7 @@ export default ({
             <div className="tw-flex tw-h-8 tw-w-full">
                 <NumberInlineInput
                     value={inlineValue}
-                    range={{ min: 1, max: 1_000_000, step: 1, decimals: 0 }}
+                    range={range}
                     onChange={val => setInlineValue(val)}
                     onChangeComplete={val => setNewValue(val)}
                     className="tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-outline-white"

--- a/src/InlineInput/NumberInputWithDropdown.tsx
+++ b/src/InlineInput/NumberInputWithDropdown.tsx
@@ -26,6 +26,7 @@ interface DropdownProps {
     numItemsBeforeScroll?: number;
     className?: string;
     disabled?: boolean;
+    title?: string;
 }
 
 export default ({
@@ -38,6 +39,7 @@ export default ({
     numItemsBeforeScroll = 0,
     className = '',
     disabled = false,
+    title,
 }: DropdownProps) => {
     const [isActive, setIsActive] = useState(false);
     const [inlineValue, setInlineValue] = useState(value);
@@ -62,6 +64,7 @@ export default ({
                     setIsActive(false);
                 }
             }}
+            title={title}
         >
             <FormLabel className="tw-mb-1 tw-text-xs">{label}</FormLabel>
             <div className="tw-flex tw-h-8 tw-w-full">

--- a/src/InlineInput/NumberInputWithDropdown.tsx
+++ b/src/InlineInput/NumberInputWithDropdown.tsx
@@ -8,11 +8,11 @@ import React, { useState } from 'react';
 import FormLabel from 'react-bootstrap/esm/FormLabel';
 
 import { DropdownItem } from '../Dropdown/Dropdown';
+import { RangeOrValues } from '../Slider/range';
 import classNames from '../utils/classNames';
 import NumberInlineInput from './NumberInlineInput';
 
 import styles from '../Dropdown/Dropdown.module.scss';
-import { RangeOrValues } from '../Slider/range';
 
 export type NumberDropdownItem = DropdownItem<number>;
 
@@ -70,8 +70,10 @@ export default ({
                     range={range}
                     onChange={val => setInlineValue(val)}
                     onChangeComplete={val => setNewValue(val)}
-                    className={`tw-underline tw-underline-offset-2 tw-decoration-white tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-outline-white ${
-                        valueIsValid ? '' : 'tw-decoration-red'
+                    className={`tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-underline tw-underline-offset-2 ${
+                        valueIsValid
+                            ? 'tw-decoration-white'
+                            : 'tw-decoration-red'
                     }`}
                     textAlignLeft
                     valueIsValidCallback={setValueIsValid}

--- a/src/InlineInput/NumberInputWithDropdown.tsx
+++ b/src/InlineInput/NumberInputWithDropdown.tsx
@@ -41,6 +41,7 @@ export default ({
 }: DropdownProps) => {
     const [isActive, setIsActive] = useState(false);
     const [inlineValue, setInlineValue] = useState(value);
+    const [valueIsValid, setValueIsValid] = useState(true);
 
     const setNewValue = (newValue: number) => {
         setInlineValue(newValue);
@@ -69,8 +70,11 @@ export default ({
                     range={range}
                     onChange={val => setInlineValue(val)}
                     onChangeComplete={val => setNewValue(val)}
-                    className="tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-outline-white"
+                    className={`tw-underline tw-underline-offset-2 tw-decoration-white tw-x-2 tw-h-full tw-w-full tw-bg-gray-700 tw-text-white tw-outline-white ${
+                        valueIsValid ? '' : 'tw-decoration-red'
+                    }`}
                     textAlignLeft
+                    valueIsValidCallback={setValueIsValid}
                 />
                 <button
                     id={id}
@@ -103,7 +107,7 @@ export default ({
                     numItemsBeforeScroll > 0 &&
                     items.length > numItemsBeforeScroll
                 }
-                className={`tw-text-while tw-absolute tw-right-0 tw-z-10 tw-w-full tw-border-t-2 tw-border-solid tw-border-gray-600 tw-bg-gray-700 tw-p-0 ${classNames(
+                className={`tw-text-while tw-absolute tw-right-0 tw-z-10 tw-w-full tw-bg-gray-700 tw-p-0 ${classNames(
                     styles.content,
                     !isActive && 'tw-hidden'
                 )}`}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export { Group, CollapsibleGroup } from './SidePanel/Group';
 export { default as InlineInput } from './InlineInput/InlineInput';
 export { default as NumberInlineInput } from './InlineInput/NumberInlineInput';
 export { default as NumberInputSliderWithUnit } from './NumberInputWithSlider/NumberInputSliderWithUnit';
+export { default as NumberInputWithDropdown } from './InlineInput/NumberInputWithDropdown';
 
 export { default as Spinner } from './Spinner/Spinner';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export { default as InlineInput } from './InlineInput/InlineInput';
 export { default as NumberInlineInput } from './InlineInput/NumberInlineInput';
 export { default as NumberInputSliderWithUnit } from './NumberInputWithSlider/NumberInputSliderWithUnit';
 export { default as NumberInputWithDropdown } from './InlineInput/NumberInputWithDropdown';
+export type { NumberDropdownItem } from './InlineInput/NumberInputWithDropdown';
 
 export { default as Spinner } from './Spinner/Spinner';
 


### PR DESCRIPTION
For now the implementation is quite specific for serial-terminal, but will hopefully evolve and be more generic in the future.

How it works is that when you click on the component, it will work as any other NumberInlineInput component, or if you click the chevron on the right, you will see a list of dropdown items to select from.

The implementation design-wise is equivalent to the Dropdown component.

**Baud Rate** is using the new NumberInputWithDropdown component, and **Data bits** is using the Dropdown component.
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/34618612/063f788d-cbee-470e-b990-c33fdf9566c0)

You can type in anything you want, but will see that the input is invalid when it is invalid.
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/34618612/5db28a16-01ea-4e5c-8adb-dca1a547f628)

When you click the Chevron, you see the list of items to select from. When an item is selected, the input field will immediately be updated to that value.
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/34618612/7c278764-2ed8-435d-8301-aa7fbb444e43)





