### PR TITLE
Specify core version of nrfutil

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,13 +7,24 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 212.0.0 - 2025-06-05
+
+### Added
+
+-   Specify what core version of nrfutil an app depends on.
+
+### Steps to upgrade when using this package
+
+-   In apps in `package.json` set the field `nrfConnectForDesktop.nrfutilCore`
+    to the core version of nrfutil that the nrfutil commands will use.
+
 ## 211.0.0 - 2025-05-29
 
 ### Fixed
 
--   It was observed that on mac we get multiple arrive event and the only chnage
-    is the number if serial ports. Now the selected device in redux will also
-    update to reflect these chnages
+-   It was observed on macOS that we get multiple arrive events and the only
+    change is the number of serial ports. Now the selected device in redux is
+    also updated to reflect these changes.
 
 ## 210.0.0 - 2025-05-15
 

--- a/ipc/MetaFiles.ts
+++ b/ipc/MetaFiles.ts
@@ -22,11 +22,12 @@ export type AppVersions = {
     [version: string]: AppVersion;
 };
 
-export type AppVersion = {
+type AppVersion = {
     shasum?: string;
     publishTimestamp?: string;
     tarballUrl: UrlString;
     nrfutilModules?: NrfutilModules;
+    nrfutilCore?: NrfutilModuleVersion;
 };
 
 export interface AppInfo {
@@ -57,6 +58,9 @@ const nrfutilModuleVersion = semver;
 export type NrfutilModuleName = z.infer<typeof nrfutilModuleName>;
 export type NrfutilModuleVersion = z.infer<typeof nrfutilModuleVersion>;
 
-export const nrfModules = z.record(nrfutilModuleName, z.tuple([semver]));
+export const nrfModules = z.record(
+    nrfutilModuleName,
+    z.tuple([nrfutilModuleVersion])
+);
 
 export type NrfutilModules = z.infer<typeof nrfModules>;

--- a/ipc/apps.ts
+++ b/ipc/apps.ts
@@ -5,7 +5,12 @@
  */
 
 import { handle, invoke } from './infrastructure/rendererToMain';
-import type { AppVersions, NrfutilModules, UrlString } from './MetaFiles';
+import type {
+    AppVersions,
+    NrfutilModules,
+    NrfutilModuleVersion,
+    UrlString,
+} from './MetaFiles';
 import { LOCAL, Source, SourceName } from './sources';
 
 export interface AppSpec {
@@ -34,6 +39,7 @@ interface Installed {
     repositoryUrl?: UrlString;
     html?: string;
     nrfutil?: NrfutilModules;
+    nrfutilCore?: NrfutilModuleVersion;
     installed: {
         publishTimestamp?: string;
         path: string;

--- a/ipc/schema/packageJson.ts
+++ b/ipc/schema/packageJson.ts
@@ -26,6 +26,7 @@ export const parsePackageJson = parseWithPrettifiedErrorMessage(packageJson);
 const nrfConnectForDesktop = z.object({
     supportedDevices: z.enum(knownDevicePcas).array().nonempty().optional(),
     nrfutil: nrfModules.optional(),
+    nrfutilCore: semver,
     html: z.string(),
 });
 
@@ -59,11 +60,11 @@ export const parsePackageJsonApp =
     parseWithPrettifiedErrorMessage(packageJsonApp);
 
 // In the launcher we want to handle that the whole nrfConnectForDesktop may be missing
-// and the html in it can also be undefined, so there we need to use this legacy variant
+// and html or nrfutilCore in it can also be undefined, so there we need to use this legacy variant
 const packageJsonLegacyApp = packageJsonApp.extend({
     nrfConnectForDesktop: nrfConnectForDesktop
         .extend({ supportedDevices: z.array(z.string()).nonempty().optional() })
-        .partial({ html: true })
+        .partial({ html: true, nrfutilCore: true })
         .optional(),
 });
 

--- a/nrfutil/index.ts
+++ b/nrfutil/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { default as prepareSandbox } from './sandbox';
-export { NrfutilSandbox } from './sandbox';
+export type { NrfutilSandbox } from './sandbox';
 export type { Progress } from './sandboxTypes';
 export { getNrfutilLogger, setNrfutilLogger } from './nrfutilLogger';
 export {

--- a/nrfutil/moduleVersion.ts
+++ b/nrfutil/moduleVersion.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { packageJsonApp } from '../src/utils/packageJson';
+import { isLauncher, packageJsonApp } from '../src/utils/packageJson';
 import {
     type Dependency,
     hasVersion,
@@ -78,7 +78,7 @@ const versionFromPackageJson = (module: string) =>
     packageJsonApp().nrfConnectForDesktop.nrfutil?.[module][0];
 
 const failToDetermineVersion = (module: string) => {
-    throw new Error(`No version specified for the bundled nrfutil ${module}`);
+    throw new Error(`No version specified for nrfutil ${module}`);
 };
 
 export const versionToInstall = (module: string, version?: string) =>
@@ -86,3 +86,12 @@ export const versionToInstall = (module: string, version?: string) =>
     overriddenVersion(module) ??
     versionFromPackageJson(module) ??
     failToDetermineVersion(module);
+
+const coreVersionFromPackageJson = () =>
+    isLauncher()
+        ? undefined // Will lead to using CORE_VERSION_FOR_LEGACY_APPS
+        : packageJsonApp().nrfConnectForDesktop.nrfutilCore ??
+          failToDetermineVersion('core');
+
+export const coreVersionsToInstall = (coreVersion?: string) =>
+    coreVersion ?? overriddenVersion('core') ?? coreVersionFromPackageJson();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "211.0.0",
+    "version": "212.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -466,6 +466,7 @@ const getUpdatedAppInfo = async (app: App): Promise<AppInfo> => {
     } = app.packageJson;
 
     const nrfutilModules = nrfConnectForDesktop?.nrfutil;
+    const nrfutilCore = nrfConnectForDesktop?.nrfutilCore;
 
     return {
         name,
@@ -482,6 +483,7 @@ const getUpdatedAppInfo = async (app: App): Promise<AppInfo> => {
                 publishTimestamp: new Date().toISOString(),
                 shasum: app.shasum,
                 nrfutilModules,
+                nrfutilCore,
             },
         },
     };


### PR DESCRIPTION
Apps must now specify what core version of nrfutil they depend on. This is to ensure that more of the environment the app runs in is locked for an app and future updates, in nrfutil do not break the app unexpectedly.

If an app e.g. specifies that it requires nrfutil core 8.0.0 and nrfutil device 2.9.0, then that sandbox will be created in the path `nrfutil-sandboxes/8.0.0/device/2.9.0`.

If the launcher encounters an old app, which does not specify the core version yet, it will default to using nrfutil core 8.0.0, but use the old path, because those apps expect it there, e.g. `nrfutil-sandboxes/device/2.9.0`.

(On macOS with Apple Silicon there would be an additional segment `arm64/` after `nrfutil-sandboxes/` in those examples)

This is used by https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/pull/1125.