### PR TITLE
Switch some code to IPC calls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ every new version is a new major version.
 
 -   Analytic events names are now distinct with a prefix of the app name
     `<AppName>:` e.g `npm:` or `ppk:`.
+-   The function to send telemetry data in `usageData` became async. If you have
+    to be sure they completed, you now have to await them.
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,8 @@ every new version is a new major version.
 
 ### Added
 
--   PID to `nrfutil device` logs when trace is enabled
+-   PID to `nrfutil device` logs when trace is enabled.
+-   `launcherConfig` to retrieve the launcher config in any renderer process.
 
 ### Changed
 
@@ -21,6 +22,10 @@ every new version is a new major version.
 ### Fixed
 
 -   Serial port in the device list where not aligned correctly
+
+### Steps to upgrade when using this package
+
+-   In `package.json` bump `engines.nrfconnect` to at least `>=4.2.2`.
 
 ## 122 - 2023-11-02
 

--- a/ipc/launcherConfig.ts
+++ b/ipc/launcherConfig.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { ipcMain, ipcRenderer } from 'electron';
+
+export interface Configuration {
+    isRunningLauncherFromSource: boolean;
+    isSkipUpdateApps: boolean;
+    isSkipUpdateLauncher: boolean;
+    launcherVersion: string;
+    userDataDir: string;
+}
+const channel = 'get-config';
+
+const getConfig = (): Configuration => ipcRenderer.sendSync(channel);
+const registerGetConfig = (config: Configuration) =>
+    ipcMain.on(channel, event => {
+        event.returnValue = config;
+    });
+
+export const forRenderer = { registerGetConfig };
+export const inMain = { getConfig };

--- a/main/index.ts
+++ b/main/index.ts
@@ -6,6 +6,7 @@
 
 import { forRenderer as forRendererAppDetails } from '../ipc/appDetails';
 import { forRenderer as forRendererApps } from '../ipc/apps';
+import { forRenderer as forRendererLauncherConfig } from '../ipc/launcherConfig';
 import { forRenderer as forRendererOpenWindow } from '../ipc/openWindow';
 import { forRenderer as forRendererPreventSleep } from '../ipc/preventSleep';
 import { forRenderer as forRendererSafeStorage } from '../ipc/safeStorage';
@@ -18,6 +19,7 @@ export { registerLauncherWindowFromMain } from '../ipc/infrastructure/mainToRend
 
 export const appDetails = { forRenderer: forRendererAppDetails };
 export const apps = { forRenderer: forRendererApps };
