### PR TITLE
Automate GitHub releases for apps

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -10,6 +10,9 @@ on:
             node_version:
                 type: number
 
+env:
+    ARTIFACT_NAME: ${{ github.event.repository.name }}
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -31,6 +34,7 @@ jobs:
                   inputs.force_pack
             - uses: actions/upload-artifact@v4
               with:
+                  name: ${{ env.ARTIFACT_NAME }}
                   path: ./*.tgz
               if:
                   github.event.push.ref == 'refs/heads/main' ||

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,6 +9,9 @@ on:
                 type: boolean
             node_version:
                 type: number
+        outputs:
+            version:
+                value: ${{ jobs.build.outputs.version }}
 
 env:
     ARTIFACT_NAME: ${{ github.event.repository.name }}
@@ -16,6 +19,8 @@ env:
 jobs:
     build:
         runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.extract_release_notes.outputs.version }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -32,10 +37,26 @@ jobs:
               if:
                   github.event.push.ref == 'refs/heads/main' ||
                   inputs.force_pack
+            - name: Extract release notes
+              id: extract_release_notes
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const fs = require('node:fs');
+
+                      const changelog = fs.readFileSync('Changelog.md', 'utf8');
+                      const latestEntry = changelog.split(/^## .*$/m)[1].trim();
+                      fs.writeFileSync('release_notes.md', latestEntry);
+
+                      const version = require('./package.json').version;
+                      core.setOutput('version', version);
+
             - uses: actions/upload-artifact@v4
               with:
                   name: ${{ env.ARTIFACT_NAME }}
-                  path: ./*.tgz
+                  path: |
+                      *.tgz
+                      release_notes.md
               if:
                   github.event.push.ref == 'refs/heads/main' ||
                   inputs.force_pack

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -13,6 +13,9 @@ on:
             doc_bundle_name:
                 type: string
 
+env:
+    ARTIFACT_NAME: ${{ github.event.repository.name }}
+
 jobs:
     build:
         uses: ./.github/workflows/build-app.yml
@@ -29,13 +32,15 @@ jobs:
 
         steps:
             - uses: actions/download-artifact@v4
+              with:
+                  name: ${{ env.ARTIFACT_NAME }}
             - name: Release app to ${{ inputs.source }}
               env:
                   ARTIFACTORY_TOKEN:
                       ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD_SWTOOLS_FRONTEND
                       }}
               run: |
-                  cd artifact
+                  cd '${{ env.ARTIFACT_NAME }}'
                   tar xaf *.tgz --strip-components 1
                   node dist/nordic-publish.js \
                     --no-pack \

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -27,6 +27,8 @@ jobs:
     release:
         runs-on: ubuntu-latest
         needs: build
+        env:
+            GH_TOKEN: ${{ github.token }}
         environment:
             name: ${{ inputs.source }}
 
@@ -34,18 +36,37 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: ${{ env.ARTIFACT_NAME }}
+
             - name: Release app to ${{ inputs.source }}
               env:
                   ARTIFACTORY_TOKEN:
                       ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD_SWTOOLS_FRONTEND
                       }}
               run: |
-                  cd '${{ env.ARTIFACT_NAME }}'
-                  tar xaf *.tgz --strip-components 1
+                  tar xaf *.tgz
+                  cp *.tgz package
+                  cd package
                   node dist/nordic-publish.js \
                     --no-pack \
                     --destination artifactory \
                     --source '${{ inputs.source }}'
+
+            - name: Create release on GitHub
+              if: inputs.source == 'official (external)'
+              run: |
+                  TAG="v${{ needs.build.outputs.version }}"
+
+                  # Check if GitHub release already exists
+                  if gh release view "$TAG" --repo ${{ github.repository }} >/dev/null 2>&1; then
+                      echo "::error::Not running because a GitHub release with the tag $TAG already exists"
+                      exit 1
+                  fi
+
+                  gh release create "$TAG" \
+                    --target ${{ inputs.ref || github.ref }} \
+                    --repo ${{ github.repository }} \
+                    --notes-file release_notes.md \
+                    ./*.tgz
 
     check-if-docs-exist:
         needs: release


### PR DESCRIPTION
[NCD-1185](https://nordicsemi.atlassian.net/browse/NCD-1185): Automatically create a GitHub release when releasing an app to the source “official (external)”

