### PR TITLE
Improved: Custom ReactMarkdown component wrapper

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -72,9 +72,11 @@ Example — Not migrated:
 ```tsx
 import ReactMarkdown from 'react-markdown';
 
-<div className="release-notes">
-    <ReactMarkdown linkTarget="_blank">{'**Some Markdown**'}</ReactMarkdown>
-</div>;
+return (
+    <div className="release-notes">
+        <ReactMarkdown linkTarget="_blank">{'**Some Markdown**'}</ReactMarkdown>
+    </div>
+);
 ```
 
 Example — Migrated:
@@ -82,7 +84,7 @@ Example — Migrated:
 ```tsx
 import { Markdown } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-<Markdown className="release-notes">{'**Some Markdown**'}</Markdown>;
+return <Markdown className="release-notes">{'**Some Markdown**'}</Markdown>;
 ```
 
 ## 244.0.0 - 2026-01-22

--- a/Changelog.md
+++ b/Changelog.md
@@ -74,7 +74,7 @@ import ReactMarkdown from 'react-markdown';
 
 return (
     <div className="release-notes">
-        <ReactMarkdown linkTarget="_blank">{'**Some Markdown**'}</ReactMarkdown>
+        <ReactMarkdown linkTarget="_blank">**Some Markdown**</ReactMarkdown>
     </div>
 );
 ```
@@ -84,7 +84,7 @@ Example — Migrated:
 ```tsx
 import { Markdown } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-return <Markdown className="release-notes">{'**Some Markdown**'}</Markdown>;