+export const launcherConfig = { forRenderer: forRendererLauncherConfig };
 export const openWindow = { forRenderer: forRendererOpenWindow };
 export const preventSleep = { forRenderer: forRendererPreventSleep };
 export const safeStorage = {

--- a/src/About/ApplicationCard.tsx
+++ b/src/About/ApplicationCard.tsx
@@ -6,12 +6,10 @@
 
 import React, { useEffect, useState } from 'react';
 
-import {
-    AppDetailsFromLauncher,
-    inMain as appDetails,
-} from '../../ipc/appDetails';
+import { AppDetailsFromLauncher } from '../../ipc/appDetails';
 import Card from '../Card/Card';
 import FactoryResetButton from '../FactoryReset/FactoryResetButton';
+import appDetails from '../utils/appDetails';
 import AboutButton from './AboutButton';
 import Section from './Section';
 import ShortcutButton from './ShortcutButton';
@@ -20,7 +18,7 @@ export default () => {
     const [appInfo, setAppInfo] = useState<AppDetailsFromLauncher>();
 
     useEffect(() => {
-        appDetails.getAppDetails().then(setAppInfo);
+        appDetails().then(setAppInfo);
     }, [setAppInfo]);
 
     if (appInfo == null) return null;

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 
+import packageJsonFromShared from '../../package.json';
 import render from '../../test/testrenderer';
 import App, { Pane } from './App';
 
@@ -18,6 +19,11 @@ jest.mock('../Log/LogViewer', () => ({
 jest.mock('../logging/index.ts', () => ({
     initialise: () => {},
     debug: () => {},
+}));
+
+jest.mock('../utils/packageJson', () => ({
+    isLauncher: () => false,
+    packageJson: () => packageJsonFromShared,
 }));
 
 const renderApp = (panes: Pane[]) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,6 @@ export {
     getAppFile,
     getAppDataDir,
     getAppLogDir,
-    getAppSource,
     getUserDataDir,
 } from './utils/appDirs';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,8 @@ export {
     persistApiKey,
 } from './utils/persistentStore';
 
+export { default as launcherConfig } from './utils/launcherConfig';
+
 export { jprogDeviceSetup } from './Device/jprogOperations';
 
 export { sdfuDeviceSetup } from './Device/sdfuOperations';

--- a/src/logging/sendInitialLogMessages.ts
+++ b/src/logging/sendInitialLogMessages.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { inMain as appDetails } from '../../ipc/appDetails';
 import NrfutilDeviceLib from '../../nrfutil/device/device';
 import {
     getExpectedVersion,
     resolveModuleVersion,
 } from '../../nrfutil/moduleVersion';
+import appDetails from '../utils/appDetails';
 import { getAppDataDir } from '../utils/appDirs';
 import logLibVersions from '../utils/logLibVersions';
 import udevInstalled from '../utils/udevInstalled';
@@ -23,8 +23,6 @@ export default async () => {
     logLibVersions();
     logger.debug(`Application data folder: ${getAppDataDir()}`);
 
-    const details = await appDetails.getAppDetails();
-
     const {
         name,
         currentVersion,
@@ -35,7 +33,7 @@ export default async () => {
         homeDir,
         tmpDir,
         source,
-    } = details;
+    } = await appDetails();
 
     logger.debug(`App ${name} v${currentVersion} (${source})`);
     logger.debug(`App path: ${installed.path}`);

--- a/src/utils/appDetails.ts
+++ b/src/utils/appDetails.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { type AppDetailsFromLauncher, inMain } from '../../ipc/appDetails';
+import { isLauncher } from './packageJson';
+
+let cached: AppDetailsFromLauncher;
+
+export default async () => {
+    if (isLauncher()) {
+        throw new Error('Must not be called by the launcher.');
+    }
+
+    if (cached == null) {
+        cached = await inMain.getAppDetails();
+    }
+
+    return cached;
+};

--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -6,7 +6,6 @@
 
 import path from 'path';
 
-import { OFFICIAL } from '../../ipc/sources';
 import launcherConfig from './launcherConfig';
 import { packageJsonApp } from './packageJson';
 
@@ -46,19 +45,4 @@ const getAppDataDir = () =>
  */
 const getAppLogDir = () => path.join(getAppDataDir(), 'logs');
 
-const getAppSource = () => {
-    const source = path
-        .parse(path.resolve(getAppDir(), '../'))
-        .base.toLowerCase();
-
-    return source === 'node_modules' ? OFFICIAL : source;
-};
-
-export {
-    getAppDir,
-    getAppFile,
-    getAppDataDir,
-    getAppLogDir,
-    getUserDataDir,
-    getAppSource,
-};
+export { getAppDir, getAppFile, getAppDataDir, getAppLogDir, getUserDataDir };

--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -7,20 +7,10 @@
 import path from 'path';
 
 import { OFFICIAL } from '../../ipc/sources';
+import launcherConfig from './launcherConfig';
 import { packageJsonApp } from './packageJson';
 
-const getUserDataDir = () => {
-    const argv = process.argv;
-    const userDataDir = argv.findIndex(arg =>
-        arg.startsWith('--user-data-dir')
-    );
-
-    if (userDataDir === -1) {
-        throw new Error('Could not find --user-data-dir argument');
-    }
-
-    return argv[userDataDir].split('=')[1];
-};
+const getUserDataDir = () => launcherConfig().userDataDir;
 
 /**
  * Get the filesystem path of the currently loaded app.

--- a/src/utils/launcherConfig.ts
+++ b/src/utils/launcherConfig.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { type Configuration, inMain } from '../../ipc/launcherConfig';
+
+let cachedConfig: Configuration;
+
+export default () => {
+    if (cachedConfig == null) {
+        cachedConfig = inMain.getConfig();
+    }
+
+    return cachedConfig;
+};

--- a/src/utils/packageJson.ts
+++ b/src/utils/packageJson.ts
@@ -16,7 +16,10 @@ let cache:
     | { type: 'launcher'; data: PackageJson }
     | { type: 'app'; data: PackageJsonApp };
 
-const parsedPackageJson = () => {
+export const isLauncher = (packageJson = parsedPackageJson()) =>
+    packageJson.name === 'nrfconnect';
+
+const parsedPackageJson = (): PackageJson | PackageJsonApp => {
     if (cache != null) {
         return cache.data;
     }
@@ -31,9 +34,7 @@ const parsedPackageJson = () => {
         );
     }
 
-    const isLauncher = parsed.data.name === 'nrfconnect';
-
-    if (isLauncher) {
+    if (isLauncher(parsed.data)) {
         cache = {
             type: 'launcher',
             data: parsed.data,

--- a/src/utils/usageData.ts
+++ b/src/utils/usageData.ts
@@ -69,13 +69,13 @@ const getUsageData = () => {
     return usageDataMain;
 };
 
-const sendUsageData = (
+const sendUsageData = async (
     action: string,
     metadata?: Metadata,
     forceSend?: boolean
 ) => {
     if (
-        getUsageData().sendUsageData(
+        await getUsageData().sendUsageData(
             `${getFriendlyAppName()}: ${action}`,
             flattenObject(metadata),
             forceSend
@@ -87,21 +87,17 @@ const sendUsageData = (
     }
 };
 
-const sendPageView = (pageName: string) => {
+const sendPageView = (pageName: string) =>
     getUsageData().sendPageView(`${getFriendlyAppName()} - ${pageName}`);
-};
 
-const sendMetric = (name: string, average: number) => {
+const sendMetric = (name: string, average: number) =>
     getUsageData().sendMetric(name, average);
-};
 
-const sendTrace = (message: string) => {
-    getUsageData().sendTrace(message);
-};
+const sendTrace = (message: string) => getUsageData().sendTrace(message);
 
 const sendErrorReport = (error: string | Error) => {
     usageDataCommon.getLogger()?.error(error);
-    getUsageData().sendErrorReport(
+    return getUsageData().sendErrorReport(
         typeof error === 'string' ? new Error(error) : error
     );
 };

--- a/src/utils/usageDataRenderer.ts
+++ b/src/utils/usageDataRenderer.ts
@@ -8,7 +8,7 @@ import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
 import { getAppSource } from './appDirs';
 import { isDevelopment } from './environment';
-import { packageJson } from './packageJson';
+import { isLauncher, packageJson } from './packageJson';
 import { getUsageDataClientId } from './persistentStore';
 import usageDataCommon, {
     INSTRUMENTATION_KEY,
@@ -32,9 +32,9 @@ const getInsights = (forceSend?: boolean) => {
 };
 
 const init = () => {
-    const appPackageJson = packageJson();
-    const applicationName = appPackageJson.name;
-    const applicationVersion = appPackageJson.version;
+    const applicationName = packageJson().name;
+    const applicationVersion = packageJson().version;
+    const source = isLauncher() ? undefined : getAppSource();
 
     const accountId = getUsageDataClientId();
 
@@ -64,10 +64,7 @@ const init = () => {
                 applicationName,
                 applicationVersion,
                 isDevelopment,
-                source:
-                    applicationName === 'nrfconnect'
-                        ? undefined
-                        : getAppSource(),
+                source,
                 ...envelope.baseData,
             };
         }

--- a/src/utils/usageDataRenderer.ts
+++ b/src/utils/usageDataRenderer.ts
@@ -6,7 +6,7 @@
 
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
-import { getAppSource } from './appDirs';
+import appDetails from './appDetails';
 import { isDevelopment } from './environment';
 import { isLauncher, packageJson } from './packageJson';
 import { getUsageDataClientId } from './persistentStore';
@@ -17,7 +17,7 @@ import usageDataCommon, {
 
 let cachedInsights: ApplicationInsights | undefined;
 
-const getInsights = (forceSend?: boolean) => {
+const getInsights = async (forceSend?: boolean) => {
     if (!usageDataCommon.getShouldSendTelemetry(forceSend)) return;
 
     if (cachedInsights) {
@@ -25,16 +25,16 @@ const getInsights = (forceSend?: boolean) => {
     }
 
     if (!cachedInsights) {
-        cachedInsights = init();
+        cachedInsights = await init();
     }
 
     return cachedInsights;
 };
 
-const init = () => {
+const init = async () => {
     const applicationName = packageJson().name;
     const applicationVersion = packageJson().version;
-    const source = isLauncher() ? undefined : getAppSource();
+    const source = isLauncher() ? undefined : (await appDetails()).source;
 
     const accountId = getUsageDataClientId();
 
@@ -73,12 +73,12 @@ const init = () => {
     return out;
 };
 
-const sendUsageData = (
+const sendUsageData = async (
     action: string,
     metadata?: Metadata,
     forceSend?: boolean
 ) => {
-    const result = getInsights(forceSend);
+    const result = await getInsights(forceSend);
     if (result !== undefined) {
         result.trackEvent(
             {
@@ -92,27 +92,27 @@ const sendUsageData = (
     return false;
 };
 
-const sendPageView = (pageName: string) => {
-    getInsights()?.trackPageView({
+const sendPageView = async (pageName: string) => {
+    (await getInsights())?.trackPageView({
         name: pageName,
     });
 };
 
-const sendMetric = (name: string, average: number) => {
-    getInsights()?.trackMetric({
+const sendMetric = async (name: string, average: number) => {
+    (await getInsights())?.trackMetric({
         name,
         average,
     });
 };
 
-const sendTrace = (message: string) => {
-    getInsights()?.trackTrace({
+const sendTrace = async (message: string) => {
+    (await getInsights())?.trackTrace({
         message,
     });
 };
 
-const sendErrorReport = (error: Error) => {
-    getInsights()?.trackException({
+const sendErrorReport = async (error: Error) => {
+    (await getInsights())?.trackException({
         exception: error,
     });
 };


### PR DESCRIPTION
The main change here is to replace the functions `getUserDataDir` and `getAppSource` in `src/utils/appDirs.ts` with code that uses IPC calls instead. One motivation for this being that for me it was too hard to understand how or why the previous code there worked.

One consequence of this is: All functions in `usageData` became async but I assume this is no problem since we never rely on the telemetry data being sent sync (and if this is needed, it could be awaited now).
