### PR TITLE
Enhance nrfutil code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@ every new version is a new major version.
 
 -   nrfutil: The core gets upgraded before installing a command.
 -   nrfutil: The `version` properties of dependencies are now optional,
-    reflecting the behaviour since nrfutil-device 2.7.
+    reflecting the behaviour since `nrfutil-device` v2.7.0.
 -   Warning for J-Link versions: Only inform (not warn) if the installed version
     is newer than the tested version. Updated the text for all cases.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ every new version is a new major version.
 
 -   nrfutil: The core gets upgraded before installing a command.
 
+### Removed
+
+-   Export of internal type `SemanticVersion`.
+
 ## 190.0.0 - 2024-11-06
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 191.0.0 - Unreleased
+
+### Changed
+
+-   nrfutil: The core gets upgraded before installing a command.
+
 ## 190.0.0 - 2024-11-06
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ every new version is a new major version.
 -   nrfutil: The core gets upgraded before installing a command.
 -   nrfutil: The `version` properties of dependencies are now optional,
     reflecting the behaviour since nrfutil-device 2.7.
+-   Warning for J-Link versions: Only inform (not warn) if the installed version
+    is newer than the tested version. Updated the text for all cases.
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,10 @@ every new version is a new major version.
 
 ## 191.0.0 - Unreleased
 
+### Added
+
+-   Function `getJlinkCompatibility`.
+
 ### Changed
 
 -   nrfutil: The core gets upgraded before installing a command.

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ every new version is a new major version.
 ### Changed
 
 -   nrfutil: The core gets upgraded before installing a command.
+-   nrfutil: The `version` properties of dependencies are now optional,
+    reflecting the behaviour since nrfutil-device 2.7.
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 191.0.0 - Unreleased
+## 191.0.0 - 2024-11-14
 
 ### Added
 

--- a/ipc/MetaFiles.ts
+++ b/ipc/MetaFiles.ts
@@ -54,9 +54,6 @@ const nrfutilModuleVersion = semver;
 export type NrfutilModuleName = z.infer<typeof nrfutilModuleName>;
 export type NrfutilModuleVersion = z.infer<typeof nrfutilModuleVersion>;
 
-export const nrfModules = z.record(
-    nrfutilModuleName,
-    nrfutilModuleVersion.array().nonempty()
-);
+export const nrfModules = z.record(nrfutilModuleName, z.tuple([semver]));
 
 export type NrfutilModules = z.infer<typeof nrfModules>;

--- a/ipc/apps.ts
+++ b/ipc/apps.ts
@@ -5,7 +5,7 @@
  */
 
 import { handle, invoke } from './infrastructure/rendererToMain';
