### PR TITLE
Linter should ignore resources

### DIFF
--- a/config/eslintrc.js
+++ b/config/eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     ],
     ignorePatterns: [
         'doc/docs/',
+        'resources/',
         'package-lock.json',
         'scripts/nordic-publish.js',
         'typings/generated',


### PR DESCRIPTION
Would solve issues where resource files should not be auto formatted:
e.g. https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/pull/419