### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,17 @@
 {
     "extends": ["config:recommended", "group:allNonMajor"],
+    "minimumReleaseAge": "7 days",
     "packageRules": [
         {
             "groupName": "Prettier",
             "matchPackageNames": ["prettier"],
             "matchUpdateTypes": ["minor", "patch"]
+        },
+        {
+            "groupName": "GitHub Actions",
+            "matchManagers": ["github-actions"],
+            "pinDigests": true,
+            "separateMajorMinor": false
         }
     ]
 }


### PR DESCRIPTION
- Move the renovate config to .github/renovate.json
- Group all updates to GitHub Actions
- For security reasons, use digest pinning for GitHub Actions.
- Also for security reasons, use a minimum release age of 7 days for all updates, to allow time for any issues to be discovered and fixed before the update is applied.