### PR TITLE
Remove build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Shared commodities for developing nRF Connect for Desktop
 
-[![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-shared?branchName=master)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=31&branchName=master)
-
 This project provides shared commodities for developing nRF Connect for Desktop
 apps and their launcher:
 


### PR DESCRIPTION
Because we stopped using Azure Pipelines.