### PR TITLE
Fix: Coverage should not be in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ nordicsemiconductor-pc-nrfconnect-shared-*.tgz
 .vscode/settings.json
 azure-pipelines.yml
 .github
+coverage


### PR DESCRIPTION
E.g. in https://unpkg.com/browse/@nordicsemiconductor/pc-nrfconnect-shared@134.0.0/coverage/ one can see that we currently include the coverage report in the package we publish to npm. But we don't want to do that.