### PR TITLE
Telemetry

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Fixed
+
+-   Removed warning from `applicationinsights` in the console on start.
+
 ## 130 - 2023-11-14
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,14 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## Unreleased
+## 131 - 2023-11-14
+
+### Changed
+
+-   Storage key `isSendingUsageData` → `isSendingTelemetry`. The consequence of
+    this is that telemetry is only sent after users again agree to it, which is
+    required because we changed the agreement from Google Analytics to Microsoft
+    Azure.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "130.0.0",
+    "version": "131.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/esbuild.ts
+++ b/scripts/esbuild.ts
@@ -43,6 +43,7 @@ const bundle = () => {
     build({
         define: {
             'process.env.PACKAGE_JSON': JSON.stringify(packageJson),
+            'process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT': '"{}"', // Needed because of https://github.com/microsoft/ApplicationInsights-node.js/issues/1226
         },
         entryPoints: [entry()],
     });

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -29,7 +29,7 @@ export interface TerminalSettings {
 
 const sharedStore = new Store<{
     verboseLogging: boolean;
-    isSendingUsageData: boolean | undefined;
+    isSendingTelemetry: boolean | undefined;
     clientId?: string;
 }>({
     name: 'pc-nrfconnect-shared',
@@ -117,11 +117,11 @@ export const getPersistedTerminalSettings = (
 };
 
 export const persistIsSendingUsageData = (value: boolean) =>
-    sharedStore.set('isSendingUsageData', value);
+    sharedStore.set('isSendingTelemetry', value);
 export const getIsSendingUsageData = () =>
-    sharedStore.get('isSendingUsageData', undefined) as boolean | undefined;
+    sharedStore.get('isSendingTelemetry', undefined) as boolean | undefined;
 export const deleteIsSendingUsageData = () =>
-    sharedStore.delete('isSendingUsageData');
+    sharedStore.delete('isSendingTelemetry');
 
 const existingUsageDataClientId = () => sharedStore.get('clientId');
 const newUsageDataClientId = () => {


### PR DESCRIPTION
- Remove warning on start
- Changed the key under which we store if users agreed to telemetry: `isSendingUsageData` → `isSendingTelemetry`. The consequence of    this is that telemetry is only sent after users again agree to it, which is    required because we changed the agreement from Google Analytics to Microsoft    Azure.