### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git"
     },
     "author": "Nordic Semiconductor ASA",
-    "license": "ISC",
+    "license": "SEE LICENSE IN LICENSE",
     "bin": {
         "check-for-typescript": "scripts/check-for-typescript.ts",
         "check-app-properties": "scripts/check-app-properties.ts",


### PR DESCRIPTION
According to https://docs.npmjs.com/cli/v11/configuring-npm/package-json#license