### PR TITLE
Add mock for appinsights

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ every new version is a new major version.
 
 -   `selectedVirtualDevice` export.
 
+### Changed
+
+-   `applicationinsights` is now mocked for test runs.
+
 ### Fixed
 
 -   Show log shortcut now works every time it is called.

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -17,6 +17,7 @@ module.exports = (disabledMocks = []) => ({
         '^electron$': `${mockDir}/electronMock.ts`,
         '^electron-store$': `${mockDir}/electronStoreMock.ts`,
         '@electron/remote': `${mockDir}/remoteMock.ts`,
+        applicationinsights: `${mockDir}/applicationinsightsMock.ts`,
         'react-markdown': require.resolve(
             'react-markdown/react-markdown.min.js'
         ),

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -13,11 +13,10 @@ module.exports = (disabledMocks = []) => ({
     moduleNameMapper: {
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)$': `${mockDir}/fileMock.ts`,
         '\\.(css|scss)$': `${mockDir}/emptyMock.ts`,
-        'pc-nrfjprog-js|nrf-device-setup|usb': `${mockDir}/emptyMock.ts`,
+        'pc-nrfjprog-js|nrf-device-setup|usb|applicationinsights': `${mockDir}/emptyMock.ts`,
         '^electron$': `${mockDir}/electronMock.ts`,
         '^electron-store$': `${mockDir}/electronStoreMock.ts`,
         '@electron/remote': `${mockDir}/remoteMock.ts`,
-        applicationinsights: `${mockDir}/applicationinsightsMock.ts`,
         'react-markdown': require.resolve(
             'react-markdown/react-markdown.min.js'
         ),

--- a/mocks/applicationinsightsMock.ts
+++ b/mocks/applicationinsightsMock.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
- */
-
-// used solely for applicationinsights v2.x.x package to remove warning during tests
-export default {};

--- a/mocks/applicationinsightsMock.ts
+++ b/mocks/applicationinsightsMock.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+// used solely for applicationinsights v2.x.x package to remove warning during tests
+export default {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "195.0.0",
+    "version": "197.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "196.0.0",
+    "version": "197.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Reason: hide warning ` ApplicationInsights:Cannot load @azure/core-auth package. This package is required for AAD token authentication. It's likely that your node.js version is not supported by the JS Azure SDK.` from the library caused by jest.requireActual()