### PR TITLE
Feat/persist log visible

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,16 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 140.0.0 - Unreleased
+
+### Added
+
+-   `isLogVisible` state is not persisted per App.
+
+### Changed
+
+-   `showLogByDefault` will not be used if `isLogVisible` is set.
+
 ## 140.0.0 - 2023-12-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "140.0.0",
+    "version": "141.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -38,8 +38,8 @@ import {
     isLogVisible as isLogVisibleSelector,
     isSidePanelVisible as isSidePanelVisibleSelector,
     setCurrentPane,
+    setLogVisible,
     setPanes,
-    toggleLogVisible,
 } from './appLayout';
 import ConnectedToStore from './ConnectedToStore';
 import VisibilityBar from './VisibilityBar';
@@ -116,7 +116,7 @@ const ConnectedApp: FC<ConnectedAppProps> = ({
 
     useEffect(() => {
         if (!showLogByDefault) {
-            dispatch(toggleLogVisible());
+                dispatch(setLogVisible(showLogByDefault));
         }
     }, [dispatch, showLogByDefault]);
 

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -30,7 +30,10 @@ import LogViewer from '../Log/LogViewer';
 import logger from '../logging';
 import NavBar from '../NavBar/NavBar';
 import classNames from '../utils/classNames';
-import { getPersistedCurrentPane } from '../utils/persistentStore';
+import {
+    getPersistedCurrentPane,
+    getPersistedLogVisible,
+} from '../utils/persistentStore';
 import usageData from '../utils/usageData';
 import useHotKey from '../utils/useHotKey';
 import {
@@ -115,8 +118,15 @@ const ConnectedApp: FC<ConnectedAppProps> = ({
     }, [dispatch, autoReselectByDefault]);
 
     useEffect(() => {
-        if (!showLogByDefault) {
+        const persistedLogVisible = getPersistedLogVisible();
+        // If they are equal, the current setting is already correct
+        // getPersistedLogVisible is used to initialise the redux state
+        if (showLogByDefault !== getPersistedLogVisible()) {
+            if (persistedLogVisible !== undefined) {
+                dispatch(setLogVisible(persistedLogVisible));
+            } else {
                 dispatch(setLogVisible(showLogByDefault));
+            }
         }
     }, [dispatch, showLogByDefault]);
 

--- a/src/App/VisibilityBar.tsx
+++ b/src/App/VisibilityBar.tsx
@@ -18,7 +18,7 @@ import useHotKey from '../utils/useHotKey';
 import {
     isLogVisible as isLogVisibleSelector,
     isSidePanelVisible as isSidePanelVisibleSelector,
-    toggleLogVisible,
+    setLogVisible,
     toggleSidePanelVisible,
 } from './appLayout';
 
@@ -48,7 +48,7 @@ export default ({ isSidePanelEnabled }: { isSidePanelEnabled: boolean }) => {
         hotKey: 'ctrl+l',
         title: 'Show log',
         isGlobal: true,
-        action: () => dispatch(toggleLogVisible()),
+        action: () => dispatch(setLogVisible(!isLogVisible)),
     });
 
     return (
@@ -93,7 +93,7 @@ export default ({ isSidePanelEnabled }: { isSidePanelEnabled: boolean }) => {
                     id="visibility-bar-show-log"
                     label="Show log"
                     title="ctrl+l"
-                    onToggle={() => dispatch(toggleLogVisible())}
+                    onToggle={() => dispatch(setLogVisible(!isLogVisible))}
                     isToggled={isLogVisible}
                     variant="secondary"
                 />

--- a/src/App/appLayout.ts
+++ b/src/App/appLayout.ts
@@ -7,7 +7,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import type { RootState } from '../store';
-import { persistCurrentPane } from '../utils/persistentStore';
+import {
+    persistCurrentPane,
+    persistLogVisible,
+} from '../utils/persistentStore';
 
 export interface AppLayout {
     isSidePanelVisible: boolean;
@@ -42,6 +45,7 @@ const slice = createSlice({
     reducers: {
         setLogVisible: (state, action: PayloadAction<boolean>) => {
             state.isLogVisible = action.payload;
+            persistLogVisible(action.payload);
         },
         toggleSidePanelVisible: state => {
             state.isSidePanelVisible = !state.isSidePanelVisible;

--- a/src/App/appLayout.ts
+++ b/src/App/appLayout.ts
@@ -8,6 +8,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import type { RootState } from '../store';
 import {
+    getPersistedLogVisible,
     persistCurrentPane,
     persistLogVisible,
 } from '../utils/persistentStore';
@@ -21,7 +22,7 @@ export interface AppLayout {
 
 const initialState: AppLayout = {
     isSidePanelVisible: true,
-    isLogVisible: true,
+    isLogVisible: !!getPersistedLogVisible(),
     currentPane: 0,
     paneNames: [],
 };

--- a/src/App/appLayout.ts
+++ b/src/App/appLayout.ts
@@ -40,8 +40,8 @@ const slice = createSlice({
     name: 'appLayout',
     initialState,
     reducers: {
-        toggleLogVisible: state => {
-            state.isLogVisible = !state.isLogVisible;
+        setLogVisible: (state, action: PayloadAction<boolean>) => {
+            state.isLogVisible = action.payload;
         },
         toggleSidePanelVisible: state => {
             state.isSidePanelVisible = !state.isSidePanelVisible;
@@ -76,7 +76,7 @@ export const {
     actions: {
         setCurrentPane,
         setPanes,
-        toggleLogVisible,
+        setLogVisible,
         toggleSidePanelVisible,
         switchToNextPane,
         switchToPreviousPane,

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -144,6 +144,7 @@ let appSpecificStore: Store | undefined;
 
 interface SharedAppSpecificStoreSchema {
     currentPane?: number;
+    isLogVisible?: boolean;
 }
 
 export const getAppSpecificStore = <
@@ -175,3 +176,10 @@ export const persistCurrentPane = (currentPane: number) =>
     );
 export const getPersistedCurrentPane = () =>
     getAppSpecificStore<SharedAppSpecificStoreSchema>().get(`currentPane`);
+export const persistLogVisible = (visible: boolean) =>
+    getAppSpecificStore<SharedAppSpecificStoreSchema>().set(
+        `isLogVisible`,
+        visible
+    );
+export const getPersistedLogVisible = () =>
+    getAppSpecificStore<SharedAppSpecificStoreSchema>().get(`isLogVisible`);


### PR DESCRIPTION
Whether the Log is now expanded or collapsed by default will be determined by a persisted state, saved per App.
If the persisted state does not exist yet, it will still fall back on to the `showLogByDefault` flag passed to the `App` component.