### PR TITLE
Exports getDevices for applications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export { jprogDeviceSetup } from './Device/jprogOperations';
 export { sdfuDeviceSetup } from './Device/sdfuOperations';
 
 export {
+    getDevices,
     selectedDevice,
     selectedDeviceInfo,
     setSelectedDeviceInfo,


### PR DESCRIPTION
Allows for use of getDevices in applications

Allows for use in applications like Cellular Monitor to allow selection of a terminal serial port that isn't associated with the trace device.

Signed-off-by Jared Wolff <hello@jaredwolff.com>