### PR TITLE
Fix: Remove buggy cancelling of label workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,7 +7,6 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
 
 jobs:
     check_label:


### PR DESCRIPTION
Cancelling the workflow could be slower than running the workflow itself.

That lead to the cancellation providing the result for the PR (meaning the check failed) instead of the workflow providing the result (which might be success).