### PR TITLE
Fix: Running build scripts failed on Windows

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -28,17 +28,19 @@ jobs:
                   registry-url: https://registry.npmjs.org
                   cache: npm
 
+            - run: npm ci
+
             - name: Check if release is possible
               run: |
-                  ./scripts/is-releasable.ts
+                  npx tsx ./scripts/is-releasable.ts
 
-            - run: npm ci
             - run: npm run check
             - run: npm test
             - run: npm pack
 
             - name: Extract release notes
-              run: ./scripts/latest-changelog-entry.ts > release_notes.md
+              run:
+                  npx tsx ./scripts/latest-changelog-entry.ts > release_notes.md
 
             - name: Determine next tag
               id: determine-next-tag

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 221.0.0 - Unreleased
+## 221.0.0 - 2025-07-21
 
 ### Added
 
@@ -15,6 +15,10 @@ every new version is a new major version.
 -   Narrower Dropdown variant.
 -   Automatic character limit derivation for number input components based on
     their range constraints.
+
+### Fixed
+
+-   Running build scripts failed on Windows.
 
 ## 220.0.0 - 2025-07-16
 

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA

--- a/scripts/check-for-typescript.ts
+++ b/scripts/check-for-typescript.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2015 Nordic Semiconductor ASA

--- a/scripts/create-source.ts
+++ b/scripts/create-source.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA

--- a/scripts/esbuild.ts
+++ b/scripts/esbuild.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 /*
  * Copyright (c) 2015 Nordic Semiconductor ASA
  *

--- a/scripts/installHusky.ts
+++ b/scripts/installHusky.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA

--- a/scripts/is-releasable.ts
+++ b/scripts/is-releasable.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA

--- a/scripts/latest-changelog-entry.ts
+++ b/scripts/latest-changelog-entry.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA

--- a/scripts/nordic-publish.ts
+++ b/scripts/nordic-publish.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2015 Nordic Semiconductor ASA

--- a/scripts/nrfconnect-license.ts
+++ b/scripts/nrfconnect-license.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2015 Nordic Semiconductor ASA

--- a/scripts/prepare-shared-release.ts
+++ b/scripts/prepare-shared-release.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env tsx
 
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA


### PR DESCRIPTION
Another fix for #1034:

Seems like the [shebang `#!/usr/bin/env -S npx tsx` recommended by tsx](https://tsx.is/shell-scripts) doesn't work well enough on Windows. 