### PR TITLE
fix: make supported devices a string enum in legacy parsing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 154.0.0 - 2024-02-05
+
+### Changed
+
+-   `packageJsonLegacyApp` type for `supportedDevices` is now `string[]`.
+
 ## 153.0.0 - 2024-02-05
 
 ### Added

--- a/ipc/schema/packageJson.ts
+++ b/ipc/schema/packageJson.ts
@@ -63,6 +63,7 @@ export const parsePackageJsonApp =
 // and the html in it can also be undefined, so there we need to use this legacy variant
 const packageJsonLegacyApp = packageJsonApp.extend({
     nrfConnectForDesktop: nrfConnectForDesktop
+        .extend({ supportedDevices: z.array(z.string()).nonempty().optional() })
         .partial({ html: true })
         .optional(),
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "153.0.0",
+    "version": "154.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This is mostly relevant for the launcher as the legacy parsing is used there. When adding a new device, it would otherwise require us to update shared and use that new version in both the app and the launcher.