### PR TITLE
feat: allow for the group heading to be a reactnode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 201.0.0 - 2025-02-21
+
+### Changed
+
+-   `Group` heading is changed to `React.ReactNode` instead of `string`.
+
 ## 200.0.0 - 2025-02-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "200.0.0",
+    "version": "201.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/Group/Group.tsx
+++ b/src/Group/Group.tsx
@@ -83,7 +83,7 @@ export const Group = ({
     onToggled,
 }: {
     className?: string;
-    heading: string;
+    heading: React.ReactNode;
     headingFullWidth?: boolean;
     title?: string;
     children?: React.ReactNode;


### PR DESCRIPTION
This is for npm to allow the usage of documentationtooltips

Sadly this specific case would override the interaction mouse pointer when hovering over the title
It would also conflict if the "title" is used so that has to be considered