### PR TITLE
Allow setting the node version in GitHub Actions

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -7,6 +7,9 @@ on:
                 type: string
             force_pack:
                 type: boolean
+            node_version:
+                type: number
+                default: 22
 
 jobs:
     build:
@@ -17,7 +20,7 @@ jobs:
                   ref: ${{ inputs.ref }}
             - uses: actions/setup-node@v4
               with:
-                  node-version: 22
+                  node-version: ${{ inputs.node_version }}
                   cache: 'npm'
             - run: npm ci
             - run: npm run check

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -8,6 +8,8 @@ on:
             source:
                 required: true
                 type: string
+            node_version:
+                type: number
 
 jobs:
     build:
@@ -15,6 +17,7 @@ jobs:
         with:
             ref: ${{ inputs.ref }}
             force_pack: true
+            node_version: ${{ inputs.node_version }}
 
     release:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Usually the default should be fine, but in one app I have to use an older version until we make it compatible to the latest node version.