### PR TITLE
Fix release script

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -31,8 +31,7 @@ jobs:
 
             - name: Check if release is possible
               run: |
-                  reason=`npx tsx ./scripts/is-releasable.ts`
-                  if [ $? -ne 0 ]; then
+                  if ! reason=$(npx tsx ./scripts/is-releasable.ts); then
                     echo "::error::$reason"
                     exit 1
                   fi


### PR DESCRIPTION
If `npx tsx ./scripts/is-releasable.ts` returned with a non-zero exit code, the GitHub action would always terminate (because by default GitHub actions runs bash with `-e`
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsshell).

This does not happen when running the subshell in the `if` statement.