### PR TITLE
Use simpler Artifactory URLs for app metadata

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 205.0.0 - Unreleased
+## 205.0.0 - 2025-04-07
 
 ### Added
 
@@ -16,6 +16,10 @@ every new version is a new major version.
 ### Removed
 
 -   Unused mocks for `pc-nrfjprog-js`, `nrf-device-setup`, `usb` packages.
+
+### Changed
+
+-   Use simpler Artifactory URLs for app metadata.
 
 ### Fixed
 

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -164,7 +164,6 @@ class ArtifactoryClient extends Client {
     token = process.env.ARTIFACTORY_TOKEN;
 
     sourceUrl: string;
-    uploadUrl: string;
 
     constructor(private readonly options: Options) {
         super();
@@ -175,11 +174,7 @@ class ArtifactoryClient extends Client {
             );
         }
 
-        this.uploadUrl = `https://files.nordicsemi.com/artifactory/swtools/${this.getAccessLevel()}/ncd/apps/${
-            options.source
-        }`;
-
-        this.sourceUrl = `https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=${this.getAccessLevel()}/ncd/apps/${
+        this.sourceUrl = `https://files.nordicsemi.com/artifactory/swtools/${this.getAccessLevel()}/ncd/apps/${
             options.source
         }`;
     }
@@ -206,7 +201,7 @@ class ArtifactoryClient extends Client {
     };
 
     upload = async (content: Buffer, remoteFilename: string) => {
-        const url = `${this.uploadUrl}/${remoteFilename}`;
+        const url = `${this.sourceUrl}/${remoteFilename}`;
         const res = await fetch(url, {
             method: 'PUT',
             body: content,


### PR DESCRIPTION
Part of [NCD-1289](https://nordicsemi.atlassian.net/browse/NCD-1289):

With the changes in https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/pull/1099 the launcher now can handle the simpler URLs, so we should also switch to them when we publish apps.