### PR TITLE
Remove launcher specific API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,14 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 223.0.0 - 2025-07-28
+
+### Changed
+
+-   Return value of `getDownloadableApps` has less fields now and some more
+    exports were removed, because they were only needed in the launcher and
+    having them in shared made changes harder in the launcher.
+
 ## 222.0.0 - 2025-07-23
 
 ### Added

--- a/ipc/apps.ts
+++ b/ipc/apps.ts
@@ -11,7 +11,7 @@ import type {
     NrfutilModuleVersion,
     UrlString,
 } from './MetaFiles';
-import { LOCAL, Source, SourceName } from './sources';
+import { LOCAL, SourceName } from './sources';
 
 export interface AppSpec {
     name: string;
@@ -75,17 +75,10 @@ export type LaunchableApp = LocalApp | InstalledDownloadableApp | WithdrawnApp;
 
 export type App = LocalApp | DownloadableApp;
 
-export interface AppWithError extends AppSpec {
-    reason: unknown;
-    path: string;
-}
-
-const channel = {
+export const channel = {
     getDownloadableApps: 'apps:get-downloadable-apps',
     installDownloadableApp: 'apps:install-downloadable-app',
 };
-
-export type SourceWithError = { source: Source; reason?: string };
 
 export const isDownloadable = (app?: App): app is DownloadableApp =>
     app != null && app?.source !== LOCAL;
@@ -115,10 +108,8 @@ export const isUpdatable = (app?: App): app is InstalledDownloadableApp =>
         latestVersionHasDifferentChecksum(app));
 
 // getDownloadableApps
-type GetDownloadableAppsResult = {
+export type GetDownloadableAppsResult = {
     apps: DownloadableApp[];
-    appsWithErrors: AppWithError[];
-    sourcesWithErrors: SourceWithError[];
 };
 
 type GetDownloadableApps = () => GetDownloadableAppsResult;

--- a/ipc/sources.ts
+++ b/ipc/sources.ts
@@ -4,16 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { UrlString } from './MetaFiles';
-
 enum StandardSourceNames {
     OFFICIAL = 'official',
     LOCAL = 'local',
 }
 
 export const { LOCAL, OFFICIAL } = StandardSourceNames;
-export const allStandardSourceNames: SourceName[] = [OFFICIAL, LOCAL];
 
 export type SourceName = string;
-export type SourceUrl = UrlString;
-export type Source = { name: SourceName; url: SourceUrl };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "222.0.0",
+    "version": "223.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,12 +196,10 @@ export {
     inMain as apps,
     type App as AppType,
     type AppSpec,
-    type AppWithError,
     type DownloadableApp,
     type InstalledDownloadableApp,
     type LaunchableApp,
     type LocalApp,
-    type SourceWithError,
     type UninstalledDownloadableApp,
     type WithdrawnApp,
 } from '../ipc/apps';


### PR DESCRIPTION
Return value of `getDownloadableApps` has less fields now and some more exports where removed, because they were only needed in the launcher and having them in shared made changes harder in the launcher.