### PR TITLE
Handle "Failed to get the library versions" if error is undefined

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,17 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 183.0.0 - unreleased
+
+### Changed
+
+-   Update JLink macOS install link pointing from `V788j` to `V794e`.
+
+### Fixed
+
+-   Do not display `undefined` or `null` in the "Failed to get the library
+    versions" error message.
+
 ## 182.0.0 - 2024-08-16
 
 ### Added

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -113,11 +113,10 @@ export default async (moduleVersion: ModuleVersion) => {
             }
         }
     } catch (error) {
-        let message = '';
-       logger?.error(
-             `Failed to get the library versions${
-                 error != null ? `: ${describeError(error)}` : ''
-             }`
-         );
+        logger?.error(
+            `Failed to get the library versions${
+                error != null ? `: ${describeError(error)}` : ''
+            }`
+        );
     }
 };

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -108,7 +108,7 @@ export default async (moduleVersion: ModuleVersion) => {
                     `It looks like you have installed JLink using ${JLinkInstallerVersion}, but currently we only support their Universal Installer for your system.`
                 );
                 logger?.warn(
-                    `Please install JLink: https://www.segger.com/downloads/jlink/JLink_MacOSX_V788j_universal.pkg`
+                    `Please install JLink: https://www.segger.com/downloads/jlink/JLink_MacOSX_V794e_universal.pkg`
                 );
             }
         }

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -113,10 +113,14 @@ export default async (moduleVersion: ModuleVersion) => {
             }
         }
     } catch (error) {
-        logger?.error(
-            `Failed to get the library versions${
-                error == null ? `: ${describeError(error)}` : ''
-            }`
-        );
+        let message = '';
+        if (error == null) {
+            message = describeError(error);
+        }
+        if (error === undefined) {
+            message = '';
+        }
+
+        logger?.error(`Failed to get the library versions${message}`);
     }
 };

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -114,13 +114,10 @@ export default async (moduleVersion: ModuleVersion) => {
         }
     } catch (error) {
         let message = '';
-        if (error == null) {
-            message = describeError(error);
-        }
-        if (error === undefined) {
-            message = '';
-        }
-
-        logger?.error(`Failed to get the library versions${message}`);
+       logger?.error(
+             `Failed to get the library versions${
+                 error != null ? `: ${describeError(error)}` : ''
+             }`
+         );
     }
 };


### PR DESCRIPTION
**What it does?**
Removes "undefined" from the error message

<img width="695" alt="image-20240823-002216" src="https://github.com/user-attachments/assets/a8bdec2a-da05-47dc-9740-a3eb836efa66">

---
Code I don't like much, but it definitely doesn't break existing one :)