### PR TITLE
Update setup-node action

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.ref }}
-            - uses: actions/setup-node@v4.0.0
+            - uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: 'npm'

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4.0.0
+            - uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: 'npm'


### PR DESCRIPTION
No need to pinning this to a specific version, just setting the major version is fine. And especially 4.0.0 seems to have an issue that saving the cache is really slow.