### PR TITLE
Avoid publishing docs twice

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -44,9 +44,6 @@ jobs:
     check-if-docs-exist:
         needs: release
         runs-on: ubuntu-latest
-        if:
-            inputs.doc_bundle_name && (inputs.source == 'official (external)' ||
-            inputs.source == 'latest (internal)')
         outputs:
             docs_exist: ${{ steps.check.outputs.docs_exist }}
         steps:
@@ -65,9 +62,11 @@ jobs:
 
     publish-docs:
         needs: check-if-docs-exist
-        if: needs.check-if-docs-exist.outputs.docs_exist == 'true'
+        if: |
+            inputs.doc_bundle_name &&
+            inputs.source == 'official (external)' &&
+            needs.check-if-docs-exist.outputs.docs_exist == 'true'
         uses: ./.github/workflows/docs-publish.yml
         with:
-            release-type:
-                ${{ inputs.source == 'official (external)' && 'prod' || 'dev' }}
+            release-type: prod
             bundle-name: ${{ inputs.doc_bundle_name }}


### PR DESCRIPTION
Part of [NCD-1394](https://nordicsemi.atlassian.net/browse/NCD-1394):

For commits on the branch `main`, the docs where sometimes published twice to dev:

- Once because we have an according trigger in the app's docs-publish-dev.yml
- Again because of the logic in release-app.yml

The former is better anyhow (because it only runs if there are changes to the docs), so the latter was removed.