### PR TITLE
Support setting a token for the GitHub packages

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,6 +9,8 @@ on:
                 type: boolean
             node_version:
                 type: number
+        secrets:
+            GH_PACKAGES_TOKEN:
         outputs:
             version:
                 value: ${{ jobs.build.outputs.version }}
@@ -33,6 +35,9 @@ jobs:
               with:
                   node-version: ${{ inputs.node_version || 22 }}
                   cache: 'npm'
+                  token: ${{ secrets.GH_PACKAGES_TOKEN }}
+                  registry-url: ${{ secrets.GH_PACKAGES_TOKEN && 'https://npm.pkg.github.com' || '' }}
+                  scope: non-existent # it caused problems, if this is was '@nordicsemiconductor' and may again cause problems if we start having packages as '@nordicsemi'
             - run: npm ci
             - run: npm run check
             - run: npm test

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -14,7 +14,7 @@ on:
                 type: string
         secrets:
             COM_NORDICSEMI_FILES_PASSWORD_SWTOOLS_FRONTEND:
-                required: false
+            GH_PACKAGES_TOKEN:
 
 env:
     ARTIFACT_NAME: ${{ github.event.repository.name }}
@@ -26,6 +26,7 @@ jobs:
             ref: ${{ inputs.ref }}
             force_pack: true
             node_version: ${{ inputs.node_version }}
+        secrets: inherit
 
     release:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This is used in pc-nrfconnect-ble-5, which reads a private package from GitHub Packages.