### PR TITLE
Fix failing release workflow

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -28,11 +28,9 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.ref }}
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 22
-                  registry-url: https://registry.npmjs.org
-                  cache: npm
+                  node-version: 24
 
             - name: Check if release is possible
               run: |
@@ -41,7 +39,6 @@ jobs:
                     exit 1
                   fi
 
-            - run: npm install --global npm@latest
             - run: npm ci
             - run: npm run check
             - run: npm test


### PR DESCRIPTION
Example of a failing release workflow: https://github.com/nordicsemi/pc-nrfconnect-shared/actions/runs/24717083609

This seems to be caused by a regression in Node 22.22.2: https://github.com/nodejs/node/issues/62425

By upgrading to Node 24 we also no longer need to run `npm install --global npm@latest`. This was previously needed because the npm of Node 22 didn't support trusted publishing yet. With Node 24 it is ok again to just use the version of npm that comes with Node. https://docs.npmjs.com/trusted-publishers#supported-cicd-providers