+return <Markdown className="release-notes">**Some Markdown**</Markdown>;
 ```
 
 ## 244.0.0 - 2026-01-22

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ every new version is a new major version.
   components.
 - Added support for `cardTitleClassName` and `cardSubtitleClassName` on
   `Card.Header.Title`
+- Added `Markdown` component to wrap `ReactMarkdown` and use it more easily
 
 ### Changed
 
@@ -56,6 +57,33 @@ import { Card } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 See
 [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide).
+
+#### Migrating `ReactMarkdown` to `Markdown`
+
+Import the new `Markdown` component from
+`@nordicsemiconductor/pc-nrfconnect-shared`, replace `ReactMarkdown` usages with
+`Markdown` and remove the `linkTarget` attribute.
+
+If the `ReactMarkdown` was wrapped in a `div` for styling, you can remove the
+`div` and move the `className` attribute onto the `Markdown` component.
+
+Example — Not migrated:
+
+```tsx
+import ReactMarkdown from 'react-markdown';
+
+<div className="release-notes">
+    <ReactMarkdown linkTarget="_blank">{'**Some Markdown**'}</ReactMarkdown>
+</div>;
+```
+
+Example — Migrated:
+
+```tsx
+import { Markdown } from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+<Markdown className="release-notes">{'**Some Markdown**'}</Markdown>;
+```
 
 ## 244.0.0 - 2026-01-22
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -31,7 +31,7 @@ module.exports = (disabledMocks = []) => ({
         '^.+\\.[jt]sx?$': '@swc/jest',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!(@nordicsemiconductor/pc-nrfconnect-shared|react-resize-detector)/)',
+        'node_modules/(?!(@nordicsemiconductor/pc-nrfconnect-shared|react-resize-detector|rehype-external-links|hast-util-is-element|is-absolute-url|space-separated-tokens|unist-util-visit|unist-util-visit-parents|unist-util-is)/)',
     ],
     setupFilesAfterEnv: [`${__dirname}/../test/setupTests.ts`],
     resolver: `${__dirname}/../test/jestResolver.js`,

--- a/mocks/reactMarkdownMock.tsx
+++ b/mocks/reactMarkdownMock.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 // Doesn't parse the markdown input into valid HTML, so this will only display
 // Markdown code as text
 const MockedMarkdown: React.FC<React.PropsWithChildren> = ({ children }) => (
-    <div>{children}</div>
+    <p>{children}</p>
 );
 
 export default MockedMarkdown;

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
                 "react-test-renderer": "^19.2.4",
                 "redux": "^5.0.1",
                 "redux-thunk": "^3.1.0",
+                "rehype-external-links": "^3.0.0",
                 "rimraf": "3.0.2",
                 "roboto-fontface": "0.10.0",
                 "semver": "7.3.8",
@@ -8548,6 +8549,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-to-jsx-runtime": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -8952,6 +8966,18 @@
             "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/is-absolute-url": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+            "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-alphabetical": {
@@ -14568,6 +14594,24 @@
             "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
             "engines": {
                 "node": ">=6.5.0"
+            }
+        },
+        "node_modules/rehype-external-links": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+            "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "is-absolute-url": "^4.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/remark": {
@@ -25296,6 +25340,14 @@
                 "function-bind": "^1.1.2"
             }
         },
+        "hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "requires": {
+                "@types/hast": "^3.0.0"
+            }
+        },
         "hast-util-to-jsx-runtime": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -25589,6 +25641,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
             "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw=="
+        },
+        "is-absolute-url": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+            "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A=="
         },
         "is-alphabetical": {
             "version": "1.0.4",
@@ -29380,6 +29437,19 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
             "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+        },
+        "rehype-external-links": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+            "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+            "requires": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "is-absolute-url": "^4.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "unist-util-visit": "^5.0.0"
+            }
         },
         "remark": {
             "version": "11.0.2",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "react-test-renderer": "^19.2.4",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
+        "rehype-external-links": "^3.0.0",
         "rimraf": "3.0.2",
         "roboto-fontface": "0.10.0",
         "semver": "7.3.8",

--- a/src/ErrorDialog/ErrorDialog.tsx
+++ b/src/ErrorDialog/ErrorDialog.tsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -30,9 +29,6 @@ const SingleErrorMessage = ({
     error: ErrorMessage;
 }) => (
     <>
-        {/* check if we actually need https://github.com/rehypejs/rehype-external-links (as per https://github.com/remarkjs/react-markdown/blob/main/changelog.md#remove-linktarget) */}
-        {/* try to remove it first (trigger launcher error by deleting .nrfconnect-apps/source.json and opening launcher without internet) */}
-        <ReactMarkdown>{message}</ReactMarkdown>
         <Markdown>{message}</Markdown>
         {detail != null && <ErrorDetails detail={detail} />}
     </>

--- a/src/ErrorDialog/ErrorDialog.tsx
+++ b/src/ErrorDialog/ErrorDialog.tsx
@@ -13,6 +13,7 @@ import {
     ErrorDetails,
     ErrorDialog as BaseErrorDialog,
 } from '../Dialog/Dialog';
+import Markdown from '../Markdown/Markdown';
 import {
     type ErrorMessage,
     errorResolutions as errorResolutionsSelector,
@@ -32,6 +33,7 @@ const SingleErrorMessage = ({
         {/* check if we actually need https://github.com/rehypejs/rehype-external-links (as per https://github.com/remarkjs/react-markdown/blob/main/changelog.md#remove-linktarget) */}
         {/* try to remove it first (trigger launcher error by deleting .nrfconnect-apps/source.json and opening launcher without internet) */}
         <ReactMarkdown>{message}</ReactMarkdown>
+        <Markdown>{message}</Markdown>
         {detail != null && <ErrorDetails detail={detail} />}
     </>
 );

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import classNames from '../utils/classNames';
+
+interface MarkdownProps
+    extends Pick<React.ComponentPropsWithRef<'div'>, 'ref' | 'className'> {
+    children?: string;
+}
+
+const Markdown: React.FC<MarkdownProps> = ({
+    className,
+    children,
+    ...attrs
+}) => (
+    <div
+        className={classNames(
+            'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
+            className,
+        )}
+        {...attrs}
+    >
+        <ReactMarkdown>{children}</ReactMarkdown>
+    </div>
+);
+
+export default Markdown;

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import rehypeExternalLinks from 'rehype-external-links';
 
 import classNames from '../utils/classNames';
 
@@ -12,16 +13,24 @@ const Markdown: React.FC<MarkdownProps> = ({
     className,
     children,
     ...attrs
-}) => (
-    <div
-        className={classNames(
-            'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
-            className,
-        )}
-        {...attrs}
-    >
-        <ReactMarkdown>{children}</ReactMarkdown>
-    </div>
-);
+}) => {
+    const externalLinksPlugin = rehypeExternalLinks({
+        target: '_blank',
+    });
+
+    return (
+        <div
+            className={classNames(
+                'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
+                className,
+            )}
+            {...attrs}
+        >
+            <ReactMarkdown rehypePlugins={[externalLinksPlugin]}>
+                {children}
+            </ReactMarkdown>
+        </div>
+    );
+};
 
 export default Markdown;

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -21,7 +21,7 @@ const Markdown: React.FC<MarkdownProps> = ({
     return (
         <div
             className={classNames(
-                'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
+                'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_code]:tw-font-mono [&_code]:tw-text-pink [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_i]:tw-italic [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_strong]:tw-font-bold [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
                 className,
             )}
             {...attrs}

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeExternalLinks from 'rehype-external-links';

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -13,24 +13,21 @@ const Markdown: React.FC<MarkdownProps> = ({
     className,
     children,
     ...attrs
-}) => {
-    const externalLinksPlugin = rehypeExternalLinks({
-        target: '_blank',
-    });
-
-    return (
-        <div
-            className={classNames(
-                'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_code]:tw-font-mono [&_code]:tw-text-pink [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_i]:tw-italic [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_strong]:tw-font-bold [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
-                className,
-            )}
-            {...attrs}
+}) => (
+    <div
+        className={classNames(
+            'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_code]:tw-font-mono [&_code]:tw-text-pink [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_i]:tw-italic [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_strong]:tw-font-bold [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
+            className,
+        )}
+        {...attrs}
+    >
+        <ReactMarkdown
+            // See https://github.com/remarkjs/react-markdown/issues/927
+            rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
         >
-            <ReactMarkdown rehypePlugins={[externalLinksPlugin]}>
-                {children}
-            </ReactMarkdown>
-        </div>
-    );
-};
+            {children}
+        </ReactMarkdown>
+    </div>
+);
 
 export default Markdown;

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -16,7 +16,7 @@ const Markdown: React.FC<MarkdownProps> = ({
 }) => (
     <div
         className={classNames(
-            'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_code]:tw-font-mono [&_code]:tw-text-pink [&_h1]:tw-text-lg [&_h1]:tw-font-medium [&_h2]:tw-text-lg [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_i]:tw-italic [&_ol]:tw-list-inside [&_ol]:tw-list-decimal [&_strong]:tw-font-bold [&_ul]:tw-list-inside [&_ul]:tw-list-disc',
+            'tw-preflight tw-flex tw-flex-col tw-gap-4 [&_code]:tw-font-mono [&_code]:tw-text-[90%] [&_code]:tw-text-pink [&_h1]:tw-text-2xl [&_h1]:tw-font-medium [&_h2]:tw-text-xl [&_h2]:tw-font-medium [&_h3]:tw-text-lg [&_h3]:tw-font-medium [&_h4]:tw-text-lg [&_h4]:tw-font-medium [&_h5]:tw-text-lg [&_h5]:tw-font-medium [&_h6]:tw-text-lg [&_h6]:tw-font-medium [&_i]:tw-italic [&_ol]:tw-list-outside [&_ol]:tw-list-decimal [&_ol]:tw-pl-4 [&_strong]:tw-font-bold [&_ul]:tw-list-outside [&_ul]:tw-list-disc [&_ul]:tw-pl-4',
             className,
         )}
         {...attrs}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export type { Step } from './Stepper/Stepper';
 export { default as ExternalLink } from './Link/ExternalLink';
 export { default as FileLink } from './Link/FileLink';
 export { default as Overlay } from './Overlay/Overlay';
+export { default as Markdown } from './Markdown/Markdown';
 
 export { default as SidePanel } from './SidePanel/SidePanel';
 export { Group } from './Group/Group';


### PR DESCRIPTION
# Explanation

`ReactMarkdown` was in many places used with Bootstrap styles, moreover, the library itself
was upgraded, rendering the `linkTarget` attribute obsolete.

This PR fixes both aspects (Tailwind styles + proper rehype plugin)
