### PR TITLE
Ignore the hostname when comparing ssh git URLs 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## 247.0.0 - 2026-04-23
+
+### Changed
+
+- In the repo URL check, ignore the hostname for ssh git URLs.
+
 ## 246.0.0 - 2026-04-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nordicsemiconductor/pc-nrfconnect-shared",
-    "version": "246.0.0",
+    "version": "247.0.0",
     "description": "Shared commodities for developing pc-nrfconnect-* packages",
     "repository": {
         "type": "git",

--- a/scripts/check-app-properties.test.ts
+++ b/scripts/check-app-properties.test.ts
@@ -48,4 +48,13 @@ describe('sameRepoURLs', () => {
             ),
         ).toBe(true);
     });
+
+    it('ignores the host name for the git protocol', () => {
+        expect(
+            sameRepoURLs(
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+                'git@nordic-git:nordicsemi/pc-nrfconnect-ppk.git',
+            ),
+        ).toBe(true);
+    });
 });

--- a/scripts/check-app-properties.test.ts
+++ b/scripts/check-app-properties.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { sameRepoURLs } from './check-app-properties';
+
+describe('sameRepoURLs', () => {
+    it('accepts equal URLs', () => {
+        expect(
+            sameRepoURLs(
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+            ),
+        ).toBe(true);
+    });
+
+    it('rejects different URLs', () => {
+        expect(
+            sameRepoURLs(
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+                'https://github.com/nordicsemi/pc-nrfconnect-shared',
+            ),
+        ).toBe(false);
+    });
+
+    it('ignores a .git postfix on either URL', () => {
+        expect(
+            sameRepoURLs(
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk.git',
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+            ),
+        ).toBe(true);
+        expect(
+            sameRepoURLs(
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk.git',
+            ),
+        ).toBe(true);
+    });
+
+    it('treats the protocol https and git as the same', () => {
+        expect(
+            sameRepoURLs(
+                'https://github.com/nordicsemi/pc-nrfconnect-ppk',
+                'git@github.com:nordicsemi/pc-nrfconnect-ppk.git',
+            ),
+        ).toBe(true);
+    });
+});

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -65,6 +65,20 @@ const mustContainOneOf = (
     }
 };
 
+export const sameRepoURLs = (url1: string, url2: string) => {
+    const withoutPostfix = (gitUrl: string) => gitUrl.replace(/\.git$/, '');
+
+    const withoutProtocol = (gitUrl: string) =>
+        gitUrl
+            .replace(/^git@github\.com:/, 'github.com/')
+            .replace(/^https:\/\//, '');
+
+    const stripped = (gitUrl: string) =>
+        withoutProtocol(withoutPostfix(gitUrl));
+
+    return stripped(url1) === stripped(url2);
+};
+
 const checkRepoUrl = (packageJson: PackageJsonApp) => {
     if (!existsSync('./.git')) {
         return;
@@ -75,17 +89,7 @@ const checkRepoUrl = (packageJson: PackageJsonApp) => {
     }).trimEnd();
     const declaredGitUrl = packageJson.repository?.url;
 
-    const withoutPostfix = (gitUrl?: string) => gitUrl?.replace(/\.git$/, '');
-
-    const withoutProtocol = (gitUrl?: string) =>
-        gitUrl
-            ?.replace(/^git@github\.com:/, 'github.com/')
-            .replace(/^https:\/\//, '');
-
-    const stripped = (gitUrl?: string) =>
-        withoutProtocol(withoutPostfix(gitUrl));
-
-    if (stripped(realGitUrl) !== stripped(declaredGitUrl)) {
+    if (declaredGitUrl == null || !sameRepoURLs(realGitUrl, declaredGitUrl)) {
         fail(
             `package.json says the repository is located at \`${declaredGitUrl}\` but \`git remote get-url origin\` says it is at \`${realGitUrl}\`.`,
         );

--- a/scripts/check-app-properties.ts
+++ b/scripts/check-app-properties.ts
@@ -69,9 +69,7 @@ export const sameRepoURLs = (url1: string, url2: string) => {
     const withoutPostfix = (gitUrl: string) => gitUrl.replace(/\.git$/, '');
 
     const withoutProtocol = (gitUrl: string) =>
-        gitUrl
-            .replace(/^git@github\.com:/, 'github.com/')
-            .replace(/^https:\/\//, '');
+        gitUrl.replace(/^git@[^:]+:/, 'github.com/').replace(/^https:\/\//, '');
 
     const stripped = (gitUrl: string) =>
         withoutProtocol(withoutPostfix(gitUrl));


### PR DESCRIPTION
Because the hostname does not need to be github.com, it can easily be configured in the ssh configuration to be anything.