### PR TITLE
Feat/dropdown styles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 159.0.0 - UNRELEASED
+
+### Added
+
+-   `minWidth` parameter to `Dropdown` component.
+-   `transparentButtonBg` parameter to `Dropdown` component.
+
 ## 158.0.0 - 2024-02-22
 
 ### Added

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -22,6 +22,7 @@ export type DropdownProps<T> = {
     defaultButtonLabel?: string;
     items: DropdownItem<T>[];
     onSelect: (item: DropdownItem<T>) => void;
+    transparentButtonBg?: boolean;
     minWidth?: boolean;
     disabled?: boolean;
     selectedItem: DropdownItem<T>;
@@ -35,6 +36,7 @@ export default <T,>({
     defaultButtonLabel = '',
     items,
     onSelect,
+    transparentButtonBg = false,
     minWidth = false,
     disabled = false,
     selectedItem,
@@ -68,8 +70,11 @@ export default <T,>({
                 id={id}
                 type="button"
                 className={classNames(
-                    'tw-flex tw-h-8 tw-items-center tw-justify-between tw-border-0 tw-bg-gray-700 tw-px-2 tw-text-white',
+                    'tw-flex tw-items-center tw-justify-between tw-border-0',
                     minWidth ? '' : 'tw-w-full',
+                    transparentButtonBg
+                        ? 'tw-bg-transparent'
+                        : 'tw-h-8 tw-bg-gray-700 tw-px-2 tw-text-white'
                 )}
                 onClick={() => setIsActive(!isActive)}
                 disabled={disabled}
@@ -80,7 +85,7 @@ export default <T,>({
                         : selectedItem.label}
                 </span>
                 <span
-                    className={`mdi mdi-chevron-down tw-text-lg ${classNames(
+                    className={`mdi mdi-chevron-down tw-text-lg/none ${classNames(
                         isActive && 'tw-rotate-180'
                     )}`}
                 />

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -22,6 +22,7 @@ export type DropdownProps<T> = {
     defaultButtonLabel?: string;
     items: DropdownItem<T>[];
     onSelect: (item: DropdownItem<T>) => void;
+    minWidth?: boolean;
     disabled?: boolean;
     selectedItem: DropdownItem<T>;
     numItemsBeforeScroll?: number;
@@ -34,6 +35,7 @@ export default <T,>({
     defaultButtonLabel = '',
     items,
     onSelect,
+    minWidth = false,
     disabled = false,
     selectedItem,
     numItemsBeforeScroll = 0,
@@ -48,7 +50,11 @@ export default <T,>({
 
     return (
         <div
-            className={`tw-preflight tw-relative tw-w-full ${className}`}
+            className={classNames(
+                'tw-preflight tw-relative',
+                minWidth ? '' : 'tw-w-full',
+                className
+            )}
             onBlur={event => {
                 if (!event.currentTarget.contains(event.relatedTarget)) {
                     setIsActive(false);
@@ -61,7 +67,10 @@ export default <T,>({
             <button
                 id={id}
                 type="button"
-                className="tw-flex tw-h-8 tw-w-full tw-items-center tw-justify-between tw-border-0 tw-bg-gray-700 tw-px-2 tw-text-white"
+                className={classNames(
+                    'tw-flex tw-h-8 tw-items-center tw-justify-between tw-border-0 tw-bg-gray-700 tw-px-2 tw-text-white',
+                    minWidth ? '' : 'tw-w-full',
+                )}
                 onClick={() => setIsActive(!isActive)}
                 disabled={disabled}
             >
@@ -93,8 +102,9 @@ export default <T,>({
                     numItemsBeforeScroll > 0 &&
                     items.length > numItemsBeforeScroll
                 }
-                className={`tw-text-while tw-absolute tw-right-0 tw-z-10 tw-w-full tw-border-t-2 tw-border-solid tw-border-gray-600 tw-bg-gray-700 tw-p-0 ${classNames(
+                className={`tw-text-while tw-absolute tw-z-10 tw-border-t-2 tw-border-solid tw-border-gray-600 tw-bg-gray-700 tw-p-0 ${classNames(
                     styles.content,
+                    minWidth ? '' : 'tw-right-0 tw-w-full',
                     !isActive && 'tw-hidden'
                 )}`}
             >


### PR DESCRIPTION
Added options to dropdown which changes styling:

**Transparent main button:**
![Screenshot from 2024-02-15 15-40-01](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/30871542/4a0174e0-6267-4bdb-bbda-a2aa59480e5f)

**Min width for dropdown button (don't take full width):**
![Screenshot from 2024-02-15 15-40-14](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/30871542/26dd7749-7c9a-4b0a-8de2-6385284b9685)
![Screenshot from 2024-02-15 15-40-21](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/30871542/83d78fe5-2910-4f9c-8a25-7b9be45723c5)


**Update**
Removed height of the button when transparent
![Screenshot from 2024-02-16 11-44-23](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/30871542/5452f712-6fd2-4df8-9f29-e5d8651864f3)
![Screenshot from 2024-02-16 11-44-32](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/assets/30871542/640618b3-09ea-4f3c-ab5f-71b92b1aac2b)
