### PR TITLE
Automatic shared releasing

### DIFF
--- a/.github/workflows/auto-publish-shared.yml
+++ b/.github/workflows/auto-publish-shared.yml
@@ -1,0 +1,42 @@
+name: Auto-publish shared
+
+on:
+    push:
+        branches: [main]
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ github.token }}
+        outputs:
+            ready_to_release:
+                ${{ steps.check-release.outputs.ready_to_release }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org
+                  cache: npm
+
+            - name: Check if release is ready
+              id: check-release
+              run: |
+                  reason=`npx tsx ./scripts/is-releasable.ts`
+                  if [ $? -ne 0 ]; then
+                    echo ":see_no_evil: Not releasing because: $reason" >> $GITHUB_STEP_SUMMARY
+                    echo "ready_to_release=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "ready_to_release=true" >> $GITHUB_OUTPUT
+                  fi
+
+    release:
+        needs: check
+        if: needs.check.outputs.ready_to_release == 'true'
+        uses: ./.github/workflows/release-shared.yml
+
+    test:
+        needs: check
+        if: needs.check.outputs.ready_to_release == 'false'
+        uses: ./.github/workflows/test-shared.yml

--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -9,6 +9,7 @@ on:
                     where the workflow is triggered, usually the main branch.
                 required: false
                 type: string
+    workflow_call:
 
 jobs:
     release:
@@ -28,12 +29,15 @@ jobs:
                   registry-url: https://registry.npmjs.org
                   cache: npm
 
-            - run: npm ci
-
             - name: Check if release is possible
               run: |
-                  npx tsx ./scripts/is-releasable.ts
+                  reason=`npx tsx ./scripts/is-releasable.ts`
+                  if [ $? -ne 0 ]; then
+                    echo "::error::$reason"
+                    exit 1
+                  fi
 
+            - run: npm ci
             - run: npm run check
             - run: npm test
             - run: npm pack

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -3,8 +3,7 @@ name: Test shared
 on:
     workflow_dispatch:
     pull_request:
-    push:
-        branches: [main]
+    workflow_call:
 
 jobs:
     test:

--- a/.github/workflows/unpublish-npm-version.yml
+++ b/.github/workflows/unpublish-npm-version.yml
@@ -1,0 +1,20 @@
+name: Unpublish npm version
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to unpublish from npm (e.g., 221.0.0)'
+                required: true
+                type: string
+
+jobs:
+    unpublish:
+        runs-on: ubuntu-latest
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.WAYLAND_NPM_TOKEN }}
+        steps:
+            - name: Unpublish version from npm
+              run: |
+                  npm unpublish "@nordicsemiconductor/pc-nrfconnect-shared@${{ inputs.version }}"
+                  echo "🗑️ Unpublished [pc-nrfconnect-shared](https://www.npmjs.com/package/@nordicsemiconductor/pc-nrfconnect-shared) version ${{ inputs.version }} from npm 🗑️" >> $GITHUB_STEP_SUMMARY

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 222.0.0 - 2025-07-23
+
+### Added
+
+-   Automatic publishing of shared.
+
 ## 221.0.0 - 2025-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ updated to the right version and today‘s date.
 
 When those conditions are met, a new release of shared will automatically be
 created when the according PR is merged into main.
+
+## Unpublishing a version
+
+If you need to unpublish a specific version from npm (e.g., due to a critical
+bug), you can use the "Unpublish npm version" GitHub Action:
+
+1. Go to the
+   [Unpublish npm version GitHub Action](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/actions/workflows/unpublish-npm-version.yml)
+   and run the workflow.
+1. Enter the version to unpublish (e.g., `221.0.0`)
+
+**Warning:** Unpublishing a version from npm is irreversible and should only be
+done in exceptional circumstances (e.g., security vulnerabilities, critical
+bugs).

--- a/README.md
+++ b/README.md
@@ -10,30 +10,27 @@ apps and their launcher:
 -   Configurations
 -   Test facilities
 
+## Developing a new feature or fixing an error
+
+Whenever something is changed in pc-nrfconnect-shared, an entry should be added
+to `Changelog.md`.
+
+If there is no latest entry there yet, and you do not intend to release the
+change as a new version right ahead, add a new section with the heading
+`## Unreleased` at the top.
+
 ## Releasing
 
-This project uses GitHub Actions for automated releases. To release a new
-version:
+To release, two files must be up-to-date:
 
-### Prepare the release
+-   `package.json` contain the correct version number (one more than the last
+    release).
+-   `Changelog.md` must contain an entry, with that version number and today's
+    date.
 
--   Update the version in `package.json`.
--   Add a changelog entry in `Changelog.md` with the format:
-    `## X.0.0 - YYYY-MM-DD`.
--   Commit and push your changes
+By running `npm run prepare-shared-release` you update the version in
+`package.json` and in `Changelog.md` a potential `## Unreleased` heading is
+updated to the right version and today‘s date.
 
-### Create the release
-
--   Go to the the
-    [Release shared](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/actions/workflows/release-shared.yml)
-    action.
--   Click "Run workflow".
--   Optionally select a ref to release, but usually this should be `main` and
-    can be left empty.
-
-The workflow will:
-
--   Check if a release is possible.
--   Build and test the package.
--   Create a GitHub release.
--   Publish to npm.
+When those conditions are met, a new release of shared will automatically be
+created when the according PR is merged into main.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "221.0.0",
+    "version": "222.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/is-releasable.ts
+++ b/scripts/is-releasable.ts
@@ -18,7 +18,7 @@ import getReleaseNumbers from './get-release-numbers';
 import { getLatestEntry } from './latest-changelog-entry';
 
 const fail = (message: string) => {
-    console.log(`::error::${message}`);
+    console.log(message);
     process.exit(1);
 };
 


### PR DESCRIPTION
Implements [NCD-1400](https://nordicsemi.atlassian.net/browse/NCD-1400):

If a new version of shared is ready on main then it is automatically
published by a GitHub Action.

The conditions for “is ready” are:

- Builds correctly
- The package.json has a correct version number (one  more than the last published one)
- There is a correct latest changelog entry
- The latest entry is not empty
- It has the correct version number and today`s date

Even if the `package.json` and `Changelog.md` are not correct, shared will still at least be build.

Also added a script to unpublished a version from npm and described the whole process in `README.md`.