### PR TITLE
Enhance telemetry API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -239,7 +239,7 @@ every new version is a new major version.
 
 ### Fixed
 
--   Telemtry: Metadata was not removed on request, when being in the main
+-   Telemetry: Metadata was not removed on request, when being in the main
     process. This is not critical because this code isn't yet executed in real
     life.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,11 +13,17 @@ every new version is a new major version.
 
 -   Renamed exported object `usageData` to `telemetry` and type
     `UsageDataMetadata` to `TelemetryMetadata`.
+-   `telemetry.enable()` and `telemetry.disable()` are replaced by
+    `telemetry.setUsersAgreedToTelemetry(boolean)`. `telemetry.reset()` is
+    renamed to `telemetry.setUsersWithdrewTelemetryAgreement()`
 
 ### Steps to upgrade when using this package
 
 -   If they are imported from shared, rename `usageData` and
     `UsageDataMetadata`.
+-   Replace usages of `telemetry.enable()` and `telemetry.disable()` with
+    `telemetry.setUsersAgreedToTelemetry(boolean)` and `telemetry.reset()` with
+    `telemetry.setUsersWithdrewTelemetryAgreement()`
 
 ## 150.0.0 - 2024-01-18
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,18 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Changed
+
+-   Renamed exported object `usageData` to `telemetry` and type
+    `UsageDataMetadata` to `TelemetryMetadata`.
+
+### Steps to upgrade when using this package
+
+-   If they are imported from shared, rename `usageData` and
+    `UsageDataMetadata`.
+
 ## 150.0.0 - 2024-01-18
 
 ### Removed

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@ every new version is a new major version.
 -   `telemetry.enable()` and `telemetry.disable()` are replaced by
     `telemetry.setUsersAgreedToTelemetry(boolean)`. `telemetry.reset()` is
     renamed to `telemetry.setUsersWithdrewTelemetryAgreement()`
+-   `telemetry.isEnabled()` got replaced by `telemetry.getIsSendingTelemetry()`,
+    which does not log anymore.
 
 ### Steps to upgrade when using this package
 
@@ -24,6 +26,9 @@ every new version is a new major version.
 -   Replace usages of `telemetry.enable()` and `telemetry.disable()` with
     `telemetry.setUsersAgreedToTelemetry(boolean)` and `telemetry.reset()` with
     `telemetry.setUsersWithdrewTelemetryAgreement()`
+-   Replace usage of `telemetry.isEnabled()` by
+    `telemetry.getIsSendingTelemetry()`. If you still want the previous log
+    message `Telemetry is {true,false}`, you have to log it yourself now.
 
 ## 150.0.0 - 2024-01-18
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,11 +20,15 @@ every new version is a new major version.
     -   `isEnabled()` → `getIsSendingTelemetry()` (which now does not log
         anymore)
     -   `sendUsageData()` → `sendEvent()`
+-   In the component `ErrorBoundary` the property `sendUsageData` is renamed to
+    `sendTelemetryEvent`.
 
 ### Steps to upgrade when using this package
 
 -   If they are imported from shared, rename `usageData` and `UsageDataMetadata`
     as well as the renamed functions mentioned above.
+-   In usages of the component `ErrorBoundary`, rename the property
+    `sendUsageData` to `sendTelemetryEvent`.
 
 ## 150.0.0 - 2024-01-18
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,22 +13,18 @@ every new version is a new major version.
 
 -   Renamed exported object `usageData` to `telemetry` and type
     `UsageDataMetadata` to `TelemetryMetadata`.
--   `telemetry.enable()` and `telemetry.disable()` are replaced by
-    `telemetry.setUsersAgreedToTelemetry(boolean)`. `telemetry.reset()` is
-    renamed to `telemetry.setUsersWithdrewTelemetryAgreement()`
--   `telemetry.isEnabled()` got replaced by `telemetry.getIsSendingTelemetry()`,
-    which does not log anymore.
+-   Renamed several function in the `telemetry` object:
+    -   `enable()` → `setUsersAgreedToTelemetry(true)`
+    -   `disable()` → `setUsersAgreedToTelemetry(false)`
+    -   `reset()` → `setUsersWithdrewTelemetryAgreement()`
+    -   `isEnabled()` → `getIsSendingTelemetry()` (which now does not log
+        anymore)
+    -   `sendUsageData()` → `sendEvent()`
 
 ### Steps to upgrade when using this package
 
