### PR TITLE
Fix type error in logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 213.0.0 - 2025-06-11
+
+### Fixed
+
+-   Typecheck error when using a recent version of the dependency logform.
+
 ## 212.0.0 - 2025-06-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "212.0.0",
+    "version": "213.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -51,19 +51,12 @@ interface SharedLogger extends Logger {
     logError: (message: string, error: unknown) => void;
 }
 
-/* This function is only needed, because our version of TypeScript still seems
-   unable to accept (unique) symbols as index types. As soon as we have
-   upgraded to a version that is capable of that, the invocations of this
-   function can be replaced by a simple `info[splat]` and this function can
-   be removed. */
-const splat = (info: TransformableInfo) => info[SPLAT as unknown as string];
-
 const logger = createLogger({
     format: format.combine(
         format(info => ({
             ...info,
-            message: splat(info)
-                ? `${info.message} ${splat(info).join(' ')}`
+            message: info[SPLAT]
+                ? `${info.message} ${info[SPLAT].join(' ')}`
                 : info.message,
         }))(),
         format.timestamp(),

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -55,7 +55,7 @@ const logger = createLogger({
     format: format.combine(
         format(info => ({
             ...info,
-            message: info[SPLAT]
+            message: Array.isArray(info[SPLAT])
                 ? `${info.message} ${info[SPLAT].join(' ')}`
                 : info.message,
         }))(),


### PR DESCRIPTION
This happened when apps use a recent version of logform. In reality only the types changes, but using `Array.isArray` also makes it a bit more expressive and safer.