### PR TITLE
Automatically publish docs to Zoomin on release

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -10,6 +10,8 @@ on:
                 type: string
             node_version:
                 type: number
+            doc_bundle_name:
+                type: string
 
 jobs:
     build:
@@ -38,3 +40,16 @@ jobs:
                     --no-pack \
                     --destination artifactory \
                     --source '${{ inputs.source }}'
+
+    publish-docs:
+        needs: release
+        uses: ./.github/workflows/zoomin-publish.yml
+        if:
+            inputs.doc_bundle_name && 
+            hashFiles('doc/mkdocs.yml') != '' && 
+            (inputs.source == 'official (external)' ||
+             inputs.source == 'latest (internal)')
+        with:
+            release-type:
+                ${{ inputs.source == 'official (external)' && 'prod' || 'dev' }}
+            bundle-name: ${{ inputs.doc_bundle_name }}


### PR DESCRIPTION
Part of [NCD-1394](https://nordicsemi.atlassian.net/browse/NCD-1394):

For this, two things are required:

- Have a `doc/mkdocs.yml` file.
- When the release-app workflow is called, specify the `doc_bundle_name` input.

When the app is then release through the GitHub Action, the docs will be automatically published to Zoomin:

- To dev if the source is `latest (internal)`
- To prod if the source is `official (external)`