### PR TITLE
Remove legacy app info file upload

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,10 @@ every new version is a new major version.
 -   `currentPane` now returns the current pane name instead of index.
 -   Persisted `currentPane` value is now the pane name instead of index.
 
+### Removed
+
+-   Removed upload of legacy app info files when publishing apps.
+
 ### Steps to upgrade when using this package
 
 -   Update all `currentPane` calls to work with strings instead of indexes.


### PR DESCRIPTION
This removes upload of legacy app info file (e.g. https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/pc-nrfconnect-rssi) while the new app info files (e.g. https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/pc-nrfconnect-rssi.json) will continue to be uploaded.

Those legacy files are only used by old versions of the launcher (< 4.0.0). All launcher releases since February 2023 do not use the legacy files but the new ones. Older versions of the launcher probably do not run recent versions of the apps anyhow (e.g. because they require `nrfutil`), so it is fine to not supply those old launcher versions with new app versions.

This PR was previously based on #914, but I now made it independent of it, so this can be merged without that.