### PR TITLE
Fix: Require at least nrfutil-device 2.7.16

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Steps to upgrade when using this package
+
+-   Minimum version of nrfutil-device is 2.7.16.
+
 ## 209.0.0 - 2025-04-30
 
 ### Changed


### PR DESCRIPTION
Before `nrfutil-device` 2.7.0, the dependency reported as `nrf-probe-lib` since then it is `nrf-probe`. The code in shared depends on the latter, otherwise a warning is issued.
https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-device/CHANGELOG.html#2024-10-22-version-270

Also, usage of `x-read` in #998 requires at least `nrfutil-device` 2.7.16 for for nRF52, nRF53, and nRF91 series devices.