### PR TITLE
Fix GitHub Action to release shared package

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -42,7 +42,7 @@ jobs:
               with:
                   script: |
                       const version = require('./package.json').version;
-                      core.setOutput('tag', `v${version}`);
+                      core.setOutput('tag', `v${version.replace('.0.0', '')}`);
 
             - name: Create GitHub release
               run: |
@@ -54,4 +54,4 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.WAYLAND_NPM_TOKEN }}
               run: |
-                  npm publish --provenance
+                  npm publish --provenance --access public


### PR DESCRIPTION
For [NCD-1212](https://nordicsemi.atlassian.net/browse/NCD-1212), fix two errors in #1034:

- The tag wrongly contained `.0.0` at the end.
- Publishing to npm failed. The `--access public` was called optional in one place but mandatory in another. Hopefully this fixes it.