### PR TITLE
Feat: Add publishing date for non-official sources

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 172.0.0 - UNRELEASED
+
+### Added
+
+-   Publish timestamp for nordic-publish for non-official sources
+
 ## 171.0.0 - 2024-04-04
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,12 +7,6 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 175.0.0 - UNRELEASED
-
-### Added
-
--   Publish timestamp for nordic-publish for non-official sources.
-
 ## 174.0.0 - UNRELEASED
 
 ### Added
@@ -20,6 +14,7 @@ every new version is a new major version.
 -   `setPaneDisabled` to disable a pane from the `NavMenu`.
 -   `setPaneHidden` to hide a pane from the `NavMenu`.
 -   `preHidden` and `preDisabled` properties in `Pane` type passed to `App`.
+-   Publish timestamp for nordic-publish for non-official sources.
 
 #### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 174.0.0 - UNRELEASED
+## 174.0.0 - 2024-04-30
 
 ### Added
 

--- a/ipc/MetaFiles.ts
+++ b/ipc/MetaFiles.ts
@@ -21,6 +21,7 @@ export type AppVersions = {
 
 export type AppVersion = {
     shasum?: string;
+    publishTimestamp?: string;
     tarballUrl: UrlString;
     nrfutilModules?: NrfutilModules;
 };

--- a/ipc/apps.ts
+++ b/ipc/apps.ts
@@ -34,6 +34,7 @@ interface Installed {
     repositoryUrl?: UrlString;
     html?: string;
     installed: {
+        publishTimestamp?: string;
         path: string;
         shasum?: string;
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "150.0.0",
+    "version": "172.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "172.0.0",
+    "version": "174.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "171.0.0",
+    "version": "172.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "175.0.0",
+    "version": "174.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -17,19 +17,17 @@ import { AppInfo, SourceJson } from '../ipc/MetaFiles';
 import { PackageJsonApp } from '../ipc/schema/packageJson';
 import checkAppProperties from './check-app-properties';
 
-interface LegacyAppDist {
-    publishTimestamp?: string;
-    tarball: string;
-    shasum: string;
-}
-
 interface LegacyAppInfo {
     ['dist-tags']?: {
         latest?: string;
     };
     versions?: {
         [version: string]: {
-            dist: LegacyAppDist;
+            dist: {
+                publishTimestamp?: string;
+                tarball: string;
+                shasum: string;
+            };
         };
     };
 }
@@ -262,15 +260,6 @@ const updateLegacyAppInfo = (appInfo: LegacyAppInfo, app: App) => {
         }
     }
 
-    const dist: LegacyAppDist = {
-        tarball: `${app.sourceUrl}/${app.filename}`,
-        shasum: app.shasum,
-    };
-
-    if (!app.isOfficial) {
-        dist.publishTimestamp = new Date().toISOString();
-    }
-
     return {
         ...appInfo,
         'dist-tags': {
@@ -280,7 +269,11 @@ const updateLegacyAppInfo = (appInfo: LegacyAppInfo, app: App) => {
         versions: {
             ...appInfo.versions,
             [app.version]: {
-                dist,
+                dist: {
+                    publishTimestamp: new Date().toISOString(),
+                    tarball: `${app.sourceUrl}/${app.filename}`,
+                    shasum: app.shasum,
+                },
             },
         },
     };
@@ -411,6 +404,7 @@ const getUpdatedAppInfo = async (app: App): Promise<AppInfo> => {
             ...versions,
             [version]: {
                 tarballUrl: `${app.sourceUrl}/${app.filename}`,
+                publishTimestamp: new Date().toISOString(),
                 shasum: app.shasum,
                 nrfutilModules,
             },

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -17,16 +17,19 @@ import { AppInfo, SourceJson } from '../ipc/MetaFiles';
 import { PackageJsonApp } from '../ipc/schema/packageJson';
 import checkAppProperties from './check-app-properties';
 
+interface LegacyAppDist {
+    publishTimestamp?: string;
+    tarball: string;
+    shasum: string;
+}
+
 interface LegacyAppInfo {
     ['dist-tags']?: {
         latest?: string;
     };
     versions?: {
         [version: string]: {
-            dist: {
-                tarball: string;
-                shasum: string;
-            };
+            dist: LegacyAppDist;
         };
     };
 }
@@ -259,6 +262,15 @@ const updateLegacyAppInfo = (appInfo: LegacyAppInfo, app: App) => {
         }
     }
 
+    const dist: LegacyAppDist = {
+        tarball: `${app.sourceUrl}/${app.filename}`,
+        shasum: app.shasum,
+    };
+
+    if (!app.isOfficial) {
+        dist.publishTimestamp = new Date().toISOString();
+    }
+
     return {
         ...appInfo,
         'dist-tags': {
@@ -268,10 +280,7 @@ const updateLegacyAppInfo = (appInfo: LegacyAppInfo, app: App) => {
         versions: {
             ...appInfo.versions,
             [app.version]: {
-                dist: {
-                    tarball: `${app.sourceUrl}/${app.filename}`,
-                    shasum: app.shasum,
-                },
+                dist,
             },
         },
     };


### PR DESCRIPTION
Motivation: We use sha sum to calculate if build is updated, but sometimes I'm missing timestamps when same version is released over and over again, ending up testing wrong version of the build.