### PR TITLE
Fix: Unhandled error on some `nrfutil` invocations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,12 @@ every new version is a new major version.
 
 -   `Overlay` tooltip inner padding should be set by the content within it.
 
+### Added
+
+-   Ability to remove the launcher window again. This is especially needed on
+    shutdown. Otherwise when at that time someone still tries to send IPC
+    messages to the launcher window, an exception is thrown.
+
 ### Fixed
 
 -   `Overlay` tooltips weren't centered due to incorrect sizing styles.

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,11 @@ every new version is a new major version.
 ### Fixed
 
 -   `Overlay` tooltips weren't centered due to incorrect sizing styles.
+-   When spawning the nrfutil process fails in certain ways, an uncaught
+    exception in the main process got thrown. The “certain ways” make this a bit
+    hard to reproduce: On macOS this happened, when the nrfutil executable did
+    not have the executable file mode. Usually this should not happen, because
+    we set that mode ourselves correctly.
 
 ## 149.0.0 - 2024-01-16
 

--- a/ipc/infrastructure/mainToRenderer.ts
+++ b/ipc/infrastructure/mainToRenderer.ts
@@ -12,6 +12,10 @@ export const registerLauncherWindowFromMain = (window: BrowserWindow) => {
     launcherWindow = window;
 };
 
+export const removeLauncherWindowFromMain = () => {
+    launcherWindow = undefined;
+};
+
 export const send =
     <T extends (...args: never[]) => void>(channel: string) =>
     (...args: Parameters<T>) =>

--- a/main/index.ts
+++ b/main/index.ts
@@ -15,7 +15,10 @@ import {
     inRenderer as inRendererSerialPort,
 } from '../ipc/serialPort';
 
-export { registerLauncherWindowFromMain } from '../ipc/infrastructure/mainToRenderer';
+export {
+    registerLauncherWindowFromMain,
+    removeLauncherWindowFromMain,
+} from '../ipc/infrastructure/mainToRenderer';
 
 export const appDetails = { forRenderer: forRendererAppDetails };
 export const apps = { forRenderer: forRendererApps };

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -374,6 +374,10 @@ export class NrfutilSandbox {
                 onStdError(data, nrfutil.pid);
             });
 
+            nrfutil.on('error', err => {
+                reject(err);
+            });
+
             nrfutil.on('close', code => {
                 controller?.signal.removeEventListener('abort', listener);
                 if (aborting) {


### PR DESCRIPTION
When spawning the `nrfutil` process fails in certain ways, an uncaught exception in the main process got thrown. 

The “certain ways” make this a bit    hard to reproduce: On macOS this happened, when the `nrfutil` executable did    not have the executable file mode. Usually this should not happen, because    we set that mode ourselves correctly.

But _when_ it happened (and there are probably more ways that can lead to this) a really ugly native dialog message was shown, because it was not reported back to the launcher as an error. The dialog looked e.g. like this: 

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/260705/d58f0f53-e2a3-49b5-803e-e765dcf7f934)

The second change gives the launcher the ability to remove the launcher window from being used in IPC calls. This is especially needed on    shutdown. Otherwise when at that time someone still tries to send IPC    messages to the launcher window, an exception is thrown, resulting in a similarly ugly dialog.