### PR TITLE
Bump nrfutil-core version for legacy apps to 8.1.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,18 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 228.0.0 - 2025-09-24
+
+### Changed
+
+-   Bump the version of `nrfutil-core` for apps who do not declare it themselves
+    to 8.1.1
+
+### Steps to upgrade when using this package
+
+-   In apps in `package.json` bump `nrfConnectForDesktop.nrfutilCore` to
+    `8.1.1`.
+
 ## 227.0.0 - 2025-09-18
 
 ### Added

--- a/nrfutil/sandbox.ts
+++ b/nrfutil/sandbox.ts
@@ -35,7 +35,7 @@ import {
     versionToInstall,
 } from './version/moduleVersion';
 
-const CORE_VERSION_FOR_LEGACY_APPS = '8.0.0';
+const CORE_VERSION_FOR_LEGACY_APPS = '8.1.1';
 
 export class NrfutilSandbox {
     private readonly onLoggingHandlers: ((

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "227.0.0",
+    "version": "228.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",


### PR DESCRIPTION
It is not strictly necessary to bump it for every app, they could continue to work for most people. But we know at least of one user https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/issues/1189 whose network setup makes it impossible to use nrfutil-core 8.0.0, so we should bump it everywhere.