### PR TITLE
NCD-554 board controller commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,15 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 139.0.0 - UNRELEASED
+
+### Added
+
+-   Added command wrappers to interact with the Board Controller using
+    `nrfutil-device`. `boardController()` to write board controller config to
+    the DK. `getBoardControllerVersion()` to get the version information from
+    the Board Controller. (like firmware version and board hardware revision)
+
 ## 138.0.0 - 2023-12-04
 
 ### Fixed

--- a/nrfutil/device/batch.ts
+++ b/nrfutil/device/batch.ts
@@ -89,6 +89,29 @@ export class Batch {
         return this;
     }
 
+    public boardController(data: object, callbacks?: Callbacks) {
+        // "operation: 2, command_id: 0" is the command to set the configuration for the board controller.
+        this.operationBatchGeneration.push(
+            new Promise<BatchOperationWrapperUnknown>(resolve => {
+                resolve({
+                    operation: {
+                        operation: {
+                            type: 'smp',
+                            operation: 2,
+                            group_id: 64,
+                            command_id: 0,
+                            sequence_number: 0,
+                            data,
+                        },
+                    },
+                    ...callbacks,
+                } as BatchOperationWrapperUnknown);
+            })
+        );
+
+        return this;
+    }
+
     public firmwareRead(core: DeviceCore, callbacks?: Callbacks<Buffer>) {
         this.enqueueBatchOperationObject('fw-read', core, {
             ...callbacks,

--- a/nrfutil/device/batch.ts
+++ b/nrfutil/device/batch.ts
@@ -112,6 +112,28 @@ export class Batch {
         return this;
     }
 
+    public getBoardControllerVersion(callbacks?: Callbacks) {
+        // "operation: 0, command_id: 1" is the command to retrieve version information from the board controller.
+        this.operationBatchGeneration.push(
+            new Promise<BatchOperationWrapperUnknown>(resolve => {
+                resolve({
+                    operation: {
+                        operation: {
+                            type: 'smp',
+                            operation: 0,
+                            group_id: 64,
+                            command_id: 1,
+                            sequence_number: 0,
+                        },
+                    },
+                    ...callbacks,
+                } as BatchOperationWrapperUnknown);
+            })
+        );
+
+        return this;
+    }
+
     public firmwareRead(core: DeviceCore, callbacks?: Callbacks<Buffer>) {
         this.enqueueBatchOperationObject('fw-read', core, {
             ...callbacks,

--- a/nrfutil/device/boardController.ts
+++ b/nrfutil/device/boardController.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { Progress } from '../sandboxTypes';
+import { deviceSingleTaskEndOperationVoid, NrfutilDevice } from './common';
+
+export default (
+    device: NrfutilDevice,
+    data: object,
+    onProgress?: (progress: Progress) => void,
+    controller?: AbortController
+) => {
+    // "operation: 2, command_id: 0" is the command to set the configuration for the board controller.
+    const json = {
+        operations: [
+            {
+                operation: {
+                    type: 'smp',
+                    operation: 2,
+                    group_id: 64,
+                    command_id: 0,
+                    sequence_number: 0,
+                    data,
+                },
+                operationId: '1',
+            },
+        ],
+    };
+
+    return deviceSingleTaskEndOperationVoid(
+        device,
+        'x-execute-batch',
+        onProgress,
+        controller,
+        ['--batch-json', JSON.stringify(json)]
+    );
+};

--- a/nrfutil/device/device.ts
+++ b/nrfutil/device/device.ts
@@ -6,6 +6,7 @@
 
 import { LogLevel, LogMessage } from '../sandboxTypes';
 import { Batch } from './batch';
+import boardController from './boardController';
 import { getDeviceSandbox } from './common';
 import deviceInfo from './deviceInfo';
 import erase from './erase';
@@ -59,5 +60,6 @@ export default {
     setLogLevel,
     setVerboseLogging,
     getModuleVersion,
+    boardController,
     batch: () => new Batch(),
 };

--- a/nrfutil/device/device.ts
+++ b/nrfutil/device/device.ts
@@ -11,6 +11,7 @@ import { getDeviceSandbox } from './common';
 import deviceInfo from './deviceInfo';
 import erase from './erase';
 import firmwareRead from './firmwareRead';
+import getBoardControllerVersion from './getBoardControllerVersion';
 import getCoreInfo from './getCoreInfo';
 import getFwInfo from './getFwInfo';
 import getProtectionStatus from './getProtectionStatus';
@@ -61,5 +62,6 @@ export default {
     setVerboseLogging,
     getModuleVersion,
     boardController,
+    getBoardControllerVersion,
     batch: () => new Batch(),
 };

--- a/nrfutil/device/getBoardControllerVersion.ts
+++ b/nrfutil/device/getBoardControllerVersion.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { Progress } from '../sandboxTypes';
+import { deviceSingleTaskEndOperation, NrfutilDevice } from './common';
+
+export interface BoardControllerVersionResponse {
+    data: BoardControllerVersion;
+}
+
+export interface BoardControllerVersion {
+    bc_fw_ver: string;
+    device_id: string;
+    major_ver: number;
+    minor_ver: number;
+    patch_ver: number;
+    pca_num: number;
+}
+
+export default (
+    device: NrfutilDevice,
+    onProgress?: (progress: Progress) => void,
+    controller?: AbortController
+) => {
+    // "operation: 0, command_id: 1" is the command to retrieve version information from the board controller.
+    const json = {
+        operations: [
+            {
+                operation: {
+                    type: 'smp',
+                    operation: 0,
+                    group_id: 64,
+                    command_id: 1,
+                    sequence_number: 0,
+                },
+                operationId: '1',
+            },
+        ],
+    };
+
+    return deviceSingleTaskEndOperation<BoardControllerVersionResponse>(
+        device,
+        'x-execute-batch',
+        onProgress,
+        controller,
+        ['--batch-json', JSON.stringify(json)]
+    ).then(res => res.data);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "138.0.0",
+    "version": "139.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Added nrfutil-device command wrappers for two board controller related commands:
* boardController() for setting a configuration JSON
* getBoardControllerVersion() for getting the boardcontroller fw version and board revision