-import { AppVersions, UrlString } from './MetaFiles';
+import type { AppVersions, NrfutilModules, UrlString } from './MetaFiles';
 import { LOCAL, Source, SourceName } from './sources';
 
 export interface AppSpec {
@@ -33,6 +33,7 @@ interface Installed {
     engineVersion?: string;
     repositoryUrl?: UrlString;
     html?: string;
+    nrfutil?: NrfutilModules;
     installed: {
         publishTimestamp?: string;
         path: string;

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -14,9 +14,12 @@ import {
     resolveModuleVersion,
 } from '../moduleVersion';
 import { getNrfutilLogger } from '../nrfutilLogger';
-import type { ModuleVersion, SubDependency } from '../sandboxTypes';
+import type { DiscriminatedVersion, ModuleVersion } from '../sandboxTypes';
 
-const log = (description: string, moduleVersion?: SubDependency | string) => {
+const log = (
+    description: string,
+    moduleVersion?: DiscriminatedVersion | string
+) => {
     const logger = getNrfutilLogger();
     if (moduleVersion == null) {
         logger?.warn(`Unable to detect version of ${description}.`);

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -14,18 +14,20 @@ import {
     resolveModuleVersion,
 } from '../moduleVersion';
 import { getNrfutilLogger } from '../nrfutilLogger';
-import type { DiscriminatedVersion, ModuleVersion } from '../sandboxTypes';
+import type { Dependency, ModuleVersion } from '../sandboxTypes';
 
 const log = (
     description: string,
-    moduleVersion?: DiscriminatedVersion | string
+    dependencyOrVersion?: Dependency | string
 ) => {
     const logger = getNrfutilLogger();
-    if (moduleVersion == null) {
+    if (dependencyOrVersion == null) {
         logger?.warn(`Unable to detect version of ${description}.`);
     } else {
         logger?.info(
-            `Using ${description} version: ${describeVersion(moduleVersion)}`
+            `Using ${description} version: ${describeVersion(
+                dependencyOrVersion
+            )}`
         );
     }
 };
@@ -86,7 +88,7 @@ export default async (moduleVersion: ModuleVersion) => {
 
         if (jlinkVersion) {
             const result = getExpectedVersion(jlinkVersion);
-            if (!result.isExpectedVersion) {
+            if (result != null && !result.isExpectedVersion) {
                 logger?.warn(
                     `Installed JLink version does not match the expected version (${result.expectedVersion})`
                 );

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -86,21 +86,21 @@ export default async (moduleVersion: ModuleVersion) => {
         switch (jlinkCompatibility.kind) {
             case 'No J-Link installed':
                 logger?.warn(
-                    `Segger J-Link is not installed. ` +
+                    `SEGGER J-Link is not installed. ` +
                         `Install at least version ${jlinkCompatibility.requiredJlink} ` +
                         `from https://www.segger.com/downloads/jlink`
                 );
                 break;
             case 'Outdated J-Link':
                 logger?.warn(
-                    `Outdated Segger J-Link. Your version of Segger J-Link (${jlinkCompatibility.actualJlink}) ` +
+                    `Outdated SEGGER J-Link. Your version of SEGGER J-Link (${jlinkCompatibility.actualJlink}) ` +
                         `is older than the one this app was tested with (${jlinkCompatibility.requiredJlink}). ` +
-                        `Install a newer version from https://www.segger.com/downloads/jlink`
+                        `Install the newer version from https://www.segger.com/downloads/jlink`
                 );
                 break;
             case 'Newer J-Link is used':
                 logger?.info(
-                    `Your version of Segger J-Link (${jlinkCompatibility.actualJlink}) ` +
+                    `Your version of SEGGER J-Link (${jlinkCompatibility.actualJlink}) ` +
                         `is newer than the one this app was tested with (${jlinkCompatibility.requiredJlink}). ` +
                         `The tested version is not required, and your J-Link version will most likely work fine.` +
                         ` If you get issues related to J-Link with your devices, use the tested version.`

--- a/nrfutil/device/logLibVersions.ts
+++ b/nrfutil/device/logLibVersions.ts
@@ -10,8 +10,8 @@ import os from 'os';
 import describeError from '../../src/logging/describeError';
 import {
     describeVersion,
+    findDependency,
     getExpectedVersion,
-    resolveModuleVersion,
 } from '../moduleVersion';
 import { getNrfutilLogger } from '../nrfutilLogger';
 import type { Dependency, ModuleVersion } from '../sandboxTypes';
@@ -80,11 +80,11 @@ export default async (moduleVersion: ModuleVersion) => {
         const dependencies = moduleVersion.dependencies;
 
         log('nrfutil-device', moduleVersion.version);
-        log('nrf-device-lib', resolveModuleVersion('nrfdl', dependencies));
-        log('nrfjprog DLL', resolveModuleVersion('jprog', dependencies));
-        log('JLink', resolveModuleVersion('JlinkARM', dependencies));
+        log('nrf-device-lib', findDependency('nrfdl', dependencies));
+        log('nrfjprog DLL', findDependency('jprog', dependencies));
+        log('JLink', findDependency('JlinkARM', dependencies));
 
-        const jlinkVersion = resolveModuleVersion('JlinkARM', dependencies);
+        const jlinkVersion = findDependency('JlinkARM', dependencies);
 
         if (jlinkVersion) {
             const result = getExpectedVersion(jlinkVersion);

--- a/nrfutil/index.ts
+++ b/nrfutil/index.ts
@@ -6,7 +6,7 @@
 
 export { default as prepareSandbox } from './sandbox';
 export { NrfutilSandbox } from './sandbox';
-export type { Progress, SemanticVersion } from './sandboxTypes';
+export type { Progress } from './sandboxTypes';
 export { getNrfutilLogger, setNrfutilLogger } from './nrfutilLogger';
 export {
     getModule,

--- a/nrfutil/index.ts
+++ b/nrfutil/index.ts
@@ -14,3 +14,4 @@ export {
     setVerboseLogging,
     getAllModuleVersions,
 } from './modules';
+export { getJlinkCompatibility } from './jlinkVersion';

--- a/nrfutil/jlinkVersion.test.ts
+++ b/nrfutil/jlinkVersion.test.ts
@@ -11,7 +11,7 @@ import {
     hasExpectedVersionFormat,
     strippedVersionName,
 } from './jlinkVersion';
-import type { ModuleVersion, SubDependency } from './sandboxTypes';
+import type { Dependency, ModuleVersion } from './sandboxTypes';
 
 // Note: In this test the space at the end of 'JLink_V7.96 ' or '7.96 ' is
 // intentional because it is also reported like that by nrfutil.
@@ -203,7 +203,7 @@ describe('existingIsOlderThanExpected', () => {
 
 describe('getJlinkCompatibility', () => {
     const createModuleVersion = (
-        ...dependencies: SubDependency[]
+        ...dependencies: Dependency[]
     ): ModuleVersion => ({
         classification: 'nrf-external',
         name: 'nrfutil-device',

--- a/nrfutil/jlinkVersion.test.ts
+++ b/nrfutil/jlinkVersion.test.ts
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    convertToSemver,
+    existingIsOlderThanExpected,
+    getJlinkCompatibility,
+    hasExpectedVersionFormat,
+    strippedVersionName,
+} from './jlinkVersion';
+import type { ModuleVersion, SubDependency } from './sandboxTypes';
+
+// Note: In this test the space at the end of 'JLink_V7.96 ' or '7.96 ' is
+// intentional because it is also reported like that by nrfutil.
+
+test('strippedVersionName', () => {
+    expect(
+        strippedVersionName({
+            version: '7.94i',
+            versionFormat: 'string',
+        })
+    ).toBe('7.94i');
+    expect(
+        strippedVersionName({
+            version: '7.96 ',
+            versionFormat: 'string',
+        })
+    ).toBe('7.96');
+});
+
+describe('expectedFormat', () => {
+    it('fails if the version format is not string', () => {
+        expect(
+            hasExpectedVersionFormat(
+                {
+                    version: 18,
+                    versionFormat: 'incremental',
+                },
+                false
+            )
+        ).toBe(false);
+
+        expect(
+            hasExpectedVersionFormat(
+                {
+                    version: { major: 1, minor: 2, patch: 3 },
+                    versionFormat: 'semantic',
+                },
+                false
+            )
+        ).toBe(false);
+    });
+
+    it('fails if the content is unexpected', () => {
+        const noJlinkPrefix = {
+            version: '7.94i',
+            versionFormat: 'string',
+        } as const;
+        expect(hasExpectedVersionFormat(noJlinkPrefix, false)).toBe(false);
+
+        const wrongCasing = {
+            version: 'jlink_v7.96',
+            versionFormat: 'string',
+        } as const;
+        expect(hasExpectedVersionFormat(wrongCasing, false)).toBe(false);
+
+        const unexpectedPostfix = {
+            version: 'JLink_V7.96-beta',
+            versionFormat: 'string',
+        } as const;
+        expect(hasExpectedVersionFormat(unexpectedPostfix, false)).toBe(false);
+    });
+
+    it('succeeds for expected content', () => {
+        expect(
+            hasExpectedVersionFormat(
+                {
+                    version: 'JLink_V7.94i',
+                    versionFormat: 'string',
+                },
+                false
+            )
+        ).toBe(true);
+        expect(
+            hasExpectedVersionFormat(
+                {
+                    version: 'JLink_V7.96 ',
+                    versionFormat: 'string',
+                },
+                false
+            )
+        ).toBe(true);
+        expect(
+            hasExpectedVersionFormat(
+                {
+                    version: 'JLink_V8.10',
+                    versionFormat: 'string',
+                },
+                false
+            )
+        ).toBe(true);
+    });
+});
+
+test('convertToSemver', () => {
+    expect(
+        convertToSemver({ version: 'JLink_V7.94', versionFormat: 'string' })
+    ).toBe('7.94.0');
+    expect(
+        convertToSemver({ version: 'JLink_V7.96 ', versionFormat: 'string' })
+    ).toBe('7.96.0');
+    expect(
+        convertToSemver({ version: 'JLink_V7.98a', versionFormat: 'string' })
+    ).toBe('7.98.1');
+    expect(
+        convertToSemver({ version: 'JLink_V8.10b', versionFormat: 'string' })
+    ).toBe('8.10.2');
+});
+
+describe('existingIsOlderThanExpected', () => {
+    const version794i = {
+        version: 'JLink_V7.94i',
+        versionFormat: 'string',
+    } as const;
+    const version794k = {
+        version: 'JLink_V7.94k',
+        versionFormat: 'string',
+    } as const;
+    const version796 = {
+        version: 'JLink_V7.96 ',
+        versionFormat: 'string',
+    } as const;
+    const version810b = {
+        version: 'JLink_V8.10b',
+        versionFormat: 'string',
+    } as const;
+
+    it('is false if no expected is specified', () => {
+        expect(
+            existingIsOlderThanExpected({ ...version794i, name: 'JlinkARM' })
+        ).toBe(false);
+    });
+    it('is false if the actual is equal the expected', () => {
+        expect(
+            existingIsOlderThanExpected({
+                ...version794i,
+                name: 'JlinkARM',
+                expectedVersion: version794i,
+            })
+        ).toBe(false);
+    });
+    it('is false if the actual is newer than the expected', () => {
+        expect(
+            existingIsOlderThanExpected({
+                ...version794k,
+                name: 'JlinkARM',
+                expectedVersion: version794i,
+            })
+        ).toBe(false);
+        expect(
+            existingIsOlderThanExpected({
+                ...version796,
+                name: 'JlinkARM',
+                expectedVersion: version794i,
+            })
+        ).toBe(false);
+        expect(
+            existingIsOlderThanExpected({
+                ...version810b,
+                name: 'JlinkARM',
+                expectedVersion: version794i,
+            })
+        ).toBe(false);
+    });
+
+    it('is true if the actual is older than the expected', () => {
+        expect(
+            existingIsOlderThanExpected({
+                ...version794i,
+                name: 'JlinkARM',
+                expectedVersion: version794k,
+            })
+        ).toBe(true);
+        expect(
+            existingIsOlderThanExpected({
+                ...version794i,
+                name: 'JlinkARM',
+                expectedVersion: version796,
+            })
+        ).toBe(true);
+        expect(
+            existingIsOlderThanExpected({
+                ...version794i,
+                name: 'JlinkARM',
+                expectedVersion: version810b,
+            })
+        ).toBe(true);
+    });
+});
+
+describe('getJlinkCompatibility', () => {
+    const createModuleVersion = (
+        ...dependencies: SubDependency[]
+    ): ModuleVersion => ({
+        classification: 'nrf-external',
+        name: 'nrfutil-device',
+        version: '2.5.0',
+        build_timestamp: '',
+        commit_date: '',
+        commit_hash: '',
+        dependencies: [
+            {
+                classification: 'nrf-external',
+                name: 'nrfdl',
+                versionFormat: 'semantic',
+                version: {
+                    major: 0,
+                    minor: 17,
+                    patch: 38,
+                },
+                dependencies,
+            },
+        ],
+        host: '',
+    });
+
+    it(`Reports no installed J-Link for for module versions reported by nrfutil-device before 2.7`, () => {
+        expect(getJlinkCompatibility(createModuleVersion())).toEqual({
+            kind: 'No J-Link installed',
+            requiredJlink: '7.94e',
+            actualJlink: 'none',
+        });
+    });
+
+    it(`Reports no installed J-Link for for module versions reported by nrfutil-device since 2.7`, () => {
+        expect(
+            getJlinkCompatibility(
+                createModuleVersion({
+                    name: 'JlinkARM',
+                    expectedVersion: {
+                        versionFormat: 'string',
+                        version: 'JLink_V8.10f',
+                    },
+                })
+            )
+        ).toEqual({
+            kind: 'No J-Link installed',
+            requiredJlink: '8.10f',
+            actualJlink: 'none',
+        });
+    });
+
+    it(`Reports an outdated JLink version`, () => {
+        expect(
+            getJlinkCompatibility(
+                createModuleVersion({
+                    name: 'JlinkARM',
+                    version: 'JLink_V7.94e',
+                    versionFormat: 'string',
+                    expectedVersion: {
+                        version: 'JLink_V7.94i',
+                        versionFormat: 'string',
+                    },
+                })
+            )
+        ).toEqual({
+            kind: 'Outdated J-Link',
+            requiredJlink: '7.94i',
+            actualJlink: '7.94e',
+        });
+    });
+
+    it(`Reports a newer JLink version is used`, () => {
+        expect(
+            getJlinkCompatibility(
+                createModuleVersion({
+                    name: 'JlinkARM',
+                    version: 'JLink_V8.10f',
+                    versionFormat: 'string',
+                    expectedVersion: {
+                        version: 'JLink_V7.94i',
+                        versionFormat: 'string',
+                    },
+                })
+            )
+        ).toEqual({
+            kind: 'Newer J-Link is used',
+            requiredJlink: '7.94i',
+            actualJlink: '8.10f',
+        });
+    });
+
+    it(`Reports the tested JLink version is used`, () => {
+        expect(
+            getJlinkCompatibility(
+                createModuleVersion({
+                    name: 'JlinkARM',
+                    version: 'JLink_V7.94i',
+                    versionFormat: 'string',
+                    expectedVersion: {
+                        version: 'JLink_V7.94i',
+                        versionFormat: 'string',
+                    },
+                })
+            )
+        ).toEqual({ kind: 'Tested J-Link is used' });
+    });
+
+    it(`Reports the tested JLink version is used by specifying no expected version`, () => {
+        expect(
+            getJlinkCompatibility(
+                createModuleVersion({
+                    name: 'JlinkARM',
+                    version: 'JLink_V7.94i',
+                    versionFormat: 'string',
+                })
+            )
+        ).toEqual({ kind: 'Tested J-Link is used' });
+    });
+});

--- a/nrfutil/jlinkVersion.test.ts
+++ b/nrfutil/jlinkVersion.test.ts
@@ -227,7 +227,7 @@ describe('getJlinkCompatibility', () => {
         host: '',
     });
 
-    it(`Reports no installed J-Link for for module versions reported by nrfutil-device before 2.7`, () => {
+    it(`Reports no installed J-Link for for module versions reported by nrfutil-device before v2.7`, () => {
         expect(getJlinkCompatibility(createModuleVersion())).toEqual({
             kind: 'No J-Link installed',
             requiredJlink: '7.94e',
@@ -235,7 +235,7 @@ describe('getJlinkCompatibility', () => {
         });
     });
 
-    it(`Reports no installed J-Link for for module versions reported by nrfutil-device since 2.7`, () => {
+    it(`Reports no installed J-Link for for module versions reported by nrfutil-device since v2.7`, () => {
         expect(
             getJlinkCompatibility(
                 createModuleVersion({
@@ -253,7 +253,7 @@ describe('getJlinkCompatibility', () => {
         });
     });
 
-    it(`Reports an outdated JLink version`, () => {
+    it(`Reports an outdated J-Link version`, () => {
         expect(
             getJlinkCompatibility(
                 createModuleVersion({
@@ -273,7 +273,7 @@ describe('getJlinkCompatibility', () => {
         });
     });
 
-    it(`Reports a newer JLink version is used`, () => {
+    it(`Reports a newer J-Link version is used`, () => {
         expect(
             getJlinkCompatibility(
                 createModuleVersion({
@@ -293,7 +293,7 @@ describe('getJlinkCompatibility', () => {
         });
     });
 
-    it(`Reports the tested JLink version is used`, () => {
+    it(`Reports the tested J-Link version is used`, () => {
         expect(
             getJlinkCompatibility(
                 createModuleVersion({
@@ -309,7 +309,7 @@ describe('getJlinkCompatibility', () => {
         ).toEqual({ kind: 'Tested J-Link is used' });
     });
 
-    it(`Reports the tested JLink version is used by specifying no expected version`, () => {
+    it(`Reports the tested J-Link version is used by specifying no expected version`, () => {
         expect(
             getJlinkCompatibility(
                 createModuleVersion({

--- a/nrfutil/jlinkVersion.ts
+++ b/nrfutil/jlinkVersion.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import semver from 'semver';
+
+import { resolveModuleVersion } from './moduleVersion';
+import {
+    type Dependency,
+    hasVersion,
+    type ModuleVersion,
+} from './sandboxTypes';
+import {
+    type DiscriminatedVersion,
+    isStringVersion,
+    versionToString,
+} from './version';
+
+export const strippedVersionName = (version: DiscriminatedVersion) =>
+    versionToString(version).trim().replace('JLink_V', '');
+
+export const hasExpectedVersionFormat = (
+    dependency: Dependency | DiscriminatedVersion,
+    logFailure = true
+): dependency is DiscriminatedVersion => {
+    if (!hasVersion(dependency)) return false;
+
+    const jlinkVersionRegex = /^JLink_V\d+\.\d+[a-z]?$/;
+    const result =
+        isStringVersion(dependency) &&
+        versionToString(dependency).trim().match(jlinkVersionRegex) != null;
+
+    if (!result && logFailure) {
+        console.error(
+            `The J-Link version was not reported in the expected format. ` +
+                `Format: ${dependency.versionFormat}, ` +
+                `version: ${JSON.stringify(dependency)}, `
+        );
+    }
+
+    return result;
+};
+
+export const convertToSemver = (version: DiscriminatedVersion) => {
+    const [, majorMinor, patchLetter] =
+        strippedVersionName(version).match(/(\d\.\d+)(.)?/) ?? [];
+
+    const patch = patchLetter
+        ? patchLetter.charCodeAt(0) - 'a'.charCodeAt(0) + 1
+        : 0;
+
+    return `${majorMinor}.${patch}`;
+};
+
+export const existingIsOlderThanExpected = (
+    jlinkVersionDependency: Dependency
+) => {
+    if (
+        jlinkVersionDependency.expectedVersion == null ||
+        !hasExpectedVersionFormat(jlinkVersionDependency) ||
+        !hasExpectedVersionFormat(jlinkVersionDependency.expectedVersion)
+    )
+        return false;
+
+    return semver.lt(
+        convertToSemver(jlinkVersionDependency),
+        convertToSemver(jlinkVersionDependency.expectedVersion)
+    );
+};
+
+const nrfutilDeviceToJLink = (nrfutilDeviceVersion: string) => {
+    // According to https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html#prerequisites
+    if (semver.lt(nrfutilDeviceVersion, '2.0.0')) {
+        return '7.80c';
+    }
+
+    if (semver.lt(nrfutilDeviceVersion, '2.1.0')) {
+        return '7.88j';
+    }
+
+    if (semver.lt(nrfutilDeviceVersion, '2.5.4')) {
+        return '7.94e';
+    }
+
+    return '7.94i';
+};
+
+export const getJlinkCompatibility = (moduleVersion: ModuleVersion) => {
+    const jlinkVersionDependency = resolveModuleVersion(
+        'JlinkARM',
+        moduleVersion.dependencies
+    );
+
+    if (!hasVersion(jlinkVersionDependency)) {
+        const requiredVersion =
+            jlinkVersionDependency?.expectedVersion != null
+                ? strippedVersionName(jlinkVersionDependency.expectedVersion)
+                : nrfutilDeviceToJLink(moduleVersion.version);
+        return {
+            kind: 'No J-Link installed',
+            requiredJlink: requiredVersion,
+            actualJlink: 'none',
+        } as const;
+    }
+
+    if (
+        jlinkVersionDependency.expectedVersion &&
+        existingIsOlderThanExpected(jlinkVersionDependency)
+    ) {
+        const requiredJlink = strippedVersionName(
+            jlinkVersionDependency.expectedVersion
+        );
+        const actualJlink = strippedVersionName(jlinkVersionDependency);
+
+        return {
+            kind: 'Outdated J-Link',
+            requiredJlink,
+            actualJlink,
+        } as const;
+    }
+
+    if (
+        jlinkVersionDependency.expectedVersion == null ||
+        jlinkVersionDependency.version ===
+            jlinkVersionDependency.expectedVersion.version
+    ) {
+        return {
+            kind: 'Tested J-Link is used',
+        } as const;
+    }
+
+    const requiredJlink = strippedVersionName(
+        jlinkVersionDependency.expectedVersion
+    );
+    const actualJlink = strippedVersionName(jlinkVersionDependency);
+
+    return {
+        kind: 'Newer J-Link is used',
+        requiredJlink,
+        actualJlink,
+    } as const;
+};

--- a/nrfutil/jlinkVersion.ts
+++ b/nrfutil/jlinkVersion.ts
@@ -6,7 +6,7 @@
 
 import semver from 'semver';
 
-import { resolveModuleVersion } from './moduleVersion';
+import { findDependency } from './moduleVersion';
 import {
     type Dependency,
     hasVersion,
@@ -88,7 +88,7 @@ const nrfutilDeviceToJLink = (nrfutilDeviceVersion: string) => {
 };
 
 export const getJlinkCompatibility = (moduleVersion: ModuleVersion) => {
-    const jlinkVersionDependency = resolveModuleVersion(
+    const jlinkVersionDependency = findDependency(
         'JlinkARM',
         moduleVersion.dependencies
     );

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -9,8 +9,8 @@ import {
     type Dependency,
     hasVersion,
     type TopLevelDependency,
-    versionToString,
 } from './sandboxTypes';
+import { versionToString } from './version';
 
 export const describeVersion = (dependencyOrVersion?: Dependency | string) => {
     if (typeof dependencyOrVersion === 'string') return dependencyOrVersion;

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -30,7 +30,7 @@ const findInDependencies = (
     dependencies: TopLevelDependency[]
 ) => {
     if (dependencies.length > 0) {
-        return resolveModuleVersion(
+        return findDependency(
             module,
             dependencies.flatMap(dependency => [
                 ...(dependency.dependencies ?? []),
@@ -57,7 +57,7 @@ export const getExpectedVersion = (dependency: Dependency) => {
     };
 };
 
-export const resolveModuleVersion = (
+export const findDependency = (
     module: KnownModule,
     versions: TopLevelDependency[] = []
 ): Dependency | undefined =>

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -6,9 +6,9 @@
 
 import { packageJsonApp } from '../src/utils/packageJson';
 import {
-    Dependency,
+    type Dependency,
     type DiscriminatedVersion,
-    SubDependency,
+    type TopLevelDependency,
     versionToString,
 } from './sandboxTypes';
 
@@ -26,7 +26,7 @@ const findTopLevel = (module: KnownModule, dependencies: Dependency[]) =>
 
 const findInDependencies = (
     module: KnownModule,
-    dependencies: Dependency[]
+    dependencies: TopLevelDependency[]
 ) => {
     if (dependencies.length > 0) {
         return resolveModuleVersion(
@@ -56,8 +56,8 @@ export const getExpectedVersion = (dependency: Dependency) => {
 
 export const resolveModuleVersion = (
     module: KnownModule,
-    versions: Dependency[] = []
-): Dependency | SubDependency | undefined =>
+    versions: TopLevelDependency[] = []
+): Dependency | undefined =>
     findTopLevel(module, versions) ?? findInDependencies(module, versions);
 
 const overriddenVersion = (module: string) => {

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -7,16 +7,17 @@
 import { packageJsonApp } from '../src/utils/packageJson';
 import {
     type Dependency,
-    type DiscriminatedVersion,
+    hasVersion,
     type TopLevelDependency,
     versionToString,
 } from './sandboxTypes';
 
-export const describeVersion = (version?: DiscriminatedVersion | string) => {
-    if (typeof version === 'string') return version;
-    if (version == null) return 'Unknown';
+export const describeVersion = (dependencyOrVersion?: Dependency | string) => {
+    if (typeof dependencyOrVersion === 'string') return dependencyOrVersion;
+    if (hasVersion(dependencyOrVersion))
+        return versionToString(dependencyOrVersion);
 
-    return versionToString(version);
+    return 'Unknown';
 };
 
 type KnownModule = 'nrfdl' | 'jprog' | 'JlinkARM';
@@ -42,6 +43,8 @@ const findInDependencies = (
 };
 
 export const getExpectedVersion = (dependency: Dependency) => {
+    if (!hasVersion(dependency)) return null;
+
     const currentVersion = versionToString(dependency);
 
     const expectedVersion = dependency.expectedVersion

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -7,27 +7,16 @@
 import { packageJsonApp } from '../src/utils/packageJson';
 import {
     Dependency,
-    isIncrementalVersion,
-    isSemanticVersion,
-    isStringVersion,
+    type DiscriminatedVersion,
     SubDependency,
     versionToString,
 } from './sandboxTypes';
 
-export const describeVersion = (version?: SubDependency | string) => {
-    if (typeof version === 'string') {
-        return version;
-    }
+export const describeVersion = (version?: DiscriminatedVersion | string) => {
+    if (typeof version === 'string') return version;
+    if (version == null) return 'Unknown';
 
-    if (isSemanticVersion(version)) {
-        return `${version.version.major}.${version.version.minor}.${version.version.patch}`;
-    }
-
-    if (isIncrementalVersion(version) || isStringVersion(version)) {
-        return String(version.version);
-    }
-
-    return 'Unknown';
+    return versionToString(version);
 };
 
 type KnownModule = 'nrfdl' | 'jprog' | 'JlinkARM';
@@ -53,16 +42,10 @@ const findInDependencies = (
 };
 
 export const getExpectedVersion = (dependency: Dependency) => {
-    const currentVersion = versionToString(
-        dependency.versionFormat,
-        dependency.version
-    );
+    const currentVersion = versionToString(dependency);
 
     const expectedVersion = dependency.expectedVersion
-        ? versionToString(
-              dependency.expectedVersion.versionFormat,
-              dependency.expectedVersion.version
-          )
+        ? versionToString(dependency.expectedVersion)
         : currentVersion;
 
     return {

--- a/nrfutil/modules.ts
+++ b/nrfutil/modules.ts
@@ -79,12 +79,7 @@ const getModuleSandbox = (module: string) => {
 
     const createModuleSandbox = async () => {
         getNrfutilLogger()?.info(`Initialising the bundled nrfutil ${module}`);
-        promiseModuleSandbox = sandbox(
-            getUserDataDir(),
-            module,
-            undefined,
-            undefined
-        );
+        promiseModuleSandbox = sandbox(getUserDataDir(), module);
         moduleSandbox = await promiseModuleSandbox;
 
         logModuleVersions(module, moduleSandbox);

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -201,6 +201,7 @@ export class NrfutilSandbox {
                     force: true,
                 });
             }
+            await this.updateNrfUtilCore();
             await this.spawnNrfutil(
                 'install',
                 [`${this.module}=${this.version}`, '--force'],

--- a/nrfutil/sandboxTypes.ts
+++ b/nrfutil/sandboxTypes.ts
@@ -149,7 +149,7 @@ type StringVersion = {
     version: string;
 };
 
-export type DiscriminatedVersion =
+type DiscriminatedVersion =
     | IncrementalVersion
     | SemanticVersion
     | StringVersion;
@@ -159,18 +159,21 @@ type Plugin = DiscriminatedVersion & {
     name: string;
 };
 
-export type Dependency = DiscriminatedVersion & {
+type DependencyWithoutVersion = {
     name: string;
     dependencies?: SubDependency[];
     expectedVersion?: DiscriminatedVersion;
 };
+type DependencyWithVersion = DiscriminatedVersion & DependencyWithoutVersion;
+
+export type Dependency = DependencyWithoutVersion | DependencyWithVersion;
 
 export type TopLevelDependency = Dependency & {
     classification?: FeatureClassification;
     plugins?: Plugin[];
 };
 
-type SubDependency = Dependency & {
+export type SubDependency = Dependency & {
     description?: string;
 };
 
@@ -196,6 +199,11 @@ export const isIncrementalVersion = (
 export const isStringVersion = (
     version?: DiscriminatedVersion
 ): version is StringVersion => version?.versionFormat === 'string';
+
+export const hasVersion = (
+    dependency?: Dependency | DiscriminatedVersion
+): dependency is DependencyWithVersion | DiscriminatedVersion =>
+    dependency != null && 'version' in dependency && dependency.version != null;
 
 export const versionToString = (version: DiscriminatedVersion) => {
     if (isSemanticVersion(version)) {

--- a/nrfutil/sandboxTypes.ts
+++ b/nrfutil/sandboxTypes.ts
@@ -155,23 +155,23 @@ export type DiscriminatedVersion =
     | StringVersion;
 
 type Plugin = DiscriminatedVersion & {
-    dependencies: Dependency[];
+    dependencies: TopLevelDependency[];
     name: string;
 };
 
 export type Dependency = DiscriminatedVersion & {
-    classification?: FeatureClassification;
     name: string;
-    plugins?: Plugin[];
     dependencies?: SubDependency[];
     expectedVersion?: DiscriminatedVersion;
 };
 
-export type SubDependency = DiscriminatedVersion & {
-    name: string;
+export type TopLevelDependency = Dependency & {
+    classification?: FeatureClassification;
+    plugins?: Plugin[];
+};
+
+type SubDependency = Dependency & {
     description?: string;
-    dependencies?: SubDependency[];
-    expectedVersion?: DiscriminatedVersion;
 };
 
 export type ModuleVersion = {
@@ -179,7 +179,7 @@ export type ModuleVersion = {
     classification: FeatureClassification;
     commit_date: string;
     commit_hash: string;
-    dependencies: Dependency[];
+    dependencies: TopLevelDependency[];
     host: string;
     name: string;
     version: string;

--- a/nrfutil/sandboxTypes.ts
+++ b/nrfutil/sandboxTypes.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import type { DiscriminatedVersion } from './version';
+
 export interface BackgroundTask<T> {
     onError: (error: Error, pid?: number) => void;
     onData: (data: T) => void;
@@ -126,34 +128,6 @@ export type LogMessage = {
     message: string;
 };
 
-type IncrementalVersion = {
-    versionFormat: 'incremental';
-    version: number;
-};
-
-type SemanticVersion = {
-    versionFormat: 'semantic';
-    version: {
-        major: number;
-        minor: number;
-        patch: number;
-        semverPreNumeric?: number;
-        semverPreAlphaNumeric?: number;
-        semverMetadataNumeric?: number;
-        semverMetadataAlphaNumeric?: number;
-    };
-};
-
-type StringVersion = {
-    versionFormat: 'string';
-    version: string;
-};
-
-type DiscriminatedVersion =
-    | IncrementalVersion
-    | SemanticVersion
-    | StringVersion;
-
 type Plugin = DiscriminatedVersion & {
     dependencies: TopLevelDependency[];
     name: string;
@@ -188,28 +162,7 @@ export type ModuleVersion = {
     version: string;
 };
 
-export const isSemanticVersion = (
-    version?: DiscriminatedVersion
-): version is SemanticVersion => version?.versionFormat === 'semantic';
-
-export const isIncrementalVersion = (
-    version?: DiscriminatedVersion
-): version is IncrementalVersion => version?.versionFormat === 'incremental';
-
-export const isStringVersion = (
-    version?: DiscriminatedVersion
-): version is StringVersion => version?.versionFormat === 'string';
-
 export const hasVersion = (
     dependency?: Dependency | DiscriminatedVersion
 ): dependency is DependencyWithVersion | DiscriminatedVersion =>
     dependency != null && 'version' in dependency && dependency.version != null;
-
-export const versionToString = (version: DiscriminatedVersion) => {
-    if (isSemanticVersion(version)) {
-        const semantic = version.version;
-        return `${semantic.major}.${semantic.minor}.${semantic.patch}`;
-    }
-
-    return String(version.version);
-};

--- a/nrfutil/sandboxTypes.ts
+++ b/nrfutil/sandboxTypes.ts
@@ -135,7 +135,8 @@ type Plugin = DiscriminatedVersion & {
 
 type DependencyWithoutVersion = {
     name: string;
-    dependencies?: SubDependency[];
+    description?: string;
+    dependencies?: Dependency[];
     expectedVersion?: DiscriminatedVersion;
 };
 type DependencyWithVersion = DiscriminatedVersion & DependencyWithoutVersion;
@@ -145,10 +146,6 @@ export type Dependency = DependencyWithoutVersion | DependencyWithVersion;
 export type TopLevelDependency = Dependency & {
     classification?: FeatureClassification;
     plugins?: Plugin[];
-};
-
-export type SubDependency = Dependency & {
-    description?: string;
 };
 
 export type ModuleVersion = {

--- a/nrfutil/sandboxTypes.ts
+++ b/nrfutil/sandboxTypes.ts
@@ -197,14 +197,11 @@ export const isStringVersion = (
     version?: DiscriminatedVersion
 ): version is StringVersion => version?.versionFormat === 'string';
 
-export const versionToString = (
-    type: DiscriminatedVersion['versionFormat'],
-    version: DiscriminatedVersion['version']
-) => {
-    if (type === 'incremental' || type === 'string') {
-        return `${version}`;
+export const versionToString = (version: DiscriminatedVersion) => {
+    if (isSemanticVersion(version)) {
+        const semantic = version.version;
+        return `${semantic.major}.${semantic.minor}.${semantic.patch}`;
     }
 
-    const v = version as SemanticVersion['version'];
-    return `${v.major}.${v.minor}.${v.patch}`;
+    return String(version.version);
 };

--- a/nrfutil/version.ts
+++ b/nrfutil/version.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+type IncrementalVersion = {
+    versionFormat: 'incremental';
+    version: number;
+};
+
+type SemanticVersion = {
+    versionFormat: 'semantic';
+    version: {
+        major: number;
+        minor: number;
+        patch: number;
+        semverPreNumeric?: number;
+        semverPreAlphaNumeric?: number;
+        semverMetadataNumeric?: number;
+        semverMetadataAlphaNumeric?: number;
+    };
+};
+
+type StringVersion = {
+    versionFormat: 'string';
+    version: string;
+};
+
+export type DiscriminatedVersion =
+    | IncrementalVersion
+    | SemanticVersion
+    | StringVersion;
+
+export const isSemanticVersion = (
+    version?: DiscriminatedVersion
+): version is SemanticVersion => version?.versionFormat === 'semantic';
+
+export const isIncrementalVersion = (
+    version?: DiscriminatedVersion
+): version is IncrementalVersion => version?.versionFormat === 'incremental';
+
+export const isStringVersion = (
+    version?: DiscriminatedVersion
+): version is StringVersion => version?.versionFormat === 'string';
+
+export const versionToString = (version: DiscriminatedVersion) => {
+    if (isSemanticVersion(version)) {
+        const semantic = version.version;
+        return `${semantic.major}.${semantic.minor}.${semantic.patch}`;
+    }
+
+    return String(version.version);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "190.0.0",
+    "version": "191.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/utils/systemReport.ts
+++ b/src/utils/systemReport.ts
@@ -11,10 +11,7 @@ import pretty from 'prettysize';
 import si from 'systeminformation';
 
 import { getAllModuleVersions } from '../../nrfutil';
-import {
-    describeVersion,
-    resolveModuleVersion,
-} from '../../nrfutil/moduleVersion';
+import { describeVersion, findDependency } from '../../nrfutil/moduleVersion';
 import {
     deviceInfo as getDeviceInfo,
     productPageUrl,
@@ -81,10 +78,10 @@ const generalInfoReport = async () => {
             result.push(
                 ...[
                     `    - nrfjprog DLL: ${describeVersion(
-                        resolveModuleVersion('jprog', dependencies)
+                        findDependency('jprog', dependencies)
                     )}`,
                     `    - SEGGER J-Link: ${describeVersion(
-                        resolveModuleVersion('JlinkARM', dependencies)
+                        findDependency('JlinkARM', dependencies)
                     )}`,
                     '',
                 ]


### PR DESCRIPTION
Some enhancements to our nrfutil code (triggered by https://nordicsemi.atlassian.net/browse/NCD-1043):

- 6efead4ccecfef96cd22797e632b35e3615f1837 Run `nrfutil self-upgrade` before installing a command.
- 24f22fc62142aec6e068802e6e4659519f176f43 Introduce a discriminated union type for the three different version variants.
- 197e63325ee283c83acda6c9911dcd81577583b2 Restrict out `package.json` schema so that only a single version per nrfutil module can be specified.
- a5d52cc8b4775506711ee96890ac5cdad50032a1 Add an `nrfutil` property to installed apps (will be used in an upcoming change to the launcher).
- a498cbd4856d778920e0c4c8589155794d9f518d Make the property `version` in dependencies optional, reflecting a change since `nrfutil-device` 2.7.
- 20fb73ed2e1d15b75d384dce9655032d23362d9e Add a function to determine the J-Link compatibility (the code is currently in the launcher, so it is effectively move here).
- bd825c32f42c90d5b10d0f999dc344cabaccf9a9 Update the in-app log warnings about potentially problematic J-Link installations to be in sync with the warnings in the launcher.

Some cleanups sprinkled in: e895eb8058c6549aaf75bf2cc9e82b17ff1fce79, 832059f790d8445db788f42e7c5ead797a7951ff, dd146a9bc974b845dab012c4466e0ec564c7f1a3, 97f20730588e576e12902c3490f2a324a879003d, 5a8cb4fafabbf9488576ce2b0001564617a8db4f