### PR TITLE
Rework `packageJson.ts`

### DIFF
--- a/ipc/schema/packageJson.ts
+++ b/ipc/schema/packageJson.ts
@@ -10,6 +10,20 @@ import { knownDevicePcas } from '../device';
 import { nrfModules, semver } from '../MetaFiles';
 import { parseWithPrettifiedErrorMessage } from './parseJson';
 
+const packageJson = z.object({
+    name: z.string(),
+    version: semver,
+
+    displayName: z.string().optional(),
+});
+
+export type PackageJson = z.infer<typeof packageJson>;
+
+export const parsePackageJson =
+    parseWithPrettifiedErrorMessage<PackageJson>(packageJson);
+
+// Apps have more required fields in their package.json
+
 const nrfConnectForDesktop = z.object({
     supportedDevices: z.enum(knownDevicePcas).array().nonempty().optional(),
     nrfutil: nrfModules.optional(),
@@ -22,12 +36,7 @@ const engines = recordOfOptionalStrings.and(
     z.object({ nrfconnect: z.string() })
 );
 
-const appPackageJson = z.object({
-    name: z.string(),
-    version: semver,
-
-    author: z.string().optional(),
-    bin: z.string().or(recordOfOptionalStrings).optional(),
+const packageJsonApp = packageJson.extend({
     dependencies: recordOfOptionalStrings.optional(),
     description: z.string(),
     homepage: z.string().url().optional(),
@@ -36,8 +45,6 @@ const appPackageJson = z.object({
     engines,
     nrfConnectForDesktop,
     files: z.string().array().optional(),
-    license: z.string().optional(),
-    main: z.string().optional(),
     peerDependencies: recordOfOptionalStrings.optional(),
     repository: z
         .object({
@@ -45,48 +52,22 @@ const appPackageJson = z.object({
             url: z.string().url(),
         })
         .optional(),
-    scripts: recordOfOptionalStrings.optional(),
 });
 
-export type AppPackageJson = z.infer<typeof appPackageJson>;
+export type PackageJsonApp = z.infer<typeof packageJsonApp>;
 
-export const parseAppPackageJson =
-    parseWithPrettifiedErrorMessage<AppPackageJson>(appPackageJson);
+export const parsePackageJsonApp =
+    parseWithPrettifiedErrorMessage<PackageJsonApp>(packageJsonApp);
 
 // In the launcher we want to handle that the whole nrfConnectForDesktop may be missing
 // and the html in it can also be undefined, so there we need to use this legacy variant
-const legacyAppPackageJson = appPackageJson.merge(
-    z.object({
-        nrfConnectForDesktop: nrfConnectForDesktop
-            .partial({ html: true })
-            .optional(),
-    })
-);
-
-export type LegacyAppPackageJson = z.infer<typeof legacyAppPackageJson>;
-
-export const parseAppLegacyPackageJson =
-    parseWithPrettifiedErrorMessage<LegacyAppPackageJson>(legacyAppPackageJson);
-
-const launcherPackageJson = z.object({
-    name: z.string(),
-    version: semver,
-    description: z.string(),
-    repository: z
-        .object({
-            type: z.string(),
-            url: z.string().url(),
-        })
+const packageJsonLegacyApp = packageJsonApp.extend({
+    nrfConnectForDesktop: nrfConnectForDesktop
+        .partial({ html: true })
         .optional(),
-    main: z.string().optional(),
-    scripts: recordOfOptionalStrings.optional(),
-    author: z.string().optional(),
-    license: z.string().optional(),
-    dependencies: recordOfOptionalStrings.optional(),
-    devDependencies: recordOfOptionalStrings.optional(),
 });
 
-export type LauncherPackageJson = z.infer<typeof launcherPackageJson>;
+export type PackageJsonLegacyApp = z.infer<typeof packageJsonLegacyApp>;
 
-export const parseLauncherPackageJson =
-    parseWithPrettifiedErrorMessage<LauncherPackageJson>(launcherPackageJson);
+export const parsePackageJsonLegacyApp =
+    parseWithPrettifiedErrorMessage<PackageJsonLegacyApp>(packageJsonLegacyApp);

--- a/main/index.ts
+++ b/main/index.ts
@@ -37,10 +37,10 @@ export {
     type WithdrawnJson,
 } from '../ipc/MetaFiles';
 export {
-    type LegacyAppPackageJson,
-    type AppPackageJson,
-    parseAppLegacyPackageJson,
-    parseAppPackageJson,
+    type PackageJsonLegacyApp,
+    type PackageJsonApp,
+    parsePackageJsonLegacyApp,
+    parsePackageJsonApp,
 } from '../ipc/schema/packageJson';
 
 export { type OverwriteOptions } from '../ipc/serialPort';

--- a/mocks/packageJsonMock.ts
+++ b/mocks/packageJsonMock.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-export default () => ({
+export const packageJson = () => ({
     name: 'mocked-test-app',
     version: '27.6.72',
 });

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { parsedAppPackageJson } from '../src/utils/packageJson';
+import { packageJsonApp } from '../src/utils/packageJson';
 import {
     Dependency,
     isIncrementalVersion,
@@ -69,7 +69,7 @@ const overriddenVersion = (module: string) => {
 };
 
 const versionFromPackageJson = (module: string) =>
-    parsedAppPackageJson().nrfConnectForDesktop.nrfutil?.[module][0];
+    packageJsonApp().nrfConnectForDesktop.nrfutil?.[module][0];
 
 const failToDetermineVersion = (module: string) => {
     throw new Error(`No version specified for nrfutil-${module}`);

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -10,7 +10,7 @@ import { execSync } from 'child_process';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import property from 'lodash/property';
 
-import { AppPackageJson, parseAppPackageJson } from '../ipc/schema/packageJson';
+import { PackageJsonApp, parsePackageJsonApp } from '../ipc/schema/packageJson';
 
 const format = (strings: string[]) =>
     strings.map(string => `\`${string}\``).join(', ');
@@ -61,7 +61,7 @@ const mustContainOneOf = (
     }
 };
 
-const checkRepoUrl = (packageJson: AppPackageJson) => {
+const checkRepoUrl = (packageJson: PackageJsonApp) => {
     if (!existsSync('./.git')) {
         return;
     }
@@ -88,7 +88,7 @@ const checkRepoUrl = (packageJson: AppPackageJson) => {
     }
 };
 
-const checkOptionalProperties = (packageJson: AppPackageJson) => {
+const checkOptionalProperties = (packageJson: PackageJsonApp) => {
     if (propertyIsMissing(packageJson)('homepage')) {
         warn('Please provide a property `homepage` in package.json.');
     }
@@ -100,7 +100,7 @@ const checkOptionalProperties = (packageJson: AppPackageJson) => {
     }
 };
 
-const checkFileProperty = (packageJson: AppPackageJson) => {
+const checkFileProperty = (packageJson: PackageJsonApp) => {
     mustContain(
         packageJson.files ?? [],
         ['LICENSE', 'dist/', 'Changelog.md'],
@@ -115,7 +115,7 @@ const checkFileProperty = (packageJson: AppPackageJson) => {
 };
 
 const readAndCheckPackageJson = () => {
-    const packageJsonResult = parseAppPackageJson(
+    const packageJsonResult = parsePackageJsonApp(
         readFileSync('./package.json', 'utf8')
     );
 
@@ -136,7 +136,7 @@ const changelogEntryRegexp = (version?: string) =>
     new RegExp(`^## ${version}`, 'mi');
 
 const checkChangelog = (
-    packageJson: AppPackageJson,
+    packageJson: PackageJsonApp,
     checkChangelogHasCurrentEntry: boolean
 ) => {
     if (!existsSync('./Changelog.md')) {

--- a/scripts/esbuild.ts
+++ b/scripts/esbuild.ts
@@ -8,11 +8,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { parseAppPackageJson } from '../ipc/schema/packageJson';
+import { parsePackageJsonApp } from '../ipc/schema/packageJson';
 import { build } from './esbuild-renderer';
 
 const validate = (packageJson: string) => {
-    const result = parseAppPackageJson(packageJson);
+    const result = parsePackageJsonApp(packageJson);
 
     if (!result.success) {
         console.log(result.error.message);
@@ -42,7 +42,7 @@ const bundle = () => {
 
     build({
         define: {
-            'process.env.PACKAGE_JSON_OF_APP': JSON.stringify(packageJson),
+            'process.env.PACKAGE_JSON': JSON.stringify(packageJson),
         },
         entryPoints: [entry()],
     });

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -14,7 +14,7 @@ import semver from 'semver';
 import calculateShasum from 'shasum';
 
 import { AppInfo, SourceJson } from '../ipc/MetaFiles';
-import { AppPackageJson } from '../ipc/schema/packageJson';
+import { PackageJsonApp } from '../ipc/schema/packageJson';
 import checkAppProperties from './check-app-properties';
 
 interface LegacyAppInfo {
@@ -41,7 +41,7 @@ interface App {
     releaseNotesFilename: string;
     iconFilename: string;
     isOfficial: boolean;
-    packageJson: AppPackageJson;
+    packageJson: PackageJsonApp;
 }
 
 const client = new FtpClient();
@@ -113,7 +113,7 @@ const parseOptions = (): Options => {
     };
 };
 
-const readPackageJson = (): AppPackageJson =>
+const readPackageJson = (): PackageJsonApp =>
     JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
 
 const packPackage = () => {

--- a/scripts/release-shared.ts
+++ b/scripts/release-shared.ts
@@ -25,7 +25,7 @@
 */
 import { execSync, spawnSync } from 'node:child_process';
 
-import { AppPackageJson } from '../ipc/schema/packageJson';
+import { PackageJsonApp } from '../ipc/schema/packageJson';
 
 const logError = (message: string) => {
     console.error(message);
@@ -88,7 +88,7 @@ export const packageJsonIsCorrect = (
     }
 ) => {
     const expectedVersionString = `${expectedVersionNumber}.0.0`;
-    const actualVersionString = parseJson<AppPackageJson>(packageJson).version;
+    const actualVersionString = parseJson<PackageJsonApp>(packageJson).version;
 
     return equality(
         expectedVersionString,

--- a/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.tsx
@@ -7,14 +7,13 @@
 import React, { ReactNode } from 'react';
 import { getCurrentWindow } from '@electron/remote';
 
-import { AppPackageJson } from '../../main';
 import Button from '../Button/Button';
 import { Device } from '../Device/deviceSlice';
 import FactoryResetButton from '../FactoryReset/FactoryResetButton';
 import { CollapsibleGroup } from '../SidePanel/Group';
 import Spinner from '../Spinner/Spinner';
 import { openUrl } from '../utils/open';
-import packageJson from '../utils/packageJson';
+import { packageJson } from '../utils/packageJson';
 import { getAppSpecificStore as store } from '../utils/persistentStore';
 import { generateSystemReport } from '../utils/systemReport';
 import usageData from '../utils/usageData';
@@ -92,9 +91,7 @@ class ErrorBoundary extends React.Component<
         }
 
         const appDisplayName =
-            appName ||
-            ((packageJson() as AppPackageJson).displayName ??
-                packageJson()?.name);
+            appName || packageJson().displayName || packageJson().name;
 
         return (
             <div className="error-boundary__container">

--- a/src/Feedback/sendFeedback.ts
+++ b/src/Feedback/sendFeedback.ts
@@ -5,18 +5,16 @@
  */
 
 import { isDevelopment } from '../utils/environment';
-import packageJson from '../utils/packageJson';
+import { packageJson } from '../utils/packageJson';
 
 const formURL =
     isDevelopment === true
         ? 'https://formkeep.com/f/87deb409a565'
         : 'https://formkeep.com/f/36b394b92851';
 
-const getAppName = () => packageJson().name;
-
 export default async (feedback: string, category?: string) => {
     const data: Record<string, unknown> = {
-        name: getAppName(),
+        name: packageJson().name,
         feedback,
         platform: process.platform,
     };

--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -7,7 +7,7 @@
 import path from 'path';
 
 import { OFFICIAL } from '../../ipc/sources';
-import { parsedAppPackageJson } from './packageJson';
+import { packageJsonApp } from './packageJson';
 
 const getUserDataDir = () => {
     const argv = process.argv;
@@ -28,7 +28,7 @@ const getUserDataDir = () => {
  * @returns {string|undefined} Absolute path of current app.
  */
 const getAppDir = () => {
-    const html = parsedAppPackageJson().nrfConnectForDesktop.html;
+    const html = packageJsonApp().nrfConnectForDesktop.html;
     const dir = path.parse(html).dir;
     return path.parse(__filename).dir.replace(dir, '');
 };

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -11,7 +11,7 @@ import { v4 as uuid } from 'uuid';
 
 import { inMain as safeStorage } from '../../ipc/safeStorage';
 import logger from '../logging';
-import packageJson from './packageJson';
+import { packageJson } from './packageJson';
 
 export interface SerialSettings {
     serialPortOptions: Omit<SerialPortOpenOptions<AutoDetectTypes>, 'path'>;

--- a/src/utils/usageData.ts
+++ b/src/utils/usageData.ts
@@ -6,12 +6,8 @@
 
 import winston from 'winston';
 
-import {
-    AppPackageJson,
-    LauncherPackageJson,
-} from '../../ipc/schema/packageJson';
 import { type Device } from '../Device/deviceSlice';
-import packageJson from './packageJson';
+import { packageJson } from './packageJson';
 import {
     deleteIsSendingUsageData,
     getIsSendingUsageData,
@@ -42,8 +38,8 @@ export const simplifyDeviceForLogging = (device: Device) => ({
     },
 });
 
-const getFriendlyAppName = (json: AppPackageJson | LauncherPackageJson) =>
-    (json.name ?? '').replace('pc-nrfconnect-', '');
+const getFriendlyAppName = () =>
+    packageJson().name.replace('pc-nrfconnect-', '');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const flattenObject = (obj?: any, parentKey?: string) => {
@@ -105,7 +101,7 @@ const sendUsageData = <T extends string>(
 ) => {
     if (
         getUsageData().sendUsageData(
-            `${getFriendlyAppName(packageJson())}: ${action}`,
+            `${getFriendlyAppName()}: ${action}`,
             flattenObject(metadata),
             forceSend
         )
@@ -115,9 +111,7 @@ const sendUsageData = <T extends string>(
 };
 
 const sendPageView = (pageName: string) => {
-    getUsageData().sendPageView(
-        `${getFriendlyAppName(packageJson())} - ${pageName}`
-    );
+    getUsageData().sendPageView(`${getFriendlyAppName()} - ${pageName}`);
 };
 
 const sendMetric = (name: string, average: number) => {

--- a/src/utils/usageDataMain.ts
+++ b/src/utils/usageDataMain.ts
@@ -7,7 +7,7 @@
 import { TelemetryClient } from 'applicationinsights';
 
 import { isDevelopment } from './environment';
-import packageJson from './packageJson';
+import { packageJson } from './packageJson';
 import { getIsSendingUsageData } from './persistentStore';
 import { type Metadata } from './usageData';
 

--- a/src/utils/usageDataRenderer.ts
+++ b/src/utils/usageDataRenderer.ts
@@ -8,7 +8,7 @@ import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
 import { getAppSource } from './appDirs';
 import { isDevelopment } from './environment';
-import packageJson from './packageJson';
+import { packageJson } from './packageJson';
 import { getIsSendingUsageData, getUsageDataClientId } from './persistentStore';
 import { type Metadata } from './usageData';
 


### PR DESCRIPTION
- Do not mix default and named exports, instead now have two explicit named exports: `packageJson` and `packageJsonApp`. The former is enough in mos cases, the latter has to be used if especially the package.json of an app is required.
- Unify the required env variables `PACKAGE_JSON_OF_APP` and `PACKAGE_JSON_OF_RENDERER` to be just `PACKAGE_JSON`.