### PR TITLE
Reorder app release steps

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -37,20 +37,6 @@ jobs:
               with:
                   name: ${{ env.ARTIFACT_NAME }}
 
-            - name: Release app to ${{ inputs.source }}
-              env:
-                  ARTIFACTORY_TOKEN:
-                      ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD_SWTOOLS_FRONTEND
-                      }}
-              run: |
-                  tar xaf *.tgz
-                  cp *.tgz package
-                  cd package
-                  node dist/nordic-publish.js \
-                    --no-pack \
-                    --destination artifactory \
-                    --source '${{ inputs.source }}'
-
             - name: Create release on GitHub
               if: inputs.source == 'official (external)'
               run: |
@@ -67,6 +53,20 @@ jobs:
                     --repo ${{ github.repository }} \
                     --notes-file release_notes.md \
                     ./*.tgz
+
+            - name: Release app to ${{ inputs.source }}
+              env:
+                  ARTIFACTORY_TOKEN:
+                      ${{ secrets.COM_NORDICSEMI_FILES_PASSWORD_SWTOOLS_FRONTEND
+                      }}
+              run: |
+                  tar xaf *.tgz
+                  cp *.tgz package
+                  cd package
+                  node dist/nordic-publish.js \
+                    --no-pack \
+                    --destination artifactory \
+                    --source '${{ inputs.source }}'
 
     check-if-docs-exist:
         needs: release


### PR DESCRIPTION
Create the GitHub release before releasing to Artifactory.

Rationale: It is more likely that the GitHub release will fail, if by accident a tag was already created. Also, it is easier to remove a wrongly created GitHub release than to remove a wrong release from Artifactory.