### PR TITLE
Upgrade `nrfutil` core before installing a command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 190.0.0 - Unreleased
+
+### Changed
+
+-   nrfutil: The core gets upgraded before installing a command.
+
 ## 189.0.0 - 2024-10-18
 
 ### Added

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -201,6 +201,7 @@ export class NrfutilSandbox {
                     force: true,
                 });
             }
+            await this.updateNrfUtilCore();
             await this.spawnNrfutil(
                 'install',
                 [`${this.module}=${this.version}`, '--force'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "189.0.0",
+    "version": "190.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This is currently not critical but potentially helpful in two cases:

- Currently the latest nrfutil wrapper, downloadable from https://www.nordicsemi.com/Products/Development-tools/nRF-Util/Download#infotabs, initially only downloads and installs nrfutil-core 7.12.0, not the latest 7.13.0. To get the latest version, `self-upgrade` needs to be run once. The developers of nrfutil do not seem to consider this a bug. For us the changes between 7.12.0 and 7.13.0 are not critical, but in the future it might become more important, that we use the fixes of the latest version.
- A few months ago the nrfutil package index was changed. Older nrfutil wrappers (e.g. the one we shipped with launcher 5.0.0) didn't know the new package index and only installed an old version of the core (7.7.1) which then only found outdated versions of the nrfutil commands. By first calling `self-upgrade` this problem would have been remidied. Since a new version of the launcher with a new wrapper is already out, this is not a problem anymore, but if a situation like this happens again, we would be prepared better now.