### PR TITLE
Fix metadata removal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,12 @@ every new version is a new major version.
     `DropdownItem<number>` to items, then the `onSelect` item will be of type
     `DropdownItem<number>`.
 
+### Fixed
+
+-   Telemtry: Metadata was not removed on request, when being in the main
+    process. This is not critical because this code isn't yet executed in real
+    life.
+
 ## 133 - 2023-11-15
 
 ### Changed

--- a/src/utils/usageDataMain.ts
+++ b/src/utils/usageDataMain.ts
@@ -47,9 +47,9 @@ const init = () => {
 
     // Add app name and version to every event
     out.addTelemetryProcessor(envelope => {
-        if (envelope.data.baseData?.removeAllMetadata) {
+        if (envelope.data.baseData?.properties.removeAllMetadata) {
             envelope.tags = [];
-            envelope.data.baseData = { name: envelope.data?.baseData };
+            envelope.data.baseData = { name: envelope.data?.baseData.name };
         } else {
             envelope.tags['ai.cloud.roleInstance'] = undefined; // remove PC name
             envelope.data.baseData = {


### PR DESCRIPTION
Looking at the documenation I found it hard to deduce, what `envelope.data.baseData` is supposed to contain. But looking at what is actually in there when `usageData.sendUsageData` is invoked from the main process in preparing an nrfutil sandbox I think that `removeAllMetadata` will be in `envelope.data.baseData.properties` and that the `name` will be in `envelope.data.baseData.name`.