### PR TITLE
Make the Dropdown component generic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,15 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 134 - Unreleased
+
+### Changed
+
+-   The `Dropdown` component is now generic, and will infer the `DropdownItem`
+    type, from the its properties. Meaning that if you pass in a list of
+    `DropdownItem<number>` to items, then the `onSelect` item will be of type
+    `DropdownItem<number>`.
+
 ## 133 - 2023-11-15
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,12 @@ every new version is a new major version.
 
 ## 134 - Unreleased
 
+### Added
+
+-   `defaultButtonLabel` on `Dropdown` component, for cases where it is useful
+    to have a default item that should not be selected after a different item
+    has been selected.
+
 ### Changed
 
 -   The `Dropdown` component is now generic, and will infer the `DropdownItem`

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -16,18 +16,18 @@ export interface DropdownItem<T = string> {
     value: T;
 }
 
-export interface DropdownProps {
+export type DropdownProps<T> = {
     id?: string;
     label?: React.ReactNode;
-    items: DropdownItem[];
-    onSelect: (item: DropdownItem) => void;
+    items: DropdownItem<T>[];
+    onSelect: (item: DropdownItem<T>) => void;
     disabled?: boolean;
-    selectedItem: DropdownItem;
+    selectedItem: DropdownItem<T>;
     numItemsBeforeScroll?: number;
     className?: string;
-}
+};
 
-export default ({
+export default <T,>({
     id,
     label,
     items,
@@ -36,10 +36,10 @@ export default ({
     selectedItem,
     numItemsBeforeScroll = 0,
     className = '',
-}: DropdownProps) => {
+}: DropdownProps<T>) => {
     const [isActive, setIsActive] = useState(false);
 
-    const onClickItem = (item: DropdownItem) => {
+    const onClickItem = (item: DropdownItem<T>) => {
         onSelect(item);
         setIsActive(false);
     };
@@ -100,7 +100,7 @@ export default ({
                     <button
                         type="button"
                         className="tw-bg-transparent tw-clear-both tw-block tw-h-6 tw-w-full tw-whitespace-nowrap tw-border-0 tw-px-2 tw-py-1 tw-text-left tw-font-normal tw-text-white hover:tw-bg-gray-600 focus:tw-bg-gray-600"
-                        key={item.value}
+                        key={JSON.stringify(item.value)}
                         onClick={() => onClickItem(item)}
                     >
                         {item.label}

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -19,6 +19,7 @@ export interface DropdownItem<T = string> {
 export type DropdownProps<T> = {
     id?: string;
     label?: React.ReactNode;
+    defaultButtonLabel?: string;
     items: DropdownItem<T>[];
     onSelect: (item: DropdownItem<T>) => void;
     disabled?: boolean;
@@ -30,6 +31,7 @@ export type DropdownProps<T> = {
 export default <T,>({
     id,
     label,
+    defaultButtonLabel = '',
     items,
     onSelect,
     disabled = false,
@@ -65,7 +67,7 @@ export default <T,>({
             >
                 <span>
                     {items.findIndex(e => e.value === selectedItem.value) === -1
-                        ? ''
+                        ? defaultButtonLabel
                         : selectedItem.label}
                 </span>
                 <span


### PR DESCRIPTION
Make it so that the DropDownItem type is inferred from the properties passed to the Dropdown component.

Some mocked use case to demonstrate:

```tsx
interface CustomValue {
    foo: string;
    bar: number;
}

const MyComponent = () => {
    const items: readonly DropdownItem<CustomValue>[] = someListOfSorts.map( ... );
    
    return <Dropdown
        selectedItem={items[0]}
        items={items}
        onSelect={ (item) => {
            console.log(item.foo) // ✅
            console.log(item.bar) // ✅
        }} />
};

```