### PR TITLE
Fix: Remove buggy cancelling of label workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,6 +7,7 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
+    queue: max
 
 jobs:
     check_label:


### PR DESCRIPTION
When a PR with two labels is created, this workflow can be triggered three times (for creating and for each label). With the default configuration, the third run would be cancelled.

If the other two runs are successful, the cancellation might still be slower, reported last and lead to the workflow being reported as failed. This change means that all runs will be executed and reported, but the workflow will not be cancelled.