--   If they are imported from shared, rename `usageData` and
-    `UsageDataMetadata`.
--   Replace usages of `telemetry.enable()` and `telemetry.disable()` with
-    `telemetry.setUsersAgreedToTelemetry(boolean)` and `telemetry.reset()` with
-    `telemetry.setUsersWithdrewTelemetryAgreement()`
--   Replace usage of `telemetry.isEnabled()` by
-    `telemetry.getIsSendingTelemetry()`. If you still want the previous log
-    message `Telemetry is {true,false}`, you have to log it yourself now.
+-   If they are imported from shared, rename `usageData` and `UsageDataMetadata`
+    as well as the renamed functions mentioned above.
 
 ## 150.0.0 - 2024-01-18
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## Unreleased
+## 151.0.0 - 2024-01-23
 
 ### Changed
 

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -332,7 +332,7 @@ export class NrfutilSandbox {
     ) =>
         new Promise<void>((resolve, reject) => {
             let aborting = false;
-            telemetry.sendUsageData(`running nrfutil ${this.module}`, {
+            telemetry.sendEvent(`running nrfutil ${this.module}`, {
                 args,
                 exec: command,
             });
@@ -513,7 +513,7 @@ export class NrfutilSandbox {
     ) =>
         new Promise<void>((resolve, reject) => {
             let aborting = false;
-            telemetry.sendUsageData(`running nrfutil ${this.module}`, {
+            telemetry.sendEvent(`running nrfutil ${this.module}`, {
                 args,
                 exec: command,
             });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "prepare": "ts-node scripts/installHusky.ts",
         "release-shared": "ts-node scripts/release-shared.ts",
         "prepare-shared-release": "ts-node scripts/prepare-shared-release.ts",
-        "clean": "rimraf dist typings/generated dist scripts/nordic-publish.js",
+        "clean": "rimraf dist typings/generated scripts/nordic-publish.js",
         "postinstall": "ts-node scripts/postinstall.ts"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "150.0.0",
+    "version": "151.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Device/DeviceSelector/DeviceSelector.tsx
+++ b/src/Device/DeviceSelector/DeviceSelector.tsx
@@ -71,7 +71,7 @@ export default ({
     const doDeselectDevice = useCallback(
         (device?: Device) => {
             if (device) {
-                telemetry.sendUsageData(
+                telemetry.sendEvent(
                     'device deselected ',
                     simplifyDevice(device)
                 );
@@ -120,7 +120,7 @@ export default ({
             dispatch(setSelectedDeviceInfo(deviceInfo));
             onDeviceSelected(device, autoReselected);
 
-            telemetry.sendUsageData('device selected', {
+            telemetry.sendEvent('device selected', {
                 device: simplifyDevice(device),
                 deviceInfo,
             });

--- a/src/Device/deviceLister.ts
+++ b/src/Device/deviceLister.ts
@@ -180,7 +180,7 @@ export const startWatchingDevices =
 
             const action = async (device: Device) => {
                 if (hasValidDeviceTraits(device.traits, deviceListing)) {
-                    telemetry.sendUsageData(
+                    telemetry.sendEvent(
                         'device connected',
                         simplifyDevice(device)
                     );

--- a/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -44,14 +44,14 @@ describe('ErrorBoundary', () => {
     });
 
     it('can take custom reporting functions', () => {
-        const sendUsageData = jest.fn();
+        const sendTelemetryEvent = jest.fn();
 
         render(
-            <ErrorBoundary sendUsageData={sendUsageData}>
+            <ErrorBoundary sendTelemetryEvent={sendTelemetryEvent}>
                 <Child />
             </ErrorBoundary>
         );
-        expect(sendUsageData).toHaveBeenCalled();
+        expect(sendTelemetryEvent).toHaveBeenCalled();
     });
 
     it('should render error boundary component when there is an error', () => {

--- a/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.tsx
@@ -32,7 +32,7 @@ interface Props {
     devices?: Device[];
     appName?: string;
     restoreDefaults?: () => void;
-    sendUsageData?: (message: string) => void;
+    sendTelemetryEvent?: (message: string) => void;
 }
 
 const genericRestoreDefaults = () => {
@@ -61,11 +61,15 @@ class ErrorBoundary extends React.Component<
     }
 
     componentDidCatch(error: Error) {
-        const { devices, selectedDevice, selectedSerialNumber, sendUsageData } =
-            this.props;
+        const {
+            devices,
+            selectedDevice,
+            selectedSerialNumber,
+            sendTelemetryEvent,
+        } = this.props;
 
-        sendUsageData != null
-            ? sendUsageData(error.message)
+        sendTelemetryEvent != null
+            ? sendTelemetryEvent(error.message)
             : sendErrorReport(error.message);
 
         generateSystemReport(

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ export {
 export { openUrl, openFile } from './utils/open';
 export { default as systemReport } from './utils/systemReport';
 
-export { default as usageData } from './telemetry/telemetry';
-export { type default as UsageDataMetadata } from './telemetry/TelemetryMetadata';
+export { default as telemetry } from './telemetry/telemetry';
+export { type default as TelemetryMetadata } from './telemetry/TelemetryMetadata';
 export { default as classNames } from './utils/classNames';
 export { truncateMiddle } from './utils/truncateMiddle';
 

--- a/src/telemetry/TelemetrySender.ts
+++ b/src/telemetry/TelemetrySender.ts
@@ -33,17 +33,6 @@ export default abstract class TelemetrySender {
         this.isTelemetryAllowedForCurrentApp &&
         getHasUserAgreedToTelemetry() === true;
 
-    /**
-     * @deprecated Use `getIsSendingTelemetry` instead
-     * @returns {boolean} If telemetry is enabled
-     */
-    isEnabled() {
-        const isSendingTelemetry = this.getIsSendingTelemetry();
-        this.logger?.debug(`Telemetry is ${isSendingTelemetry}`);
-
-        return isSendingTelemetry;
-    }
-
     async sendAgreementEvent() {
         this.sendUsageData('Telemetry Opt-In');
 

--- a/src/telemetry/TelemetrySender.ts
+++ b/src/telemetry/TelemetrySender.ts
@@ -34,14 +34,14 @@ export default abstract class TelemetrySender {
         getHasUserAgreedToTelemetry() === true;
 
     async sendAgreementEvent() {
-        this.sendUsageData('Telemetry Opt-In');
+        this.sendEvent('Telemetry Opt-In');
 
         const { platform, arch } = await si.osInfo();
-        this.sendUsageData('Report OS info', { platform, arch });
+        this.sendEvent('Report OS info', { platform, arch });
     }
 
     sendDisagreementEvent() {
-        this.sendMinimalUsageData('Telemetry Opt-Out');
+        this.sendMinimalEvent('Telemetry Opt-Out');
     }
 
     async setUsersAgreedToTelemetry(hasAgreed: boolean) {
@@ -60,15 +60,15 @@ export default abstract class TelemetrySender {
 
     setUsersWithdrewTelemetryAgreement() {
         deleteHasUserAgreedToTelemetry();
-        this.sendMinimalUsageData('Telemetry Opt-Reset');
+        this.sendMinimalEvent('Telemetry Opt-Reset');
         this.logger?.debug('Telemetry has been reset');
     }
 
-    sendMinimalUsageData(action: string) {
-        this.sendUsageData(action, { removeAllMetadata: true });
+    sendMinimalEvent(action: string) {
+        this.sendEvent(action, { removeAllMetadata: true });
     }
 
-    abstract sendUsageData(
+    abstract sendEvent(
         action: string,
         metadata?: TelemetryMetadata
     ): MaybePromise<void>;

--- a/src/telemetry/TelemetrySender.ts
+++ b/src/telemetry/TelemetrySender.ts
@@ -44,26 +44,35 @@ export default abstract class TelemetrySender {
         return isSendingTelemetry;
     }
 
-    async enable() {
-        persistHasUserAgreedToTelemetry(true);
+    async sendAgreementEvent() {
         this.sendUsageData('Telemetry Opt-In');
 
         const { platform, arch } = await si.osInfo();
         this.sendUsageData('Report OS info', { platform, arch });
-
-        this.logger?.debug('Usage data has been enabled');
     }
 
-    disable() {
-        persistHasUserAgreedToTelemetry(false);
+    sendDisagreementEvent() {
         this.sendMinimalUsageData('Telemetry Opt-Out');
-        this.logger?.debug('Usage data has been disabled');
     }
 
-    reset() {
+    async setUsersAgreedToTelemetry(hasAgreed: boolean) {
+        persistHasUserAgreedToTelemetry(hasAgreed);
+
+        if (hasAgreed) {
+            await this.sendAgreementEvent();
+        } else {
+            this.sendDisagreementEvent();
+        }
+
+        this.logger?.debug(
+            `Telemetry has been ${hasAgreed ? 'enabled' : 'disabled'}`
+        );
+    }
+
+    setUsersWithdrewTelemetryAgreement() {
         deleteHasUserAgreedToTelemetry();
         this.sendMinimalUsageData('Telemetry Opt-Reset');
-        this.logger?.debug('Usage data setting has been reset');
+        this.logger?.debug('Telemetry has been reset');
     }
 
     sendMinimalUsageData(action: string) {

--- a/src/telemetry/TelemetrySenderInMain.ts
+++ b/src/telemetry/TelemetrySenderInMain.ts
@@ -58,9 +58,9 @@ export default class TelemetrySenderInMain extends TelemetrySender {
 
     getClient = () => this.client ?? this.initClient();
 
-    sendUsageData = (action: string, metadata?: TelemetryMetadata) => {
+    sendEvent = (action: string, metadata?: TelemetryMetadata) => {
         this.getClient().trackEvent({ name: action, properties: metadata });
-        this.logger?.debug(`Sending usage data ${JSON.stringify(action)}`);
+        this.logger?.debug(`Sending event ${JSON.stringify(action)}`);
     };
 
     sendPageView = (pageName: string) =>

--- a/src/telemetry/TelemetrySenderInRenderer.ts
+++ b/src/telemetry/TelemetrySenderInRenderer.ts
@@ -63,9 +63,9 @@ export default class TelemetrySenderInRenderer extends TelemetrySender {
 
     getClient = () => this.client ?? this.initClient();
 
-    sendUsageData = async (action: string, metadata?: TelemetryMetadata) => {
+    sendEvent = async (action: string, metadata?: TelemetryMetadata) => {
         (await this.getClient()).trackEvent({ name: action }, metadata);
-        this.logger?.debug(`Sending usage data ${JSON.stringify(action)}`);
+        this.logger?.debug(`Sending event ${JSON.stringify(action)}`);
     };
 
     sendPageView = async (pageName: string) =>

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -49,7 +49,8 @@ const setLogger = (logger: Logger) =>
     getTelemetrySenderUnconditionally().setLogger(logger);
 const setUsersAgreedToTelemetry = (hasAgreed: boolean) =>
     getTelemetrySenderUnconditionally().setUsersAgreedToTelemetry(hasAgreed);
-const isEnabled = () => getTelemetrySenderUnconditionally().isEnabled();
+const getIsSendingTelemetry = () =>
+    getTelemetrySenderUnconditionally().getIsSendingTelemetry();
 const setUsersWithdrewTelemetryAgreement = () =>
     getTelemetrySenderUnconditionally().setUsersWithdrewTelemetryAgreement();
 const enableTelemetry = () =>
@@ -86,7 +87,7 @@ export default {
     setLogger,
     setUsersAgreedToTelemetry,
     setUsersWithdrewTelemetryAgreement,
-    isEnabled,
+    getIsSendingTelemetry,
     sendErrorReport,
     sendUsageData,
     sendPageView,

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -61,8 +61,8 @@ const enableTelemetry = () =>
 const getFriendlyAppName = () =>
     packageJson().name.replace('pc-nrfconnect-', '');
 
-const sendUsageData = (action: string, metadata?: TelemetryMetadata) =>
-    getTelemetrySenderIfEnabled()?.sendUsageData(
+const sendEvent = (action: string, metadata?: TelemetryMetadata) =>
+    getTelemetrySenderIfEnabled()?.sendEvent(
         `${getFriendlyAppName()}: ${action}`,
         flatObject(metadata)
     );
@@ -89,7 +89,7 @@ export default {
     setUsersWithdrewTelemetryAgreement,
     getIsSendingTelemetry,
     sendErrorReport,
-    sendUsageData,
+    sendEvent,
     sendPageView,
     sendMetric,
     sendTrace,

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -47,10 +47,11 @@ const getTelemetrySenderIfEnabled = () => {
 
 const setLogger = (logger: Logger) =>
     getTelemetrySenderUnconditionally().setLogger(logger);
-const enable = () => getTelemetrySenderUnconditionally().enable();
+const setUsersAgreedToTelemetry = (hasAgreed: boolean) =>
+    getTelemetrySenderUnconditionally().setUsersAgreedToTelemetry(hasAgreed);
 const isEnabled = () => getTelemetrySenderUnconditionally().isEnabled();
-const disable = () => getTelemetrySenderUnconditionally().disable();
-const reset = () => getTelemetrySenderUnconditionally().reset();
+const setUsersWithdrewTelemetryAgreement = () =>
+    getTelemetrySenderUnconditionally().setUsersWithdrewTelemetryAgreement();
 const enableTelemetry = () =>
     getTelemetrySenderUnconditionally().allowTelemetryForCurrentApp();
 
@@ -83,10 +84,9 @@ const sendErrorReport = (error: string | Error) =>
 
 export default {
     setLogger,
-    disable,
-    enable,
+    setUsersAgreedToTelemetry,
+    setUsersWithdrewTelemetryAgreement,
     isEnabled,
-    reset,
     sendErrorReport,
     sendUsageData,
     sendPageView,

--- a/src/utils/useHotKey.ts
+++ b/src/utils/useHotKey.ts
@@ -18,7 +18,7 @@ const useNewHotKey = (shortcut: Shortcut, deps: DependencyList = []) => {
 
         Mousetrap.bind(shortcut.hotKey, (_e, combo) => {
             shortcut.action();
-            telemetry.sendUsageData('pressed hotkey', { combo });
+            telemetry.sendEvent('pressed hotkey', { combo });
         });
 
         return () => {


### PR DESCRIPTION
This PR does several changes postponed in #833 because I didn't want to change the API in that PR. The changes here are not big, mostly just refactorings which mean that apps using the telemetry API of shared will have to change the names with which they call it but usually not a lot more.

This should be reviewed and merged after #833 is merged, because the changes here are based on changes that are done in that PR and also partially on what happened in `main` since then.