### PR TITLE
Upgrade systeminformation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Changed
+
+-   Upgraded systeminformation, which will get rid of some warnings concerning
+    `util._extend` in test runs.
+
 ## 201.0.0 - 2025-02-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "198.0.0",
+    "version": "201.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-            "version": "198.0.0",
+            "version": "201.0.0",
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
@@ -95,7 +95,7 @@
                 "semver": "7.3.8",
                 "serialport": "^12.0.0",
                 "shasum": "1.0.2",
-                "systeminformation": "5.17.12",
+                "systeminformation": "^5.25.11",
                 "tailwindcss": "3.3.2",
                 "tree-kill-promise": "^3.0.14",
                 "ts-node": "10.9.1",
@@ -16430,9 +16430,10 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.17.12",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.17.12.tgz",
-            "integrity": "sha512-I3pfMW2vue53u+X08BNxaJieaHkRoMMKjWetY9lbYJeWFaeWPO6P4FkNc4XOCX8F9vbQ0HqQ25RJoz3U/B7liw==",
+            "version": "5.25.11",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
+            "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
+            "license": "MIT",
             "os": [
                 "darwin",
                 "linux",
@@ -29535,9 +29536,9 @@
             }
         },
         "systeminformation": {
-            "version": "5.17.12",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.17.12.tgz",
-            "integrity": "sha512-I3pfMW2vue53u+X08BNxaJieaHkRoMMKjWetY9lbYJeWFaeWPO6P4FkNc4XOCX8F9vbQ0HqQ25RJoz3U/B7liw=="
+            "version": "5.25.11",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
+            "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g=="
         },
         "table": {
             "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "semver": "7.3.8",
         "serialport": "^12.0.0",
         "shasum": "1.0.2",
-        "systeminformation": "5.17.12",
+        "systeminformation": "^5.25.11",
         "tailwindcss": "3.3.2",
         "tree-kill-promise": "^3.0.14",
         "ts-node": "10.9.1",


### PR DESCRIPTION
This will get rid of some warnings concerning `util._extend` in test runs.