### PR TITLE
Fix: Font size of error details

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 147.0.0 - 2024-01-09
+
+### Fixed
+
+-   Error details had a larger font size (16px) than the rest of the body of an
+    error dialog (14px).
+
 ## 146.0.0 - 2024-01-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "146.0.0",
+    "version": "147.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Dialog/dialog.scss
+++ b/src/Dialog/dialog.scss
@@ -42,6 +42,7 @@
         padding: 32px 16px 16px 16px;
         margin: 0;
         p,
+        details,
         li {
             font-size: 14px;
         }


### PR DESCRIPTION
Error details had a larger font size (16px) than the rest of the body of an error dialog (14px).

Before the fix:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/ccfc515a-95d2-4f5e-9abd-025bb23a5a0a)

With the fix:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/c4d1611a-cd0e-4c22-b54a-fcba4fbf1551)
