### PR TITLE
Fix error when verbose logging is turned on

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 219.0.0 - 2025-07-10
+
+### Fixed
+
+-   Error when verbose logging was turned on.
+
 ## 218.0.0 - 2025-07-08
 
 ### Fixed

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -140,9 +140,9 @@ export class NrfutilSandbox {
     public isSandboxInstalled = () =>
         this.executableExists() && this.commandReportsCorrectVersion();
 
-    private log(message: LogMessage, pid: number | undefined) {
+    private log = (message: LogMessage, pid: number | undefined) => {
         this.onLoggingHandlers.forEach(onLogging => onLogging(message, pid));
-    }
+    };
 
     private executableExists() {
         return fs.existsSync(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "218.0.0",
+    "version": "219.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The error was introduced in #1003 when `this.log` was passed to the new CollectingResultParser. But because `log` was a regular method, `this` in it pointed to the CollectingResultParser instance, not the NrfutilSandbox instance. So turning `log` into an arrow function fixed the issue.

The error was only triggered when verbose logging was turned on, because only in this case log events were emitted.