### PR TITLE
Feat/extend app params

### DIFF
--- a/ipc/apps.ts
+++ b/ipc/apps.ts
@@ -37,7 +37,10 @@ interface Installed {
     currentVersion: string;
     engineVersion?: string;
     repositoryUrl?: UrlString;
+    dist?: string;
     html?: string;
+    webHtml?: UrlString;
+    preloadScript?: string;
     nrfutil?: NrfutilModules;
     nrfutilCore?: NrfutilModuleVersion;
     fixedSize?: {

--- a/ipc/schema/packageJson.ts
+++ b/ipc/schema/packageJson.ts
@@ -23,9 +23,14 @@ export const parsePackageJson = parseWithPrettifiedErrorMessage(packageJson);
 
 const relativePath = z
     .string()
-    .refine(value => !/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value), {
-        message: 'Must be a relative path to a file within the app, not a URL',
-    })
+    .min(1, { message: 'Must be a non-empty relative path' })
+    .refine(
+        value => !/^(?![a-zA-Z]:[\\/])[a-zA-Z][a-zA-Z\d+.-]*:/.test(value),
+        {
+            message:
+                'Must be a relative path to a file within the app, not a URL',
+        },
+    )
     .refine(value => !/^[\\/]/.test(value) && !/^[a-zA-Z]:[\\/]/.test(value), {
         message: 'Must be a relative path, not an absolute one',
     })
@@ -53,8 +58,7 @@ const secureUrl = z
         },
     );
 
-// Apps have more required fields in their package.json
-const nrfConnectForDesktopBase = z.object({
+const nrfConnectForDesktop = z.object({
     supportedDevices: z.enum(knownDevicePcas).array().nonempty().optional(),
     nrfutil: nrfModules.optional(),
     nrfutilCore: semver,
@@ -69,30 +73,6 @@ const nrfConnectForDesktopBase = z.object({
         })
         .optional(),
 });
-
-const nrfConnectForDesktop = nrfConnectForDesktopBase.superRefine(
-    (data, ctx) => {
-        const hasHtml = data.html != null;
-        const hasWebHtml = data.webHtml != null;
-
-        if (hasHtml === hasWebHtml) {
-            const message = hasHtml
-                ? 'Only one of `html` or `webHtml` can be set, not both'
-                : 'Either `html` or `webHtml` must be set';
-
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message,
-                path: ['html'],
-            });
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message,
-                path: ['webHtml'],
-            });
-        }
-    },
-);
 
 const recordOfOptionalStrings = z.record(z.string().optional());
 
@@ -126,7 +106,7 @@ export const parsePackageJsonApp =
 // In the launcher we want to handle that the whole nrfConnectForDesktop may be missing
 // and html or nrfutilCore in it can also be undefined, so there we need to use this legacy variant
 const packageJsonLegacyApp = packageJsonApp.extend({
-    nrfConnectForDesktop: nrfConnectForDesktopBase
+    nrfConnectForDesktop: nrfConnectForDesktop
         .extend({ supportedDevices: z.array(z.string()).nonempty().optional() })
         .partial({
             dist: true,

--- a/ipc/schema/packageJson.ts
+++ b/ipc/schema/packageJson.ts
@@ -21,13 +21,47 @@ export type PackageJson = z.infer<typeof packageJson>;
 
 export const parsePackageJson = parseWithPrettifiedErrorMessage(packageJson);
 
-// Apps have more required fields in their package.json
+const relativePath = z
+    .string()
+    .refine(value => !/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value), {
+        message: 'Must be a relative path to a file within the app, not a URL',
+    })
+    .refine(value => !/^[\\/]/.test(value) && !/^[a-zA-Z]:[\\/]/.test(value), {
+        message: 'Must be a relative path, not an absolute one',
+    })
+    .refine(value => !value.split(/[\\/]/).includes('..'), {
+        message: 'Must not contain `..` path segments',
+    });
 
-const nrfConnectForDesktop = z.object({
+const secureUrl = z
+    .string()
+    .url()
+    .refine(
+        value => {
+            const url = new URL(value);
+            const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(
+                url.hostname,
+            );
+            return (
+                url.protocol === 'https:' ||
+                (url.protocol === 'http:' && isLocalhost)
+            );
+        },
+        {
+            message:
+                'Must be an https URL (http is only allowed for localhost during development)',
+        },
+    );
+
+// Apps have more required fields in their package.json
+const nrfConnectForDesktopBase = z.object({
     supportedDevices: z.enum(knownDevicePcas).array().nonempty().optional(),
     nrfutil: nrfModules.optional(),
     nrfutilCore: semver,
-    html: z.string(),
+    dist: relativePath,
+    html: relativePath.optional(),
+    webHtml: secureUrl.optional(),
+    preloadScript: relativePath.optional(),
     fixedSize: z
         .object({
             width: z.number().int().positive(),
@@ -35,6 +69,30 @@ const nrfConnectForDesktop = z.object({
         })
         .optional(),
 });
+
+const nrfConnectForDesktop = nrfConnectForDesktopBase.superRefine(
+    (data, ctx) => {
+        const hasHtml = data.html != null;
+        const hasWebHtml = data.webHtml != null;
+
+        if (hasHtml === hasWebHtml) {
+            const message = hasHtml
+                ? 'Only one of `html` or `webHtml` can be set, not both'
+                : 'Either `html` or `webHtml` must be set';
+
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message,
+                path: ['html'],
+            });
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message,
+                path: ['webHtml'],
+            });
+        }
+    },
+);
 
 const recordOfOptionalStrings = z.record(z.string().optional());
 
@@ -68,9 +126,15 @@ export const parsePackageJsonApp =
 // In the launcher we want to handle that the whole nrfConnectForDesktop may be missing
 // and html or nrfutilCore in it can also be undefined, so there we need to use this legacy variant
 const packageJsonLegacyApp = packageJsonApp.extend({
-    nrfConnectForDesktop: nrfConnectForDesktop
+    nrfConnectForDesktop: nrfConnectForDesktopBase
         .extend({ supportedDevices: z.array(z.string()).nonempty().optional() })
-        .partial({ html: true, nrfutilCore: true })
+        .partial({
+            dist: true,
+            html: true,
+            webHtml: true,
+            preloadScript: true,
+            nrfutilCore: true,
+        })
         .optional(),
 });
 

--- a/src/utils/appDirs.ts
+++ b/src/utils/appDirs.ts
@@ -17,9 +17,11 @@ const getUserDataDir = () => launcherConfig().userDataDir;
  * @returns {string|undefined} Absolute path of current app.
  */
 const getAppDir = () => {
-    const html = packageJsonApp().nrfConnectForDesktop.html;
-    const dir = path.parse(html).dir;
-    return path.parse(__filename).dir.replace(dir, '');
+    const dir =
+        packageJsonApp().nrfConnectForDesktop?.dist ??
+        packageJsonApp().nrfConnectForDesktop?.html;
+    const parsedDir = path.parse(dir).dir;
+    return path.parse(__filename).dir.replace(parsedDir, '');
 };
 
 /**


### PR DESCRIPTION
This PR extends the app package.json contract to support additional app parameters (notably a new `dist` entry point, optional remote `webHtml`, and an optional preloadScript) and updates shared utilities/types accordingly.

- `Dist` is added because `html` becomes optional. However, `html` was/is used to identify app's location;
- For older apps, with missing `dist`, we will still use `html` instead.