### PR TITLE
Adjust app release workflow for unified docs

### DIFF
--- a/.github/workflows/notify-swtools-app-docs.yml
+++ b/.github/workflows/notify-swtools-app-docs.yml
@@ -1,0 +1,54 @@
+name: Notify swtools-app-docs about release
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        description: Name of the project in `projects.json` in the swtools-app-docs repository (e.g. pc-nrfconnect-ppk)
+        type: string
+        required: true
+      tag:
+        description: Tag to put in `projects.json` (e.g. v1.2.3)
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      project-name:
+        description: Name of the project in `projects.json` in the swtools-app-docs repository (e.g. pc-nrfconnect-ppk)
+        type: string
+        required: true
+      tag:
+        description: Tag to put in `projects.json` (e.g. v1.2.3)
+        type: string
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.JENKINS_NCS_APP_ID }}
+          private-key: ${{ secrets.JENKINS_NCS_APP_PRIVATE_KEY }}
+          owner: nordicsemi
+          repositories: swtools-app-docs
+
+      - uses: actions/github-script@v7
+        env:
+          project: ${{ inputs.project-name }}
+          tag: ${{ inputs.tag }}
+          repository: ${{ github.repository }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            github.rest.repos.createDispatchEvent({
+              owner: 'nordicsemi',
+              repo: 'swtools-app-docs',
+              event_type: 'bump-project-tag',
+              client_payload: {
+                project: process.env.project,
+                tag: process.env.tag,
+                repo: `https://github.com/${process.env.repository}`,
+              },
+            });

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -10,7 +10,7 @@ on:
                 type: string
             node_version:
                 type: number
-            doc_bundle_name:
+            unified_doc_project_name:
                 type: string
         secrets:
             COM_NORDICSEMI_FILES_PASSWORD_SWTOOLS_FRONTEND:
@@ -35,6 +35,8 @@ jobs:
             GH_TOKEN: ${{ github.token }}
         environment:
             name: ${{ inputs.source }}
+        outputs:
+            tag: ${{ steps.create_github_release.outputs.tag }}
 
         steps:
             - name: Fail on missing Artifactory token
@@ -66,6 +68,7 @@ jobs:
                     --source '${{ inputs.source }}'
 
             - name: Create release on GitHub
+              id: create_github_release
               if: inputs.source == 'official (external)'
               run: |
                   TAG="v${{ needs.build.outputs.version }}"
@@ -82,6 +85,8 @@ jobs:
                     --repo ${{ github.repository }} \
                     --notes-file release_notes.md \
                     ./*.tgz
+
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
     check-if-docs-exist:
         needs: release
@@ -103,13 +108,13 @@ jobs:
                   fi
 
     publish-docs:
-        needs: check-if-docs-exist
+        needs: [build, release, check-if-docs-exist]
         if: |
-            inputs.doc_bundle_name &&
+            inputs.unified_doc_project_name &&
             inputs.source == 'official (external)' &&
             needs.check-if-docs-exist.outputs.docs_exist == 'true'
-        uses: ./.github/workflows/docs-publish.yml
+        uses: ./.github/workflows/notify-swtools-app-docs.yml
         with:
-            release-type: prod
-            bundle-name: ${{ inputs.doc_bundle_name }}
+            project-name: ${{ inputs.unified_doc_project_name }}
+            tag: ${{ needs.release.outputs.tag }}
         secrets: inherit

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,26 @@ This project does _not_ adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) but contrary to it
 every new version is a new major version.
 
+## Unreleased
+
+### Changed
+
+- Adjusted app release workflow for unified docs.
+
+### Steps to upgrade when using this package
+
+- Update the workflows as demonstrated in
+  https://github.com/nordicsemi/pc-nrfconnect-boilerplate/pull/168:
+    - Delete the outdated `.github/workflows/docs-bundle.yml`,
+      `.github/workflows/docs-publish-dev.yml`, and
+      `.github/workflows/docs-publish-prod.yml`.
+    - If the project has documentation, then adjust the workflow
+      `.github/workflows/release.yml`: Replace the `doc_bundle_name` property
+      with a property called `unified_doc_project_name` which contains the right
+      project name from
+      https://github.com/nordicsemi/swtools-app-docs/blob/main/projects.json
+      (currently always the name of the project's repository).
+
 ## 248.0.0 - 2026-05-20
 
 ### Fixed


### PR DESCRIPTION
This change will not really be “released” as a version, since we always use the `main` branch when referencing our own Github Actions for convenience.

As a consequence, the “Steps to upgrade when using this package” should be done soon after this is merged into main in all apps, as demonstrated in https://github.com/nordicsemi/pc-nrfconnect-boilerplate/pull/168:

- Delete the outdated `.github/workflows/docs-bundle.yml`, `.github/workflows/docs-publish-dev.yml`, and `.github/workflows/docs-publish-prod.yml` files.

- If the project has documentation, then adjust the workflow `.github/workflows/release.yml`: Replace the `doc_bundle_name` property with a property called `unified_doc_project_name` which contains the right project name from https://github.com/nordicsemi/swtools-app-docs/blob/main/projects.json (currently always the name of the project's repository).