### PR TITLE
Revert "Use simpler Artifactory URLs for app metadata"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,13 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 206.0.0 - 2025-04-08
+
+### Fixed
+
+-   Rolled back the use of simpler Artifactory URLs from v205, because older
+    versions of the launcher need the URLs using the download API.
+
 ## 205.0.0 - 2025-04-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "205.0.0",
+    "version": "206.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -164,6 +164,7 @@ class ArtifactoryClient extends Client {
     token = process.env.ARTIFACTORY_TOKEN;
 
     sourceUrl: string;
+    uploadUrl: string;
 
     constructor(private readonly options: Options) {
         super();
@@ -174,7 +175,11 @@ class ArtifactoryClient extends Client {
             );
         }
 
-        this.sourceUrl = `https://files.nordicsemi.com/artifactory/swtools/${this.getAccessLevel()}/ncd/apps/${
+        this.uploadUrl = `https://files.nordicsemi.com/artifactory/swtools/${this.getAccessLevel()}/ncd/apps/${
+            options.source
+        }`;
+
+        this.sourceUrl = `https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=${this.getAccessLevel()}/ncd/apps/${
             options.source
         }`;
     }
@@ -201,7 +206,7 @@ class ArtifactoryClient extends Client {
     };
 
     upload = async (content: Buffer, remoteFilename: string) => {
-        const url = `${this.sourceUrl}/${remoteFilename}`;
+        const url = `${this.uploadUrl}/${remoteFilename}`;
         const res = await fetch(url, {
             method: 'PUT',
             body: content,


### PR DESCRIPTION
Rolled back the use of simpler Artifactory URLs from v205, because older versions of the launcher need the URLs using the download API.

This reverts commit 386208b65f57b5c09e3d0460939d7aa5c07c4233.