### PR TITLE
Fix: Always set a title for app github releases

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -49,6 +49,7 @@ jobs:
                   fi
 
                   gh release create "$TAG" \
+                    --title "$TAG" \
                     --target ${{ inputs.ref || github.ref }} \
                     --repo ${{ github.repository }} \
                     --notes-file release_notes.md \


### PR DESCRIPTION
While the documentation suggests that the tag should be the default, we experienced it multiple times that it was the title of the last commit instead. So we now set it explicitly.