### PR TITLE
Fix auto-publish script

### DIFF
--- a/.github/workflows/auto-publish-shared.yml
+++ b/.github/workflows/auto-publish-shared.yml
@@ -23,12 +23,11 @@ jobs:
             - name: Check if release is ready
               id: check-release
               run: |
-                  reason=`npx tsx ./scripts/is-releasable.ts`
-                  if [ $? -ne 0 ]; then
+                  if reason=$(npx tsx ./scripts/is-releasable.ts); then
+                    echo "ready_to_release=true" >> $GITHUB_OUTPUT
+                  else
                     echo ":see_no_evil: Not releasing because: $reason" >> $GITHUB_STEP_SUMMARY
                     echo "ready_to_release=false" >> $GITHUB_OUTPUT
-                  else
-                    echo "ready_to_release=true" >> $GITHUB_OUTPUT
                   fi
 
     release:


### PR DESCRIPTION
For [NCD-1400](https://nordicsemi.atlassian.net/browse/NCD-1400):

Fix a bug introduced in #1042: Because in GitHub Actions bash is run with `-e` by default, the script failed if shared is not releasable.