### PR TITLE
Fix: No problematic nRF Util core version check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,11 +7,15 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
-## 227.0.0 - unreleased
+## 227.0.0 - 2025-09-18
 
 ### Added
 
 -   Added Nordic Thingy:53 to known devices.
+
+### Fixed
+
+-   No problematic check for the nRF Util core version.
 
 ## 226.0.0 - 2025-09-10
 

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -184,19 +184,10 @@ export class NrfutilSandbox {
         }
     };
 
-    private installNrfUtilCore = async (onProgress?: OnProgress) => {
-        const currentCoreVersion = await this.getCoreVersion();
+    private installNrfUtilCore = (onProgress?: OnProgress) => {
         const requestedCoreVersion =
             this.coreVersion ?? CORE_VERSION_FOR_LEGACY_APPS;
-        if (currentCoreVersion.version === requestedCoreVersion) {
-            getNrfutilLogger()?.debug(
-                `Requested nRF Util's core version ${requestedCoreVersion} is already installed.`
-            );
-
-            return;
-        }
-
-        await this.install(
+        return this.install(
             'core',
             requestedCoreVersion,
             'self-upgrade',


### PR DESCRIPTION
The check was unnecessary, because it is only called when a sandbox is created, so there is no nRF Util core yet. And it was problematic, because it led to the latest version (or more concret to the one in https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/index/bootstrap.json) of the core being installed initially and that version might not run correctly, which is why we introduced the ability to specify a core version in the first place.